### PR TITLE
feat(webui): implement auto-logout and manual logout redirect

### DIFF
--- a/webui/src/app.vue
+++ b/webui/src/app.vue
@@ -6,5 +6,62 @@
 </template>
 
 <script setup>
+import { onMounted, onUnmounted, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useLoginStore } from './stores.js'
 import Header from './header.vue'
+
+const loginStore = useLoginStore()
+const router = useRouter()
+let idleTimer = null
+const IDLE_TIMEOUT = 5 * 60 * 1000 // 5 minutes
+
+const resetTimer = () => {
+  if (idleTimer) clearTimeout(idleTimer)
+  if (loginStore.isLoggedIn) {
+    idleTimer = setTimeout(logout, IDLE_TIMEOUT)
+  }
+}
+
+const logout = () => {
+  loginStore.logout()
+  router.push('/login')
+}
+
+const setupIdleListeners = () => {
+  window.addEventListener('mousemove', resetTimer)
+  window.addEventListener('mousedown', resetTimer)
+  window.addEventListener('keypress', resetTimer)
+  window.addEventListener('touchmove', resetTimer)
+  window.addEventListener('scroll', resetTimer)
+}
+
+const removeIdleListeners = () => {
+  window.removeEventListener('mousemove', resetTimer)
+  window.removeEventListener('mousedown', resetTimer)
+  window.removeEventListener('keypress', resetTimer)
+  window.removeEventListener('touchmove', resetTimer)
+  window.removeEventListener('scroll', resetTimer)
+  if (idleTimer) clearTimeout(idleTimer)
+}
+
+watch(() => loginStore.isLoggedIn, (isLoggedIn) => {
+  if (isLoggedIn) {
+    setupIdleListeners()
+    resetTimer()
+  } else {
+    removeIdleListeners()
+  }
+})
+
+onMounted(() => {
+  if (loginStore.isLoggedIn) {
+    setupIdleListeners()
+    resetTimer()
+  }
+})
+
+onUnmounted(() => {
+  removeIdleListeners()
+})
 </script>

--- a/webui/src/header.vue
+++ b/webui/src/header.vue
@@ -58,6 +58,6 @@ const changeLocale = (newLocale) => {
 
 const logout = () => {
   loginStore.logout()
-  router.go()
+  router.push('/login')
 }
 </script>


### PR DESCRIPTION
- Added idle timer logic to `webui/src/app.vue` to automatically log out users after 5 minutes of inactivity.
- Updated `webui/src/header.vue` to redirect to the login page (`/login`) instead of reloading the page upon manual logout.
- Verified functionality with frontend tests.