### PR TITLE
Refactor code to fix CppCheck warnings

### DIFF
--- a/include/gps.h
+++ b/include/gps.h
@@ -41,6 +41,8 @@ private:
 
 public:
     GPS(Settings *settings, SystemClock *clk);
+    GPS(const GPS&) = delete;
+    GPS& operator=(const GPS&) = delete;
 
     void start(void);
     void stop(void);

--- a/include/radiomoduleconnector.h
+++ b/include/radiomoduleconnector.h
@@ -53,6 +53,8 @@ private:
 
 public:
     RadioModuleConnector(LED *redLED, LED *greenLed, LED *blueLed);
+    RadioModuleConnector(const RadioModuleConnector&) = delete;
+    RadioModuleConnector& operator=(const RadioModuleConnector&) = delete;
 
     void start();
     void stop();

--- a/src/hmframe.cpp
+++ b/src/hmframe.cpp
@@ -75,7 +75,7 @@ bool HMFrame::TryParse(unsigned char *buffer, uint16_t len, HMFrame *frame)
     return true;
 }
 
-HMFrame::HMFrame() : data_len(0)
+HMFrame::HMFrame() : counter(0), destination(0), command(0), data(nullptr), data_len(0)
 {
 }
 

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -81,21 +81,17 @@ void LED::stop()
     }
 }
 
-LED::LED(gpio_num_t pin)
+LED::LED(gpio_num_t pin) : _state(LED_STATE_OFF), _channel_conf({})
 {
-    _channel_conf = {
-        .gpio_num = pin,
-        .speed_mode = LEDC_HIGH_SPEED_MODE,
-        .channel = LEDC_CHANNEL_MAX,
-        .intr_type = LEDC_INTR_DISABLE,
-        .timer_sel = LEDC_TIMER_0,
-        .duty = 0,
-        .hpoint = 0,
-        .sleep_mode = LEDC_SLEEP_MODE_NO_ALIVE_NO_PD,
-        .flags = {
-            .output_invert = 0
-        },
-    };
+    _channel_conf.gpio_num = pin;
+    _channel_conf.speed_mode = LEDC_HIGH_SPEED_MODE;
+    _channel_conf.channel = LEDC_CHANNEL_MAX;
+    _channel_conf.intr_type = LEDC_INTR_DISABLE;
+    _channel_conf.timer_sel = LEDC_TIMER_0;
+    _channel_conf.duty = 0;
+    _channel_conf.hpoint = 0;
+    _channel_conf.sleep_mode = LEDC_SLEEP_MODE_NO_ALIVE_NO_PD;
+    _channel_conf.flags.output_invert = 0;
 
     for (uint8_t i = 0; i < MAX_LED_COUNT; i++)
     {

--- a/src/linereader.cpp
+++ b/src/linereader.cpp
@@ -24,7 +24,7 @@
 #include "linereader.h"
 #include <stdint.h>
 
-LineReader::LineReader(std::function<void(unsigned char *buffer, uint16_t len)> processor) : _processor(processor), _buffer_pos(0)
+LineReader::LineReader(std::function<void(unsigned char *buffer, uint16_t len)> processor) : _buffer{0}, _processor(processor), _buffer_pos(0)
 {
 }
 

--- a/src/ntpserver.cpp
+++ b/src/ntpserver.cpp
@@ -47,7 +47,7 @@ void _ntp_udpReceivePaket(void *arg, udp_pcb *pcb, pbuf *pb, const ip_addr_t *ad
     }
 }
 
-NtpServer::NtpServer(SystemClock *clk) : _clk(clk)
+NtpServer::NtpServer(SystemClock *clk) : _clk(clk), _pcb(NULL), _udp_queue(NULL), _tHandle(NULL)
 {
 }
 

--- a/src/rawuartudplistener.cpp
+++ b/src/rawuartudplistener.cpp
@@ -48,7 +48,7 @@ void _raw_uart_udpReceivePaket(void *arg, udp_pcb *pcb, pbuf *pb, const ip_addr_
     }
 }
 
-RawUartUdpListener::RawUartUdpListener(RadioModuleConnector *radioModuleConnector) : _radioModuleConnector(radioModuleConnector)
+RawUartUdpListener::RawUartUdpListener(RadioModuleConnector *radioModuleConnector) : _radioModuleConnector(radioModuleConnector), _lastReceivedKeepAlive(0), _pcb(NULL), _udp_queue(NULL), _tHandle(NULL)
 {
     atomic_init(&_connectionStarted, false);
     atomic_init(&_remotePort, (ushort)0);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -92,7 +92,11 @@ void Settings::load()
   }
 
   // Also try to load explicit passwordChanged flag (overrides auto-detection)
-  GET_BOOL(handle, "passwordChanged", _passwordChanged, _passwordChanged);
+  // We use a temporary variable to avoid self-assignment warning if key is missing
+  {
+      bool currentVal = _passwordChanged;
+      GET_BOOL(handle, "passwordChanged", _passwordChanged, currentVal);
+  }
 
   size_t hostnameLength = sizeof(_hostname);
   if (nvs_get_str(handle, "hostname", _hostname, &hostnameLength) != ESP_OK)

--- a/src/streamparser.cpp
+++ b/src/streamparser.cpp
@@ -24,7 +24,7 @@
 #include "streamparser.h"
 #include <stdint.h>
 
-StreamParser::StreamParser(bool decodeEscaped, std::function<void(unsigned char *buffer, uint16_t len)> processor) : _bufferPos(0), _state(NO_DATA), _isEscaped(false), _decodeEscaped(decodeEscaped), _processor(processor)
+StreamParser::StreamParser(bool decodeEscaped, std::function<void(unsigned char *buffer, uint16_t len)> processor) : _buffer{0}, _bufferPos(0), _framePos(0), _frameLength(0), _state(NO_DATA), _isEscaped(false), _decodeEscaped(decodeEscaped), _processor(processor)
 {
 }
 


### PR DESCRIPTION
- Explicitly delete copy constructor and assignment operator for `GPS` and `RadioModuleConnector` classes to prevent unsafe copying of resource-managing objects.
- Initialize all member variables in constructor initializer lists for `HMFrame`, `LED`, `LineReader`, `NtpServer`, `RawUartUdpListener`, and `StreamParser` to prevent undefined behavior from uninitialized memory.
- Fix redundant self-assignment warning in `Settings` by using a temporary variable when reading `passwordChanged` from NVS.
- Fix performance warning in `LED` by initializing `_channel_conf` in the initializer list.
- Ensure strict initialization order in `StreamParser` to comply with `-Werror=reorder`.