### PR TITLE
fix: add missing header includes for build

### DIFF
--- a/src/updatecheck.cpp
+++ b/src/updatecheck.cpp
@@ -26,6 +26,7 @@
 #include "esp_https_ota.h"
 #include "esp_log.h"
 #include "esp_crt_bundle.h"
+#include "esp_task_wdt.h"
 #include "string.h"
 #include "cJSON.h"
 

--- a/src/webui.cpp
+++ b/src/webui.cpp
@@ -26,6 +26,8 @@
 #include <string.h>
 #include <inttypes.h>
 #include <sys/param.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "webui.h"
 #include "esp_log.h"
 #include "cJSON.h"


### PR DESCRIPTION
- Add esp_task_wdt.h to updatecheck.cpp for watchdog functions
- Add freertos/FreeRTOS.h and freertos/task.h to webui.cpp for stack monitoring