### PR TITLE
Polish analyzer UI and lifecycle

### DIFF
--- a/include/analyzer.h
+++ b/include/analyzer.h
@@ -32,6 +32,7 @@ private:
     QueueHandle_t _frameQueue;
     TaskHandle_t _taskHandle;
     bool _running;
+    bool _initialized;
 
     void _processingTask();
     void _processFrame(const AnalyzerFrame &frame);
@@ -45,6 +46,7 @@ public:
     void addClient(httpd_handle_t hd, int fd);
     void removeClient(httpd_handle_t hd, int fd);
     bool hasClients();
+    bool isReady() const { return _initialized; }
 
     // Static handler for WebSocket events
     static esp_err_t ws_handler(httpd_req_t *req);

--- a/include/hmlgw.h
+++ b/include/hmlgw.h
@@ -27,6 +27,8 @@ private:
     int _keepAliveClientSocket;
     TaskHandle_t _keepAliveTaskHandle;
 
+    void cleanupSockets();
+    void handleFatalError(const char* reason);
     void run();
     void runKeepAlive();
     void handleClient();


### PR DESCRIPTION
## Summary
- Improve analyzer lifecycle safety by explicitly clearing initialization state during destruction.
- Refresh Analyzer web UI with a modern status hero, live stats tiles, and polished table styling to match the design.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69484402bebc83279f208a2dbcd1d01b)