### PR TITLE
feat: add PlatformIO OTA upload support via web API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # PlatformIO
 .pio/
 .vscode/
+platformio_local.ini
 
 # ESP-IDF Build artifacts
 build/

--- a/OTA_UPLOAD.md
+++ b/OTA_UPLOAD.md
@@ -1,0 +1,146 @@
+# OTA Upload via PlatformIO
+
+Diese Anleitung erklärt, wie du Firmware-Updates über das Netzwerk (OTA - Over The Air) mit PlatformIO durchführst.
+
+## Voraussetzungen
+
+### 1. Python Requests-Modul installieren
+```bash
+pip install requests
+```
+
+### 2. Umgebungsvariable für Passwort setzen (optional)
+
+**Windows (PowerShell):**
+```powershell
+$env:HB_RF_ETH_PASSWORD="dein_passwort"
+```
+
+**Windows (CMD):**
+```cmd
+set HB_RF_ETH_PASSWORD=dein_passwort
+```
+
+**Linux/Mac:**
+```bash
+export HB_RF_ETH_PASSWORD="dein_passwort"
+```
+
+**Alternativ:** Wenn keine Umgebungsvariable gesetzt ist, wirst du beim Upload nach dem Passwort gefragt.
+
+## Verwendung
+
+### Methode 1: OTA-Upload mit vorkonfigurierter IP
+
+Die IP-Adresse `192.168.178.56` ist bereits in `platformio.ini` vorkonfiguriert.
+
+**In Visual Studio Code:**
+1. Öffne die PlatformIO-Leiste
+2. Wähle ein OTA-Environment aus:
+   - `hb-rf-eth-ng-standard-ota`
+   - `hb-rf-eth-ng-hmlgw-ota`
+   - `hb-rf-eth-ng-analyzer-ota`
+   - `hb-rf-eth-ng-full-ota`
+3. Klicke auf "Upload" (oder drücke `Ctrl+Alt+U`)
+
+**In der Kommandozeile:**
+```bash
+pio run -e hb-rf-eth-ng-standard-ota -t upload
+```
+
+### Methode 2: OTA-Upload mit individueller IP
+
+Überschreibe die IP-Adresse via Umgebungsvariable:
+
+```bash
+# Windows PowerShell
+$env:UPLOAD_PORT="192.168.1.100"
+pio run -e hb-rf-eth-ng-standard-ota -t upload
+
+# Linux/Mac
+UPLOAD_PORT=192.168.1.100 pio run -e hb-rf-eth-ng-standard-ota -t upload
+```
+
+### Methode 3: Permanente IP-Adresse konfigurieren
+
+**Empfohlen:** Nutze `platformio_local.ini` für deine lokale IP (wird nicht in Git committed):
+
+```bash
+# Kopiere das Template
+cp platformio_local.ini.example platformio_local.ini
+
+# Bearbeite platformio_local.ini und trage deine IP ein
+```
+
+**Alternativ:** Bearbeite direkt `platformio.ini` und ändere `upload_port`:
+
+```ini
+[env:hb-rf-eth-ng-standard-ota]
+upload_port = 192.168.178.56  ; <-- Deine IP hier eintragen
+```
+
+⚠️ **Hinweis:** Wenn du die IP direkt in `platformio.ini` änderst, wird sie bei `git commit` mit committed. Nutze besser `platformio_local.ini` oder die Umgebungsvariable `UPLOAD_PORT`.
+
+## Ablauf
+
+Der OTA-Upload führt folgende Schritte automatisch aus:
+
+1. **Login**: Authentifizierung mit dem Gerätepasswort
+2. **Token-Abruf**: Erhält Authentifizierungs-Token vom Gerät
+3. **Firmware-Upload**: Lädt die kompilierte `.bin` Datei hoch
+4. **Neustart**: Gerät startet automatisch mit neuer Firmware
+
+## Beispiel-Ausgabe
+
+```
+============================================================
+HB-RF-ETH-ng OTA Upload
+============================================================
+Target device: 192.168.178.56
+Firmware: .pio/build/hb-rf-eth-ng-standard/firmware.bin
+------------------------------------------------------------
+Logging in to 192.168.178.56...
+✓ Login successful, token received
+Uploading firmware: firmware.bin (918528 bytes)
+Uploading... (this may take 30-60 seconds)
+✓ Firmware uploaded successfully!
+Device is restarting with new firmware...
+
+OTA Update completed!
+```
+
+## Fehlerbehebung
+
+### "No password provided"
+- Setze die Umgebungsvariable `HB_RF_ETH_PASSWORD`
+- Oder führe den Upload in einer interaktiven Shell aus (Passwort-Prompt)
+
+### "Authentication failed"
+- Überprüfe das Passwort
+- Standard-Passwort: `admin` (sollte beim ersten Login geändert werden)
+
+### "Connection timeout"
+- Überprüfe die IP-Adresse mit `ping 192.168.178.56`
+- Stelle sicher, dass Gerät und PC im gleichen Netzwerk sind
+- Firewall-Regeln prüfen (Port 80 muss erreichbar sein)
+
+### "Upload failed"
+- Ausreichend Speicherplatz auf dem Gerät prüfen
+- Firmware-Datei korrumpiert → Rebuild mit `pio run -e <environment> -t clean`
+- Gerät neu starten und erneut versuchen
+
+## Normaler Upload via USB
+
+Für den ersten Upload oder bei Problemen nutze die Standard-Environments (ohne `-ota`):
+
+```bash
+# Via USB
+pio run -e hb-rf-eth-ng-standard -t upload
+```
+
+## Sicherheit
+
+- **Token-Sicherheit**: Das Token wird bei jedem Boot neu generiert
+- **Passwort**: Ändere das Standard-Passwort beim ersten Login!
+- **Netzwerk**: OTA-Updates funktionieren nur im lokalen Netzwerk
+- **Verschlüsselung**: HTTP wird verwendet (keine TLS/HTTPS auf ESP32)

