### PR TITLE
Harden authentication handling

### DIFF
--- a/include/settings.h
+++ b/include/settings.h
@@ -36,9 +36,16 @@ typedef enum
 
 class Settings
 {
+public:
+  static constexpr size_t PASSWORD_SALT_SIZE = 16;
+  static constexpr size_t PASSWORD_HASH_SIZE = 32; // SHA-256
+
 private:
-  char _adminPassword[33] = {0};
+  char _adminPassword[33] = {0}; // Only used transiently during migration; kept zeroed afterwards
+  uint8_t _adminPasswordSalt[PASSWORD_SALT_SIZE] = {0};
+  uint8_t _adminPasswordHash[PASSWORD_HASH_SIZE] = {0};
   bool _passwordChanged;
+  bool _passwordHashValid = false;
 
   char _hostname[33] = {0};
   bool _useDHCP;
@@ -74,8 +81,8 @@ public:
   void save();
   void clear();
 
-  char *getAdminPassword();
-  void setAdminPassword(char* password);
+  bool verifyAdminPassword(const char *password);
+  void setAdminPassword(const char* password);
   bool getPasswordChanged();
 
   char *getHostname();

--- a/src/rate_limiter.cpp
+++ b/src/rate_limiter.cpp
@@ -12,6 +12,7 @@
 #include "esp_log.h"
 #include "esp_timer.h"
 #include <string.h>
+#include <lwip/inet.h>
 #include <lwip/sockets.h>
 #include <lwip/netdb.h>
 
@@ -19,7 +20,8 @@ static const char *TAG = "RateLimiter";
 
 typedef struct
 {
-    uint32_t ip_address;
+    uint8_t ip_address[16];
+    uint8_t ip_length;
     int64_t last_attempt_time;
     uint8_t attempt_count;
     bool is_active;
@@ -29,12 +31,12 @@ static rate_limit_entry_t rate_limit_table[MAX_TRACKED_IPS];
 static bool initialized = false;
 
 // Get client IP address from request
-static uint32_t get_client_ip(httpd_req_t *req)
+static bool get_client_ip(httpd_req_t *req, uint8_t *out_addr, uint8_t *out_len)
 {
     int sockfd = httpd_req_to_sockfd(req);
     if (sockfd < 0)
     {
-        return 0;
+        return false;
     }
 
     struct sockaddr_storage addr;
@@ -42,20 +44,29 @@ static uint32_t get_client_ip(httpd_req_t *req)
 
     if (getpeername(sockfd, (struct sockaddr *)&addr, &addr_len) != 0)
     {
-        return 0;
+        return false;
     }
 
     if (addr.ss_family == AF_INET)
     {
         struct sockaddr_in *s = (struct sockaddr_in *)&addr;
-        return s->sin_addr.s_addr;
+        memcpy(out_addr, &s->sin_addr.s_addr, sizeof(s->sin_addr.s_addr));
+        *out_len = sizeof(s->sin_addr.s_addr);
+        return true;
+    }
+    else if (addr.ss_family == AF_INET6)
+    {
+        struct sockaddr_in6 *s6 = (struct sockaddr_in6 *)&addr;
+        memcpy(out_addr, &s6->sin6_addr.s6_addr, sizeof(s6->sin6_addr.s6_addr));
+        *out_len = sizeof(s6->sin6_addr.s6_addr);
+        return true;
     }
 
-    return 0;
+    return false;
 }
 
 // Find or create entry for IP address
-static rate_limit_entry_t* find_or_create_entry(uint32_t ip_address)
+static rate_limit_entry_t* find_or_create_entry(const uint8_t *ip_address, uint8_t ip_length)
 {
     int64_t current_time = esp_timer_get_time() / 1000000; // Convert to seconds
     rate_limit_entry_t *oldest_entry = NULL;
@@ -64,7 +75,9 @@ static rate_limit_entry_t* find_or_create_entry(uint32_t ip_address)
     // First, try to find existing entry
     for (int i = 0; i < MAX_TRACKED_IPS; i++)
     {
-        if (rate_limit_table[i].is_active && rate_limit_table[i].ip_address == ip_address)
+        if (rate_limit_table[i].is_active &&
+            rate_limit_table[i].ip_length == ip_length &&
+            memcmp(rate_limit_table[i].ip_address, ip_address, ip_length) == 0)
         {
             return &rate_limit_table[i];
         }
@@ -75,7 +88,8 @@ static rate_limit_entry_t* find_or_create_entry(uint32_t ip_address)
     {
         if (!rate_limit_table[i].is_active)
         {
-            rate_limit_table[i].ip_address = ip_address;
+            memcpy(rate_limit_table[i].ip_address, ip_address, ip_length);
+            rate_limit_table[i].ip_length = ip_length;
             rate_limit_table[i].last_attempt_time = current_time;
             rate_limit_table[i].attempt_count = 0;
             rate_limit_table[i].is_active = true;
@@ -94,7 +108,8 @@ static rate_limit_entry_t* find_or_create_entry(uint32_t ip_address)
     if (oldest_entry != NULL)
     {
         ESP_LOGW(TAG, "Rate limit table full, evicting oldest entry");
-        oldest_entry->ip_address = ip_address;
+        memcpy(oldest_entry->ip_address, ip_address, ip_length);
+        oldest_entry->ip_length = ip_length;
         oldest_entry->last_attempt_time = current_time;
         oldest_entry->attempt_count = 0;
         oldest_entry->is_active = true;
@@ -130,14 +145,15 @@ bool rate_limiter_check_login(httpd_req_t *req)
         rate_limiter_init();
     }
 
-    uint32_t client_ip = get_client_ip(req);
-    if (client_ip == 0)
+    uint8_t client_ip[16] = {0};
+    uint8_t client_ip_len = 0;
+    if (!get_client_ip(req, client_ip, &client_ip_len))
     {
         ESP_LOGW(TAG, "Could not determine client IP address");
         return true; // Allow request if we can't determine IP
     }
 
-    rate_limit_entry_t *entry = find_or_create_entry(client_ip);
+    rate_limit_entry_t *entry = find_or_create_entry(client_ip, client_ip_len);
     if (entry == NULL)
     {
         ESP_LOGE(TAG, "Could not create rate limit entry");
@@ -159,10 +175,16 @@ bool rate_limiter_check_login(httpd_req_t *req)
     {
         int64_t remaining_time = RATE_LIMIT_WINDOW_SECONDS - time_since_last;
 
-        // Log IP address in dotted notation
-        uint8_t *ip_bytes = (uint8_t *)&client_ip;
-        ESP_LOGW(TAG, "Rate limit exceeded for IP %d.%d.%d.%d (wait %lld seconds)",
-                 ip_bytes[0], ip_bytes[1], ip_bytes[2], ip_bytes[3], remaining_time);
+        char ip_str[INET6_ADDRSTRLEN] = {0};
+        if (entry->ip_length == 4)
+        {
+            inet_ntop(AF_INET, entry->ip_address, ip_str, sizeof(ip_str));
+        }
+        else if (entry->ip_length == 16)
+        {
+            inet_ntop(AF_INET6, entry->ip_address, ip_str, sizeof(ip_str));
+        }
+        ESP_LOGW(TAG, "Rate limit exceeded for IP %s (wait %lld seconds)", ip_str[0] ? ip_str : "unknown", remaining_time);
 
         return false; // Block request
     }
@@ -181,8 +203,9 @@ void rate_limiter_reset_ip(httpd_req_t *req)
         return;
     }
 
-    uint32_t client_ip = get_client_ip(req);
-    if (client_ip == 0)
+    uint8_t client_ip[16] = {0};
+    uint8_t client_ip_len = 0;
+    if (!get_client_ip(req, client_ip, &client_ip_len))
     {
         return;
     }
@@ -190,14 +213,23 @@ void rate_limiter_reset_ip(httpd_req_t *req)
     // Find and reset entry for this IP
     for (int i = 0; i < MAX_TRACKED_IPS; i++)
     {
-        if (rate_limit_table[i].is_active && rate_limit_table[i].ip_address == client_ip)
+        if (rate_limit_table[i].is_active &&
+            rate_limit_table[i].ip_length == client_ip_len &&
+            memcmp(rate_limit_table[i].ip_address, client_ip, client_ip_len) == 0)
         {
             rate_limit_table[i].attempt_count = 0;
             rate_limit_table[i].last_attempt_time = esp_timer_get_time() / 1000000;
 
-            uint8_t *ip_bytes = (uint8_t *)&client_ip;
-            ESP_LOGD(TAG, "Reset rate limit for IP %d.%d.%d.%d",
-                     ip_bytes[0], ip_bytes[1], ip_bytes[2], ip_bytes[3]);
+            char ip_str[INET6_ADDRSTRLEN] = {0};
+            if (client_ip_len == 4)
+            {
+                inet_ntop(AF_INET, client_ip, ip_str, sizeof(ip_str));
+            }
+            else if (client_ip_len == 16)
+            {
+                inet_ntop(AF_INET6, client_ip, ip_str, sizeof(ip_str));
+            }
+            ESP_LOGD(TAG, "Reset rate limit for IP %s", ip_str[0] ? ip_str : "unknown");
             break;
         }
     }

--- a/src/webui.cpp
+++ b/src/webui.cpp
@@ -170,15 +170,13 @@ int secure_strcmp(const char *s1, const char *s2) {
 
     size_t len1 = strlen(s1);
     size_t len2 = strlen(s2);
-    size_t min_len = (len1 < len2) ? len1 : len2;
-    int result = 0;
+    size_t max_len = (len1 > len2) ? len1 : len2;
+    int result = (len1 != len2);
 
-    if (len1 != len2) {
-        result = 1;
-    }
-
-    for (size_t i = 0; i < min_len; i++) {
-        result |= (s1[i] ^ s2[i]);
+    for (size_t i = 0; i < max_len; i++) {
+        const char c1 = (i < len1) ? s1[i] : 0;
+        const char c2 = (i < len2) ? s2[i] : 0;
+        result |= (c1 ^ c2);
     }
 
     return result;
@@ -223,7 +221,7 @@ esp_err_t post_login_json_handler_func(httpd_req_t *req)
 
         char *password = cJSON_GetStringValue(cJSON_GetObjectItem(root, "password"));
 
-        bool isAuthenticated = (password != NULL) && (secure_strcmp(password, _settings->getAdminPassword()) == 0);
+        bool isAuthenticated = (password != NULL) && _settings->verifyAdminPassword(password);
 
         cJSON_Delete(root);
 


### PR DESCRIPTION
## Summary
- Store the admin password as a salted SHA-256 hash in NVS, migrate legacy plaintext credentials, and keep verification state private.
- Use constant-time comparison paths for login token/password validation and verify credentials through hashing instead of plaintext comparisons.
- Extend login rate limiting to IPv6 clients and improve logging of blocked addresses.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947361e2ef883279a9a5b504917113f)