### PR TITLE
Enhance WebUI Security and Stability

### DIFF
--- a/include/secure_utils.h
+++ b/include/secure_utils.h
@@ -1,0 +1,17 @@
+#ifndef SECURE_UTILS_H
+#define SECURE_UTILS_H
+
+#include <stddef.h>
+
+/**
+ * @brief Securely zeros out memory to prevent compiler optimization
+ *
+ * @param v Pointer to memory to zero
+ * @param n Number of bytes to zero
+ */
+static inline void secure_zero(void *v, size_t n) {
+    volatile unsigned char *p = (volatile unsigned char *)v;
+    while (n--) *p++ = 0;
+}
+
+#endif // SECURE_UTILS_H


### PR DESCRIPTION
This PR addresses security, stability, and performance concerns in the WebUI module.

**Security:**
- Introduced `include/secure_utils.h` with a `secure_zero` function that prevents compiler optimization when clearing memory.
- Applied `secure_zero` to clear buffers containing passwords and tokens in:
    - `post_login_json_handler_func`
    - `post_settings_json_handler_func`
    - `post_restore_handler_func_actual`
    - `post_change_password_handler_func`
    - `generateToken`

**Stability:**
- Refactored `get_sysinfo_json_handler_func` to use `cJSON` library instead of manual `snprintf` into a fixed buffer. This eliminates potential buffer overflows if system info strings grow and ensures valid JSON output.
- Added NULL checks for `cJSON_PrintUnformatted` and `cJSON_Print` return values across all WebUI handlers. This prevents null pointer dereferences (crashes) if JSON serialization fails (e.g., due to low memory).
- Defined `RESTORE_BUFFER_SIZE` constant in `post_restore_handler_func_actual` to ensure consistent usage of the buffer size during allocation, receiving, and clearing.

**Performance:**
- While `cJSON` adds heap allocation overhead compared to stack `snprintf`, the safety and correctness benefits outweigh the minor performance cost in the administrative interface.


---
*PR created automatically by Jules for task [9393827965206328354](https://jules.google.com/task/9393827965206328354) started by @Xerolux*