### PR TITLE
fix: Code-Review Optimierungen und kritische Fehler behoben

### DIFF
--- a/src/updatecheck.cpp
+++ b/src/updatecheck.cpp
@@ -225,11 +225,12 @@ void UpdateCheck::_updateLatestVersion()
       ESP_LOGI(TAG, "Found suitable release: %s (prerelease=%d)", tag_name, is_prerelease);
 
       // Remove 'v' prefix if present
-      if (tag_name[0] == 'v' || tag_name[0] == 'V') {
-          tag_name++;
+      const char* version_str = tag_name;
+      if ((tag_name[0] == 'v' || tag_name[0] == 'V') && tag_name[1] != '\0') {
+          version_str = tag_name + 1;
       }
 
-      strncpy(_latestVersion, tag_name, sizeof(_latestVersion) - 1);
+      strncpy(_latestVersion, version_str, sizeof(_latestVersion) - 1);
       _latestVersion[sizeof(_latestVersion) - 1] = '\0';
       found_release = true;
       ESP_LOGI(TAG, "Set latest version to: %s", _latestVersion);
@@ -332,8 +333,6 @@ void UpdateCheck::_taskFunc()
       }
     }
   }
-
-  vTaskDelete(NULL);
 }
 
 void UpdateCheck::performOnlineUpdate()


### PR DESCRIPTION
- Unreachable code nach unendlicher Schleife in updatecheck.cpp:336 entfernt
- Pointer-Sicherheit verbessert: Prüfung ob nach 'v' Präfix noch Zeichen folgen
- Verhindert potentiellen Zugriff auf leeren String bei Version-Parsing

Diese Änderungen verbessern die Code-Qualität und eliminieren tote Code-Pfade.