### PR TITLE
Address code review feedback for DTLS password modal

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "@vuelidate/core": "^2.0.3",

--- a/webui/src/components/PasswordInput.vue
+++ b/webui/src/components/PasswordInput.vue
@@ -1,0 +1,63 @@
+<template>
+  <BInputGroup>
+    <BFormInput
+      :type="visible ? 'text' : 'password'"
+      :model-value="modelValue"
+      @update:model-value="$emit('update:modelValue', $event)"
+      :state="state"
+      :placeholder="placeholder"
+      :autofocus="autofocus"
+    />
+    <BInputGroupAppend>
+      <BButton
+        @click="toggleVisibility"
+        variant="outline-secondary"
+        :aria-label="visible ? 'Hide password' : 'Show password'"
+      >
+        <svg v-if="visible" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-slash" viewBox="0 0 16 16">
+          <path d="M13.359 11.238C15.06 9.72 16 8 16 8s-3-5.5-8-5.5a7.028 7.028 0 0 0-2.79.588l.77.771A5.944 5.944 0 0 1 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.134 13.134 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755-.165.165-.337.328-.517.486z"/>
+          <path d="M11.297 5.316 5.066 11.547c-.862-.2-1.635-.726-2.195-1.474-.294-.396-.569-.83-.798-1.258a13.3 13.3 0 0 1-.954-3.14l.872-.486c.205.908.537 1.728.954 2.196.48.538 1.106.945 1.764 1.115l.623-.623A4.5 4.5 0 0 1 4.5 8a4.502 4.502 0 0 1 4.093-6.248l.965.965a5.503 5.503 0 0 0-.66.068c-1.996-.282-3.87 1.053-4.186 3.018l.865.865A3.49 3.49 0 0 0 11 8c0 .245-.045.478-.127.697l2.128 2.128a11.59 11.59 0 0 0 1.25-1.583l-.872-.486c-.238.41-.502.795-.788 1.139l-1.294-1.294z"/>
+          <path d="M0 1.354 1.354 0l14 14-1.354 1.354-14-14zM8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5z"/>
+        </svg>
+        <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye" viewBox="0 0 16 16">
+          <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.133 13.133 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.133 13.133 0 0 1 14.828 8c-.314.435-.8.995-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.134 13.134 0 0 1 1.172 8z"/>
+          <path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/>
+        </svg>
+      </BButton>
+    </BInputGroupAppend>
+  </BInputGroup>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+defineProps({
+  modelValue: {
+    type: String,
+    default: ''
+  },
+  state: {
+    type: [Boolean, null],
+    default: null
+  },
+  placeholder: {
+    type: String,
+    default: '••••••'
+  },
+  autofocus: {
+    type: Boolean,
+    default: false
+  }
+})
+
+defineEmits(['update:modelValue'])
+
+const visible = ref(false)
+
+const toggleVisibility = () => {
+  visible.value = !visible.value
+}
+</script>
+
+<style scoped>
+</style>

