### PR TITLE
fix: Resolve update errors and prevent system panics

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -127,10 +127,21 @@ void Settings::load()
   esp_err_t err = nvs_flash_init();
   if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND)
   {
-    ESP_ERROR_CHECK(nvs_flash_erase());
+    ESP_LOGW(TAG, "NVS partition needs to be erased (err: %s)", esp_err_to_name(err));
+    esp_err_t erase_err = nvs_flash_erase();
+    if (erase_err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to erase NVS flash: %s - using defaults", esp_err_to_name(erase_err));
+      // Continue with defaults - don't crash
+      return;
+    }
     err = nvs_flash_init();
   }
-  ESP_ERROR_CHECK(err);
+
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to initialize NVS flash: %s - using defaults", esp_err_to_name(err));
+    // Continue with defaults instead of crashing
+    return;
+  }
 
   err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
   if (err != ESP_OK) {


### PR DESCRIPTION
Critical fixes for update functionality and system stability:

Update/Online-Update Fixes:
- Fixed missing update notifications and download issues
- Added comprehensive error handling in performOnlineUpdate()
- Improved update check validation before starting OTA
- Added detailed HTTP client configuration with timeouts
- Implemented proper GitHub API headers for downloads
- Enhanced error reporting with specific failure reasons
- Added download URL validation before update attempt

Task Watchdog Improvements:
- Fixed watchdog handling during OTA updates
- Added error checking for watchdog disable/enable operations
- Prevents watchdog timeout during long-running updates
- Proper cleanup on update failure

Panic Prevention:
- Replaced ESP_ERROR_CHECK with safe error handling in NVS operations
- Settings now use defaults instead of crashing on NVS failures
- Added graceful degradation for flash initialization errors
- Prevents system panics from storage errors

WebUI Update Handler:
- Online update handler now validates version availability
- Returns detailed error messages to frontend
- Checks for download URL before starting update
- Improved user feedback with success/error states
- Better task creation error handling

Logging Enhancements:
- Added comprehensive logging throughout update process
- Detailed error messages for debugging
- Status updates at each stage of OTA process
- Better visibility into update failures

These changes ensure:
- Updates work reliably with proper feedback
- No silent failures or missing notifications
- System stability during and after updates
- Clear error messages for troubleshooting
- No unexpected resets or panics