### PR TITLE
Fix missing firmware variants in release assets

### DIFF
--- a/append_version_to_progname.py
+++ b/append_version_to_progname.py
@@ -7,7 +7,7 @@ if version_file.exists():
     with open(version_file, "r", encoding="utf-8") as fp:
         version = fp.readline().strip()
         if version:
-            env.Replace(PROGNAME=f"firmware_{version.replace('.', '_')}")
+            env.Replace(PROGNAME=f"firmware_{version}")
             print(f"Building firmware version: {version}")
         else:
             print("WARNING: version.txt is empty, using default firmware name")

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -113,7 +113,7 @@ def generate_release_notes(version: str) -> str:
         notes.append("| File | Description |")
         notes.append("|------|-------------|")
         for file in firmware_files:
-            if file.startswith('firmware_'):
+            if file.startswith('firmware'):
                 notes.append(f"| `{file}` | Main firmware binary |")
             elif file == 'bootloader.bin':
                 notes.append(f"| `{file}` | ESP32 bootloader |")
@@ -126,7 +126,7 @@ def generate_release_notes(version: str) -> str:
     notes.append("")
     notes.append("### Method 1: WebUI Update (Recommended)")
     notes.append("")
-    notes.append("1. Download the main firmware file (`firmware_*.bin`)")
+    notes.append("1. Download the main firmware file (`firmware*.bin`)")
     notes.append("2. Login to your HB-RF-ETH-ng WebUI")
     notes.append("3. Navigate to **Firmware Update**")
     notes.append("4. Select the downloaded `.bin` file")
@@ -144,7 +144,7 @@ def generate_release_notes(version: str) -> str:
     notes.append("  --flash_mode dio --flash_freq 40m --flash_size 4MB \\")
     notes.append("  0x1000 bootloader.bin \\")
     notes.append("  0x8000 partitions.bin \\")
-    notes.append("  0x10000 firmware_*.bin")
+    notes.append("  0x10000 firmware*.bin")
     notes.append("```")
     notes.append("")
 
@@ -160,7 +160,7 @@ def generate_release_notes(version: str) -> str:
     notes.append("")
     notes.append("**Windows (PowerShell):**")
     notes.append("```powershell")
-    notes.append("Get-FileHash firmware_*.bin -Algorithm SHA256")
+    notes.append("Get-FileHash firmware*.bin -Algorithm SHA256")
     notes.append("```")
     notes.append("")
 


### PR DESCRIPTION
The release workflow failed to pick up firmware binaries because of a filename mismatch: `append_version_to_progname.py` was generating `firmware_2_1_3.bin` (replacing dots with underscores), while `release.yml` was looking for `firmware_2.1.3.bin`. 

This change:
1.  Updates `append_version_to_progname.py` to use `firmware_2.1.3.bin` format.
2.  Updates `generate_release_notes.py` to correctly list the renamed artifacts (e.g., `firmware-standard-v2.1.3.bin`) in the release notes table, as they now follow a dash-separated pattern after being processed by the release workflow.
3.  Generalizes the documentation to refer to `firmware*.bin`.

---
*PR created automatically by Jules for task [15637513935949813318](https://jules.google.com/task/15637513935949813318) started by @Xerolux*