--- a/webui/src/locales/de.js
+++ b/webui/src/locales/de.js
@@ -103,7 +103,7 @@ export default {
       description: 'Sichere Transportverschlüsselung für die Kommunikation zwischen Platine und CCU über Port 3008.',
       mode: 'Verschlüsselungsmodus',
       modeDisabled: 'Deaktiviert (Standard)',
-      modePSK: 'Pre-Shared Key (PSK)',
+      modePsk: 'Pre-Shared Key (PSK)',
       modeCert: 'X.509 Zertifikat',
       cipherSuite: 'Cipher Suite',
       cipherAes128: 'AES-128-GCM-SHA256',

--- a/webui/src/locales/en.js
+++ b/webui/src/locales/en.js
@@ -103,7 +103,7 @@ export default {
       description: 'Secure transport encryption for communication between board and CCU on port 3008.',
       mode: 'Encryption Mode',
       modeDisabled: 'Disabled (Default)',
-      modePSK: 'Pre-Shared Key (PSK)',
+      modePsk: 'Pre-Shared Key (PSK)',
       modeCert: 'X.509 Certificate',
       cipherSuite: 'Cipher Suite',
       cipherAes128: 'AES-128-GCM-SHA256',

--- a/webui/src/locales/es.js
+++ b/webui/src/locales/es.js
@@ -83,7 +83,7 @@ export default {
       description: 'Cifrado de transporte seguro para la comunicación entre la placa y CCU en el puerto 3008.',
       mode: 'Modo de cifrado',
       modeDisabled: 'Deshabilitado (predeterminado)',
-      modePSK: 'Clave precompartida (PSK)',
+      modePsk: 'Clave precompartida (PSK)',
       modeCert: 'Certificado X.509',
       cipherSuite: 'Suite de cifrado',
       cipherAes128: 'AES-128-GCM-SHA256',

--- a/webui/src/locales/fr.js
+++ b/webui/src/locales/fr.js
@@ -86,7 +86,7 @@ export default {
       description: 'Chiffrement de transport sécurisé pour la communication entre la carte et CCU sur le port 3008.',
       mode: 'Mode de chiffrement',
       modeDisabled: 'Désactivé (par défaut)',
-      modePSK: 'Clé prépartagée (PSK)',
+      modePsk: 'Clé prépartagée (PSK)',
       modeCert: 'Certificat X.509',
       cipherSuite: 'Suite de chiffrement',
       cipherAes128: 'AES-128-GCM-SHA256',

--- a/webui/src/login.vue
+++ b/webui/src/login.vue
@@ -8,32 +8,11 @@
   >
     <BForm @submit.stop.prevent="loginClick">
       <BFormGroup :label="t('login.password')" label-cols-sm="4">
-        <BInputGroup>
-          <BFormInput
-            :type="passwordVisible ? 'text' : 'password'"
-            v-model="password"
-            :state="v$.password.$error ? false : null"
-            autofocus
-            placeholder="••••••"
-          />
-          <BInputGroupAppend>
-            <BButton
-              @click="passwordVisible = !passwordVisible"
-              variant="outline-secondary"
-              :aria-label="passwordVisible ? 'Hide password' : 'Show password'"
-            >
-              <svg v-if="passwordVisible" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-slash" viewBox="0 0 16 16">
-                <path d="M13.359 11.238C15.06 9.72 16 8 16 8s-3-5.5-8-5.5a7.028 7.028 0 0 0-2.79.588l.77.771A5.944 5.944 0 0 1 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.134 13.134 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755-.165.165-.337.328-.517.486z"/>
-                <path d="M11.297 5.316 5.066 11.547c-.862-.2-1.635-.726-2.195-1.474-.294-.396-.569-.83-.798-1.258a13.3 13.3 0 0 1-.954-3.14l.872-.486c.205.908.537 1.728.954 2.196.48.538 1.106.945 1.764 1.115l.623-.623A4.5 4.5 0 0 1 4.5 8a4.502 4.502 0 0 1 4.093-6.248l.965.965a5.503 5.503 0 0 0-.66.068c-1.996-.282-3.87 1.053-4.186 3.018l.865.865A3.49 3.49 0 0 0 11 8c0 .245-.045.478-.127.697l2.128 2.128a11.59 11.59 0 0 0 1.25-1.583l-.872-.486c-.238.41-.502.795-.788 1.139l-1.294-1.294z"/>
-                <path d="M0 1.354 1.354 0l14 14-1.354 1.354-14-14zM8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5z"/>
-              </svg>
-              <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye" viewBox="0 0 16 16">
-                <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.133 13.133 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.133 13.133 0 0 1 14.828 8c-.314.435-.8.995-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.134 13.134 0 0 1 1.172 8z"/>
-                <path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/>
-              </svg>
-            </BButton>
-          </BInputGroupAppend>
-        </BInputGroup>
+        <PasswordInput
+          v-model="password"
+          :state="v$.password.$error ? false : null"
+          :autofocus="true"
+        />
       </BFormGroup>
       <BAlert
         variant="danger"
@@ -64,6 +43,7 @@ import { useI18n } from 'vue-i18n'
 import { useVuelidate } from '@vuelidate/core'
 import { required } from '@vuelidate/validators'
 import { useLoginStore } from './stores.js'
+import PasswordInput from './components/PasswordInput.vue'
 
 const { t } = useI18n()
 
@@ -72,7 +52,6 @@ const route = useRoute()
 const loginStore = useLoginStore()
 
 const password = ref('')
-const passwordVisible = ref(false)
 const showError = ref(null)
 const loading = ref(false)
 

--- a/webui/src/settings.vue
+++ b/webui/src/settings.vue
@@ -238,7 +238,7 @@
       <BFormGroup :label="t('settings.dtls.mode')" label-cols-sm="4">
         <BFormRadioGroup buttons v-model="dtlsMode" required>
           <BFormRadio :value="0">{{ t('common.disabled') }}</BFormRadio>
-          <BFormRadio :value="1">{{ t('settings.dtls.modePSK') }}</BFormRadio>
+          <BFormRadio :value="1">{{ t('settings.dtls.modePsk') }}</BFormRadio>
           <BFormRadio :value="2">{{ t('settings.dtls.modeCert') }}</BFormRadio>
         </BFormRadioGroup>
       </BFormGroup>
@@ -348,58 +348,16 @@
     :cancel-title="t('common.cancel')"
   >
     <BFormGroup :label="t('settings.changePassword')" label-cols-sm="4">
-      <BInputGroup>
-        <BFormInput
-          :type="adminPasswordVisible ? 'text' : 'password'"
-          v-model="adminPassword"
-          :state="passwordValidation.password.$error ? false : null"
-          placeholder="••••••"
-        />
-        <BInputGroupAppend>
-          <BButton
-            @click="adminPasswordVisible = !adminPasswordVisible"
-            variant="outline-secondary"
-            :aria-label="adminPasswordVisible ? 'Hide password' : 'Show password'"
-          >
-            <svg v-if="adminPasswordVisible" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-slash" viewBox="0 0 16 16">
-              <path d="M13.359 11.238C15.06 9.72 16 8 16 8s-3-5.5-8-5.5a7.028 7.028 0 0 0-2.79.588l.77.771A5.944 5.944 0 0 1 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.134 13.134 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755-.165.165-.337.328-.517.486z"/>
-              <path d="M11.297 5.316 5.066 11.547c-.862-.2-1.635-.726-2.195-1.474-.294-.396-.569-.83-.798-1.258a13.3 13.3 0 0 1-.954-3.14l.872-.486c.205.908.537 1.728.954 2.196.48.538 1.106.945 1.764 1.115l.623-.623A4.5 4.5 0 0 1 4.5 8a4.502 4.502 0 0 1 4.093-6.248l.965.965a5.503 5.503 0 0 0-.66.068c-1.996-.282-3.87 1.053-4.186 3.018l.865.865A3.49 3.49 0 0 0 11 8c0 .245-.045.478-.127.697l2.128 2.128a11.59 11.59 0 0 0 1.25-1.583l-.872-.486c-.238.41-.502.795-.788 1.139l-1.294-1.294z"/>
-              <path d="M0 1.354 1.354 0l14 14-1.354 1.354-14-14zM8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5z"/>
-            </svg>
-            <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye" viewBox="0 0 16 16">
-              <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.133 13.133 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.133 13.133 0 0 1 14.828 8c-.314.435-.8.995-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.134 13.134 0 0 1 1.172 8z"/>
-              <path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/>
-            </svg>
-          </BButton>
-        </BInputGroupAppend>
-      </BInputGroup>
+      <PasswordInput
+        v-model="adminPassword"
+        :state="passwordValidation.password.$error ? false : null"
+      />
     </BFormGroup>
     <BFormGroup :label="t('settings.repeatPassword')" label-cols-sm="4">
-      <BInputGroup>
-        <BFormInput
-          :type="adminPasswordRepeatVisible ? 'text' : 'password'"
-          v-model="adminPasswordRepeat"
-          :state="passwordValidation.passwordRepeat.$error ? false : null"
-          placeholder="••••••"
-        />
-        <BInputGroupAppend>
-          <BButton
-            @click="adminPasswordRepeatVisible = !adminPasswordRepeatVisible"
-            variant="outline-secondary"
-            :aria-label="adminPasswordRepeatVisible ? 'Hide password' : 'Show password'"
-          >
-            <svg v-if="adminPasswordRepeatVisible" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye-slash" viewBox="0 0 16 16">
-              <path d="M13.359 11.238C15.06 9.72 16 8 16 8s-3-5.5-8-5.5a7.028 7.028 0 0 0-2.79.588l.77.771A5.944 5.944 0 0 1 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.134 13.134 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755-.165.165-.337.328-.517.486z"/>
-              <path d="M11.297 5.316 5.066 11.547c-.862-.2-1.635-.726-2.195-1.474-.294-.396-.569-.83-.798-1.258a13.3 13.3 0 0 1-.954-3.14l.872-.486c.205.908.537 1.728.954 2.196.48.538 1.106.945 1.764 1.115l.623-.623A4.5 4.5 0 0 1 4.5 8a4.502 4.502 0 0 1 4.093-6.248l.965.965a5.503 5.503 0 0 0-.66.068c-1.996-.282-3.87 1.053-4.186 3.018l.865.865A3.49 3.49 0 0 0 11 8c0 .245-.045.478-.127.697l2.128 2.128a11.59 11.59 0 0 0 1.25-1.583l-.872-.486c-.238.41-.502.795-.788 1.139l-1.294-1.294z"/>
-              <path d="M0 1.354 1.354 0l14 14-1.354 1.354-14-14zM8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5z"/>
-            </svg>
-            <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye" viewBox="0 0 16 16">
-              <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.133 13.133 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.133 13.133 0 0 1 14.828 8c-.314.435-.8.995-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.134 13.134 0 0 1 1.172 8z"/>
-              <path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/>
-            </svg>
-          </BButton>
-        </BInputGroupAppend>
-      </BInputGroup>
+      <PasswordInput
+        v-model="adminPasswordRepeat"
+        :state="passwordValidation.passwordRepeat.$error ? false : null"
+      />
     </BFormGroup>
     <BAlert
       variant="danger"
@@ -428,6 +386,7 @@ import {
   requiredUnless
 } from '@vuelidate/validators'
 import { useSettingsStore } from './stores.js'
+import PasswordInput from './components/PasswordInput.vue'
 
 const hostname_validator = helpers.regex(/^[a-zA-Z0-9_-]{1,63}$/)
 const domainname_validator = helpers.regex(/^([a-zA-Z0-9_-]{1,63}\.)*[a-zA-Z0-9_-]{1,63}$/)
@@ -441,8 +400,6 @@ const settingsStore = useSettingsStore()
 const restoreFile = ref(null)
 const adminPassword = ref('')
 const adminPasswordRepeat = ref('')
-const adminPasswordVisible = ref(false)
-const adminPasswordRepeatVisible = ref(false)
 const hostname = ref('')
 const useDHCP = ref(true)
 const localIP = ref('')
@@ -499,12 +456,14 @@ const password_validator = helpers.regex(/^(?=.*[A-Za-z])(?=.*\d).{6,}$/)
 // Validation rules
 const passwordRules = {
   password: {
+    required,
     minLength: minLength(6),
     maxLength: maxLength(32),
     password_validator: helpers.withMessage('Must contain letters and numbers', password_validator)
   },
   passwordRepeat: {
-    sameAsPassword: sameAs(adminPassword)
+    required,
+    sameAsPassword: helpers.withMessage('Passwords do not match', sameAs(adminPassword))
   }
 }
 
@@ -786,12 +745,8 @@ const handlePasswordChange = async (event) => {
   passwordValidation.value.$touch()
 
   if (passwordValidation.value.$error) {
-    passwordError.value = t('changePassword.passwordsDoNotMatch')
+    passwordError.value = passwordValidation.value.$errors[0].$message
     return
-  }
-
-  if (!adminPassword.value || adminPassword.value === '') {
-    return // No password change requested
   }
 
   try {


### PR DESCRIPTION
This commit addresses all code review suggestions:

1. Enhanced password validation:
   - Added 'required' validator to both password fields
   - Added custom message to 'sameAs' validator

2. Improved error handling:
   - Display specific validation errors instead of generic messages
   - Shows first validation error message to user

3. Naming consistency:
   - Renamed 'modePSK' to 'modePsk' across all locale files (en, de, es, fr)
   - Updated settings.vue to use the renamed key
   - Follows camelCase naming convention consistently

4. Code reusability:
   - Created reusable PasswordInput component
   - Extracted duplicated password input with show/hide functionality
   - Updated login.vue and settings.vue to use the new component
   - Reduced code duplication and improved maintainability