### PR TITLE
fix: Register analyzer WebSocket clients during handshake

### DIFF
--- a/src/analyzer.cpp
+++ b/src/analyzer.cpp
@@ -181,6 +181,9 @@ esp_err_t Analyzer::ws_handler(httpd_req_t *req)
     if (req->method == HTTP_GET) {
         // Handshake
         ESP_LOGI(TAG, "Handshake done, the new connection was opened");
+        if (_instance) {
+            _instance->addClient(req->handle, httpd_req_to_sockfd(req));
+        }
         return ESP_OK;
     }
 


### PR DESCRIPTION
The analyzer was not receiving any frames because clients were never
added to the client list. The ws_handler returned early during the
HTTP_GET handshake without calling addClient(), preventing the analyzer
from registering with the RadioModuleConnector.

This fix adds the client during the handshake, ensuring frames are
properly captured and displayed in the analyzer UI.

Fixes empty analyzer frame list issue.