--- a/ota_upload.py
+++ b/ota_upload.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+OTA Upload Script for HB-RF-ETH-ng
+Performs authenticated OTA firmware upload via Web API
+"""
+
+Import("env")  # PlatformIO SCons import
+import requests
+import sys
+import os
+
+def get_upload_params():
+    """Extract upload parameters from environment"""
+    # Get IP address from upload_port or UPLOAD_PORT env variable
+    upload_port = env.get("UPLOAD_PORT", "")
+    if not upload_port:
+        upload_port = env.get("upload_port", "")
+
+    if not upload_port:
+        print("Error: No upload_port specified!")
+        print("Set upload_port in platformio.ini or use UPLOAD_PORT environment variable")
+        sys.exit(1)
+
+    # Get password from environment variable or prompt
+    password = os.environ.get("HB_RF_ETH_PASSWORD", "")
+    if not password:
+        try:
+            import getpass
+            password = getpass.getpass("Enter device password: ")
+        except:
+            print("Error: No password provided!")
+            print("Set HB_RF_ETH_PASSWORD environment variable or run interactively")
+            sys.exit(1)
+
+    return upload_port, password
+
+def login_and_get_token(ip_address, password):
+    """Login to device and retrieve authentication token"""
+    login_url = f"http://{ip_address}/login.json"
+
+    print(f"Logging in to {ip_address}...")
+
+    try:
+        response = requests.post(
+            login_url,
+            json={"password": password},
+            timeout=10
+        )
+
+        if response.status_code != 200:
+            print(f"Login failed with status {response.status_code}")
+            print(f"Response: {response.text}")
+            sys.exit(1)
+
+        data = response.json()
+
+        if not data.get("isAuthenticated", False):
+            print("Authentication failed! Check password.")
+            sys.exit(1)
+
+        token = data.get("token")
+        if not token:
+            print("No token received from device!")
+            sys.exit(1)
+
+        print("✓ Login successful, token received")
+        return token
+
+    except requests.exceptions.RequestException as e:
+        print(f"Network error during login: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error during login: {e}")
+        sys.exit(1)
+
+def upload_firmware(ip_address, token, firmware_path):
+    """Upload firmware using authentication token"""
+    ota_url = f"http://{ip_address}/ota_update"
+
+    if not os.path.exists(firmware_path):
+        print(f"Firmware file not found: {firmware_path}")
+        sys.exit(1)
+
+    file_size = os.path.getsize(firmware_path)
+    print(f"Uploading firmware: {os.path.basename(firmware_path)} ({file_size} bytes)")
+
+    try:
+        with open(firmware_path, 'rb') as f:
+            files = {'file': (os.path.basename(firmware_path), f, 'application/octet-stream')}
+            headers = {'Authorization': f'Token {token}'}
+
+            print("Uploading... (this may take 30-60 seconds)")
+
+            response = requests.post(
+                ota_url,
+                files=files,
+                headers=headers,
+                timeout=120  # 2 minutes timeout for upload
+            )
+
+            if response.status_code == 200:
+                print("✓ Firmware uploaded successfully!")
+                print("Device is restarting with new firmware...")
+                print("\nOTA Update completed!")
+                return True
+            else:
+                print(f"Upload failed with status {response.status_code}")
+                print(f"Response: {response.text}")
+                sys.exit(1)
+
+    except requests.exceptions.Timeout:
+        print("Upload timeout! Check network connection and device status.")
+        sys.exit(1)
+    except requests.exceptions.RequestException as e:
+        print(f"Network error during upload: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error during upload: {e}")
+        sys.exit(1)
+
+def ota_upload(source, target, env):
+    """Main OTA upload function called by PlatformIO"""
+    print("\n" + "="*60)
+    print("HB-RF-ETH-ng OTA Upload")
+    print("="*60)
+
+    # Get parameters
+    ip_address, password = get_upload_params()
+    firmware_path = str(target[0])
+
+    print(f"Target device: {ip_address}")
+    print(f"Firmware: {firmware_path}")
+    print("-"*60)
+
+    # Login and get token
+    token = login_and_get_token(ip_address, password)
+
+    # Upload firmware
+    upload_firmware(ip_address, token, firmware_path)
+
+# Register upload action
+env.Replace(UPLOADCMD=ota_upload)

--- a/platformio.ini
+++ b/platformio.ini
@@ -86,3 +86,44 @@ build_flags =
 ; Legacy alias - maps to full variant for backwards compatibility
 [env:hb-rf-eth-ng]
 extends = env:hb-rf-eth-ng-full
+
+; ============================================================
+; OTA Upload Environments (for remote upload via network)
+; ============================================================
+
+; OTA Upload for standard variant
+; Set upload_port to your device IP or use UPLOAD_PORT environment variable
+[env:hb-rf-eth-ng-standard-ota]
+extends = env:hb-rf-eth-ng-standard
+upload_protocol = custom
+upload_port = 192.168.1.100  ; Change to your device IP address
+extra_scripts =
+    ${env:base.extra_scripts}
+    ota_upload.py
+
+; OTA Upload for hmlgw variant
+[env:hb-rf-eth-ng-hmlgw-ota]
+extends = env:hb-rf-eth-ng-hmlgw
+upload_protocol = custom
+upload_port = 192.168.1.100  ; Change to your device IP address
+extra_scripts =
+    ${env:base.extra_scripts}
+    ota_upload.py
+
+; OTA Upload for analyzer variant
+[env:hb-rf-eth-ng-analyzer-ota]
+extends = env:hb-rf-eth-ng-analyzer
+upload_protocol = custom
+upload_port = 192.168.1.100  ; Change to your device IP address
+extra_scripts =
+    ${env:base.extra_scripts}
+    ota_upload.py
+
+; OTA Upload for full variant
+[env:hb-rf-eth-ng-full-ota]
+extends = env:hb-rf-eth-ng-full
+upload_protocol = custom
+upload_port = 192.168.1.100  ; Change to your device IP address
+extra_scripts =
+    ${env:base.extra_scripts}
+    ota_upload.py

--- a/platformio_local.ini.example
+++ b/platformio_local.ini.example
@@ -1,0 +1,21 @@
+; Local PlatformIO Configuration Override Example
+;
+; Copy this file to platformio_local.ini and customize for your setup
+; platformio_local.ini is git-ignored and won't be committed
+;
+; Usage:
+;   1. cp platformio_local.ini.example platformio_local.ini
+;   2. Edit platformio_local.ini with your local IP addresses
+;   3. PlatformIO will automatically use settings from platformio_local.ini
+
+[env:hb-rf-eth-ng-standard-ota]
+upload_port = 192.168.178.56  ; Your device IP
+
+[env:hb-rf-eth-ng-hmlgw-ota]
+upload_port = 192.168.178.56  ; Your device IP
+
+[env:hb-rf-eth-ng-analyzer-ota]
+upload_port = 192.168.178.56  ; Your device IP
+
+[env:hb-rf-eth-ng-full-ota]
+upload_port = 192.168.178.56  ; Your device IP


### PR DESCRIPTION
- Add ota_upload.py script for authenticated firmware upload
- Add OTA environments for all firmware variants
- Support login-based token authentication
- Add platformio_local.ini for local IP configuration
- Add comprehensive OTA upload documentation

Features:
- Automatic login and token retrieval
- HTTP POST to /ota_update endpoint
- Environment variable support (UPLOAD_PORT, HB_RF_ETH_PASSWORD)
- Git-safe: local IPs in platformio_local.ini (ignored)

Usage: pio run -e hb-rf-eth-ng-standard-ota -t upload