### PR TITLE
Fix: Ensure reliable CCU reconnection after restart

### DIFF
--- a/src/rawuartudplistener.cpp
+++ b/src/rawuartudplistener.cpp
@@ -109,8 +109,7 @@ void RawUartUdpListener::handlePacket(pbuf *pb, ip4_addr_t addr, uint16_t port)
             }
             else if (data[3] != (endpointConnectionIdentifier & 0xff))
             {
-                ESP_LOGE(TAG, "Received raw-uart reconnect packet with invalid endpoint identifier %d, should be %d", data[3], endpointConnectionIdentifier);
-                return;
+                ESP_LOGW(TAG, "Received raw-uart reconnect packet with invalid endpoint identifier %d, should be %d. Sending response to force sync.", data[3], endpointConnectionIdentifier);
             }
 
             atomic_store(&_remotePort, (ushort)0);
@@ -323,16 +322,8 @@ bool RawUartUdpListener::_udpReceivePacket(pbuf *pb, const ip_addr_t *addr, uint
 
     e->pb = pb;
 
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wpointer-arith"
-
-    ip_hdr *iphdr = reinterpret_cast<ip_hdr *>(pb->payload - UDP_HLEN - IP_HLEN);
-    e->addr.addr = iphdr->src.addr;
-
-    udp_hdr *udphdr = reinterpret_cast<udp_hdr *>(pb->payload - UDP_HLEN);
-    e->port = ntohs(udphdr->src);
-
-    #pragma GCC diagnostic pop
+    e->addr.addr = ip_addr_get_ip4_u32(addr);
+    e->port = port;
 
     if (xQueueSend(_udp_queue, &e, portMAX_DELAY) != pdPASS)
     {


### PR DESCRIPTION
Modified `RawUartUdpListener` to handle UDP "reconnect" packets with mismatched endpoint identifiers (which occur when the device restarts but the CCU maintains its session state). Instead of dropping these packets and waiting for a CCU timeout, the device now logs a warning and responds with its current (reset) identifier. This forces the CCU to recognize the state mismatch and initiate a full re-synchronization immediately.

Also includes the previous fix for correct source IP/Port extraction from LWIP callbacks.