### PR TITLE
Fix Analyzer Light: Empty device list and no received packets

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "@vuelidate/core": "^2.0.3",


### PR DESCRIPTION
This commit fixes two critical issues causing the Analyzer Light to show no devices and no received packets:

1. **Frame Processing Bug**: The frontend only processed frames that started with 'FD' (CoPro format) AND had command 0x04. All other frames were silently ignored. Now frames without 'FD' prefix are processed directly as BidCos frames.

2. **Client Registration Bug**: The WebSocket client never sent an initial message after connecting, so addClient() was never called in the backend. This meant the Analyzer was never registered with the RadioModuleConnector and received no frames. Now the client sends a 'connected' message on open.

Changes:
- webui/src/analyzer.vue: Fix frame processing logic to handle all frame types
- webui/src/analyzer.vue: Send initial message on WebSocket connection
- webui/package-lock.json: Update dependencies from npm install