### PR TITLE
Guard analyzer feature and enforce DTLS compatibility

### DIFF
--- a/src/analyzer.cpp
+++ b/src/analyzer.cpp
@@ -45,6 +45,16 @@ Analyzer::~Analyzer()
         _radioModuleConnector->removeFrameHandler(this);
     }
 
+    // Close any active websocket sessions to avoid dangling clients
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(200))) {
+        for (size_t i = 0; i < _clients.size(); i++) {
+            httpd_sess_trigger_close(_clients[i], _client_fds[i]);
+        }
+        _clients.clear();
+        _client_fds.clear();
+        xSemaphoreGive(_mutex);
+    }
+
     // Signal task to stop
     _running = false;
 


### PR DESCRIPTION
## Summary
- require the analyzer setting before accepting websocket connections and only spin up the analyzer task when enabled
- close analyzer websocket clients and tear down the task when the feature is disabled to avoid background impact
- automatically disable DTLS when Analyzer or HMLGW are enabled to prevent incompatible runtime configurations
- block Analyzer when HMLGW mode is active and avoid instantiating it in that mode to keep LAN gateway operation isolated

## Testing
- pio check --skip-packages *(fails: PlatformIO is not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69473286fe6883279d926961a44a4b38)