### PR TITLE
fix: Release-Body auf Changelog + Sponsor reduzieren statt gesamte README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,13 @@ jobs:
           cp ".pio/build/hb-rf-eth-ng/bootloader.bin" release/ 2>/dev/null || true
           cp ".pio/build/hb-rf-eth-ng/partitions.bin" release/ 2>/dev/null || true
 
-          # Copy documentation
+          # Copy version file
           cp version.txt release/
-          cp README.md release/
+
+      - name: Generate release notes
+        run: |
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          python generate_release_notes.py "$VERSION" release/RELEASE_NOTES.md
 
       - name: Create checksums
         run: |
@@ -142,7 +146,7 @@ jobs:
         with:
           tag_name: ${{ steps.get_version.outputs.VERSION_TAG }}
           name: 🚀 HB-RF-ETH-ng Firmware ${{ steps.get_version.outputs.VERSION_TAG }}
-          body_path: release/README.md
+          body_path: release/RELEASE_NOTES.md
           files: |
             release/firmware_*.bin
             release/bootloader.bin

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -1,38 +1,39 @@
 #!/usr/bin/env python3
 """
 Generate release notes for HB-RF-ETH-ng firmware releases.
-Combines changelog, installation instructions, and funding information.
+Produces a concise release body: short intro, changelog, and sponsor block.
 
 Usage:
     python generate_release_notes.py <version> <output_file>
 
 Example:
-    python generate_release_notes.py 2.1.0 release_notes.md
+    python generate_release_notes.py 2.1.0 release/README.md
 """
 
 import sys
 import re
 from pathlib import Path
-from datetime import datetime
+
 
 def extract_changelog(version: str) -> str:
-    """Extract changelog section for specific version"""
+    """Extract changelog section for specific version from CHANGELOG.md"""
     changelog_file = Path("CHANGELOG.md")
 
     if not changelog_file.exists():
-        return "No changelog available."
+        return ""
 
     content = changelog_file.read_text()
 
-    # Try to find the version section
-    pattern = rf"## \[?{re.escape(version)}\]?"
+    # Try to find the version section (handles various formats:
+    # "## Version 2.0.0 (...)", "## [2.0.0]", "## v2.0.0", "## 2.0.0")
+    pattern = rf"## (?:Version )?\[?v?{re.escape(version)}\]?"
     lines = content.split('\n')
 
     changelog_lines = []
     found = False
 
     for line in lines:
-        if re.match(pattern, line):
+        if re.match(pattern, line, re.IGNORECASE):
             found = True
             continue
         elif found and line.startswith('## '):
@@ -43,224 +44,108 @@ def extract_changelog(version: str) -> str:
     if changelog_lines:
         return '\n'.join(changelog_lines).strip()
 
-    return "See CHANGELOG.md for version details."
+    return ""
 
-def get_firmware_files() -> list:
-    """Get list of firmware binary files"""
-    release_dir = Path("release")
 
-    if not release_dir.exists():
-        return []
+def extract_readme_changes(version: str) -> str:
+    """Extract version-specific changes from README.md as fallback"""
+    readme_file = Path("README.md")
 
-    files = []
-    for file in sorted(release_dir.glob("*.bin")):
-        files.append(file.name)
+    if not readme_file.exists():
+        return ""
 
-    return files
+    content = readme_file.read_text()
+
+    # Look for "Version X.Y.Z Änderungen:" section
+    pattern = rf"\*\*Version {re.escape(version)} Änderungen:\*\*"
+    lines = content.split('\n')
+
+    change_lines = []
+    found = False
+
+    for line in lines:
+        if re.match(pattern, line):
+            found = True
+            continue
+        elif found and (line.startswith('**Version ') or line.startswith('### ')):
+            break
+        elif found:
+            change_lines.append(line)
+
+    if change_lines:
+        return '\n'.join(change_lines).strip()
+
+    return ""
+
 
 def generate_release_notes(version: str) -> str:
-    """Generate complete release notes"""
+    """Generate concise release notes: intro, changelog, sponsor block."""
 
-    # Determine if this is a pre-release
     is_prerelease = any(tag in version.lower() for tag in ['alpha', 'beta', 'rc'])
 
-    # Extract changelog
+    # Try changelog first, fall back to README changes
     changelog = extract_changelog(version)
