### PR TITLE
Fix ethernet yellow light issue

### DIFF
--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -52,6 +52,8 @@ private:
   eth_speed_t _linkSpeed;
   eth_duplex_t _duplexMode;
 
+  void _configurePHYLEDs();
+
 public:
   Ethernet(Settings *settings);
 


### PR DESCRIPTION
Adds proper LED configuration for the LAN8720 Ethernet PHY to ensure both status LEDs work correctly. The PHY's register 31 LED control bits are now explicitly configured on startup.

Changes:
- Add _configurePHYLEDs() method to configure PHY register 31
- Set LED mode to: LED1=Link status, LED2=Activity
- Call configuration during Ethernet start()
- Add logging for LED configuration status

Fixes issue where green LED was not lighting up (only yellow/amber LED visible)

Resolves: #ethernet-led-issue