+    if not changelog:
+        changelog = extract_readme_changes(version)
 
-    # Get firmware files
-    firmware_files = get_firmware_files()
-
-    # Build release notes
     notes = []
 
-    # Header
-    notes.append(f"# 🚀 HB-RF-ETH-ng Firmware v{version}")
+    # Short intro
+    notes.append(f"# HB-RF-ETH-ng Firmware v{version}")
     notes.append("")
 
     if is_prerelease:
-        notes.append("> ⚠️ **Pre-Release Version** - This is a pre-release version for testing purposes.")
-        notes.append("> Use at your own risk and report any issues on GitHub.")
+        notes.append("> **Pre-Release** - Testversion, Nutzung auf eigene Gefahr.")
         notes.append("")
 
-    notes.append(f"**Release Date:** {datetime.now().strftime('%Y-%m-%d')}")
+    notes.append("Firmware-Update für die HB-RF-ETH Platine.")
     notes.append("")
 
-    # What's New
-    notes.append("## 📋 What's New")
-    notes.append("")
-    notes.append(changelog)
-    notes.append("")
-
-    # Download Section
-    notes.append("## 📥 Download & Installation")
-    notes.append("")
-    notes.append("### Complete Release Package")
-    notes.append("")
-    notes.append(f"Download the complete firmware package: **`hb-rf-eth-ng-firmware-v{version}.zip`**")
-    notes.append("")
-    notes.append("This package includes:")
-    notes.append("- Firmware binary files")
-    notes.append("- Bootloader and partition table")
-    notes.append("- SHA256 checksums")
-    notes.append("- README and CHANGELOG")
-    notes.append("")
-
-    # Individual Files
-    if firmware_files:
-        notes.append("### Individual Firmware Files")
+    # What changed
+    if changelog:
+        notes.append(f"## Was ist neu in v{version}?")
         notes.append("")
-        notes.append("| File | Description |")
-        notes.append("|------|-------------|")
-        for file in firmware_files:
-            if file.startswith('firmware_'):
-                notes.append(f"| `{file}` | Main firmware binary |")
-            elif file == 'bootloader.bin':
-                notes.append(f"| `{file}` | ESP32 bootloader |")
-            elif file == 'partitions.bin':
-                notes.append(f"| `{file}` | Partition table |")
+        notes.append(changelog)
         notes.append("")
 
-    # Installation Instructions
-    notes.append("## 🔧 Installation Instructions")
+    # Brief install hint
+    notes.append("## Installation")
     notes.append("")
-    notes.append("### Method 1: WebUI Update (Recommended)")
-    notes.append("")
-    notes.append("1. Download the main firmware file (`firmware_*.bin`)")
-    notes.append("2. Login to your HB-RF-ETH-ng WebUI")
-    notes.append("3. Navigate to **Firmware Update**")
-    notes.append("4. Select the downloaded `.bin` file")
-    notes.append("5. Click **Update** and wait for completion")
-    notes.append("6. Device will automatically reboot with new firmware")
-    notes.append("")
-    notes.append("### Method 2: Serial Flash (Advanced)")
-    notes.append("")
-    notes.append("For initial installation or recovery:")
-    notes.append("")
-    notes.append("```bash")
-    notes.append("# Using esptool.py")
-    notes.append("esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 \\")
-    notes.append("  --before default_reset --after hard_reset write_flash -z \\")
-    notes.append("  --flash_mode dio --flash_freq 40m --flash_size 4MB \\")
-    notes.append("  0x1000 bootloader.bin \\")
-    notes.append("  0x8000 partitions.bin \\")
-    notes.append("  0x10000 firmware_*.bin")
-    notes.append("```")
+    notes.append("Die `firmware_*.bin` Datei herunterladen und per WebUI hochladen oder per URL installieren.")
+    notes.append("SHA256-Prüfsummen befinden sich in `SHA256SUMS.txt`.")
     notes.append("")
 
-    # Verification
-    notes.append("## 🔐 Verify Download Integrity")
+    # Sponsor block
+    notes.append("## Unterstützung")
     notes.append("")
-    notes.append("SHA256 checksums are provided in `SHA256SUMS.txt`.")
-    notes.append("")
-    notes.append("**Linux/Mac:**")
-    notes.append("```bash")
-    notes.append("sha256sum -c SHA256SUMS.txt")
-    notes.append("```")
-    notes.append("")
-    notes.append("**Windows (PowerShell):**")
-    notes.append("```powershell")
-    notes.append("Get-FileHash firmware_*.bin -Algorithm SHA256")
-    notes.append("```")
-    notes.append("")
-
-    # Important Notes
-    notes.append("## ⚠️ Important Notes")
-    notes.append("")
-    notes.append("- **Backup your settings** before updating")
-    notes.append("- **Default password:** `admin` (must be changed on first login)")
-    notes.append("- After device restart, you may need to restart your CCU/debmatic/piVCCU3")
-    notes.append("- Factory reset available via hardware button (see documentation)")
-    notes.append("")
-
-    # Features
-    notes.append("## ✨ Key Features")
-    notes.append("")
-    notes.append("- 🌐 Ethernet connectivity for HomeMatic radio modules")
-    notes.append("- 🔄 OTA firmware updates via WebUI")
-    notes.append("- 🕐 Multiple time sources (NTP, GPS, DCF77, RTC)")
-    notes.append("- 📊 SNMP monitoring support")
-    notes.append("- 🔍 Check_MK agent integration")
-    notes.append("- 🔒 Enforced password change on first login")
-    notes.append("- 📱 Modern Vue 3 WebUI")
-    notes.append("- ⚙️ ESP-IDF 5.x based")
-    notes.append("")
-
-    # Compatibility
-    notes.append("## 🔌 Compatibility")
-    notes.append("")
-    notes.append("**Supported Radio Modules:**")
-    notes.append("- RPI-RF-MOD")
-    notes.append("- HM-MOD-RPI-PCB")
-    notes.append("")
-    notes.append("**Compatible Systems:**")
-    notes.append("- piVCCU3 (≥ v3.51.6-41)")
-    notes.append("- debmatic (≥ v3.51.6-46)")
-    notes.append("- openCCU")
-    notes.append("")
-
-    # Support & Funding
-    notes.append("## 💖 Support This Project")
-    notes.append("")
-    notes.append("If you find this firmware useful, please consider supporting its development:")
+    notes.append("Dir gefällt dieses Projekt und du möchtest es unterstützen?")
     notes.append("")
     notes.append("[![Buy Me A Coffee](https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg?style=for-the-badge)](https://www.buymeacoffee.com/xerolux)")
     notes.append("[![Tesla Referral](https://img.shields.io/badge/Tesla-Referral-red?style=for-the-badge&logo=tesla)](https://ts.la/sebastian564489)")
     notes.append("")
-    notes.append("Your support helps maintain and improve this project! 🙏")
-    notes.append("")
-
-    # Links
-    notes.append("## 🔗 Links & Resources")
-    notes.append("")
-    notes.append("- 📖 [Documentation](https://github.com/Xerolux/HB-RF-ETH-ng/blob/main/README.md)")
-    notes.append("- 🐛 [Report Issues](https://github.com/Xerolux/HB-RF-ETH-ng/issues)")
-    notes.append("- 💬 [Discussions](https://github.com/Xerolux/HB-RF-ETH-ng/discussions)")
-    notes.append("- 📋 [Full Changelog](https://github.com/Xerolux/HB-RF-ETH-ng/blob/main/CHANGELOG.md)")
-    notes.append("- 🔧 [Troubleshooting Guide](https://github.com/Xerolux/HB-RF-ETH-ng/blob/main/docs/TROUBLESHOOTING.md)")
-    notes.append("")
-
-    # Credits
-    notes.append("## 👏 Credits")
-    notes.append("")
-    notes.append("This firmware is a modernized fork of the original [HB-RF-ETH](https://github.com/alexreinert/HB-RF-ETH) by **Alexander Reinert**.")
-    notes.append("")
-    notes.append("Special thanks to:")
-    notes.append("- Alexander Reinert for the original firmware and hardware design")
-    notes.append("- The HomeMatic community")
-    notes.append("- All contributors and testers")
-    notes.append("")
-
-    # Footer
-    notes.append("---")
-    notes.append("")
-    notes.append("**License:** [CC BY-NC-SA 4.0](https://github.com/Xerolux/HB-RF-ETH-ng/blob/main/LICENSE.md)")
-    notes.append("")
-    notes.append(f"**Version:** {version} | **Built:** {datetime.now().strftime('%Y-%m-%d %H:%M UTC')}")
 
     return '\n'.join(notes)
+
 
 def main():
     if len(sys.argv) != 3:
         print("Usage: python generate_release_notes.py <version> <output_file>")
-        print("Example: python generate_release_notes.py 2.1.0 release_notes.md")
+        print("Example: python generate_release_notes.py 2.1.0 release/README.md")
         sys.exit(1)
 
     version = sys.argv[1].lstrip('v')
     output_file = sys.argv[2]
 
-    print(f"📝 Generating release notes for version {version}")
+    print(f"Generating release notes for version {version}")
 
     try:
         notes = generate_release_notes(version)
-
         Path(output_file).write_text(notes)
-
-        print(f"✅ Release notes written to {output_file}")
-        print(f"📄 {len(notes.split(chr(10)))} lines generated")
-
+        print(f"Release notes written to {output_file}")
     except Exception as e:
-        print(f"❌ Error generating release notes: {e}")
+        print(f"Error generating release notes: {e}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/release/README.md
+++ b/release/README.md
@@ -1,53 +1,5 @@
-# HB-RF-ETH-ng Firmware v2.1.2
+# HB-RF-ETH-ng Firmware
 
-Dieses Release enthält die fertige Firmware für die HB-RF-ETH Platine.
+Diese Datei wird beim Release automatisch durch `generate_release_notes.py` ersetzt.
 
-## Was ist neu in v2.1.2?
-
-### Erhöhte Sicherheit
-- Stärkere Passwort-Anforderungen (8 Zeichen, Groß-/Kleinschreibung, Zahlen)
-- OTA-Passwort wird nicht mehr im Browser gespeichert (Security Best Practice)
-
-### Verbesserte Firmware-Update-UX
-- Passwort-Stärke-Anzeige beim Setzen
-- Warnhinweis wenn OTA-Passwort nicht gesetzt
-- Automatischer Neustart nach erfolgreichem Update
-
-### Detaillierte Neustart-Gründe
-- Zeigt Ursache des letzten Neustarts (Update, Werksreset, Fehler, etc.)
-
-### Neue Features
-- **OTA Update per URL** - Firmware direkt aus dem Netzwerk herunterladen
-- **Werksreset** auch über WebUI möglich
-- **Moderne, responsive WebUI** mit Mobile-Support
-
-## Installationsanleitung
-
-1. Herunterladen der `firmware_2.1.2.bin` Datei
-2. In der WebUI zur Seite "Firmware Update" navigieren
-3. Die .bin Datei hochladen
-4. OTA-Passwort eingeben (falls konfiguriert)
-5. Update wird automatisch eingespielt
-
-**Alternativ via URL-Download:**
-1. In der WebUI zur Seite "Firmware Update" navigieren
-2. Direkte URL zur .bin Datei eingeben
-3. Quick-Button für die neueste GitHub-Version nutzen
-4. Firmware wird heruntergeladen und installiert
-
-## Prüfsümme
-
-Die SHA256-Prüfsummen befinden sich in `SHA256SUMS.txt`.
-
-## Unterstützung gefällig?
-
-Dir gefällt dieses Projekt und du möchtest mir einen Kaffee ausgeben?
-
-[![Buy Me A Coffee][buymeacoffee-badge]][buymeacoffee]
-[![Tesla][tesla-badge]][tesla]
-
-<!-- Links -->
-[buymeacoffee]: https://www.buymeacoffee.com/xerolux
-[buymeacoffee-badge]: https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg?style=for-the-badge
-[tesla]: https://ts.la/sebastian564489
-[tesla-badge]: https://img.shields.io/badge/Tesla-Referral-red?style=for-the-badge&logo=tesla
+Siehe [README.md](../README.md) für die vollständige Dokumentation.


### PR DESCRIPTION
Die release.yml hat bisher die komplette README.md als Release-Body
verwendet. Jetzt wird generate_release_notes.py genutzt, das nur
die relevanten Änderungen, einen kurzen Installationshinweis und
den Sponsor-Block in die Release Notes schreibt.

https://claude.ai/code/session_01LRRBiYFgP6n7fcwWQ7LyMq