### PR TITLE
Remove OTA password and fix security bugs

### DIFF
--- a/include/settings.h
+++ b/include/settings.h
@@ -39,7 +39,6 @@ class Settings
 private:
   char _adminPassword[33] = {0};
   bool _passwordChanged;
-  char _otaPassword[33] = {0};  // Separate password for firmware updates
 
   char _hostname[33] = {0};
   bool _useDHCP;
@@ -78,10 +77,6 @@ public:
   char *getAdminPassword();
   void setAdminPassword(char* password);
   bool getPasswordChanged();
-
-  char *getOtaPassword();
-  void setOtaPassword(char* password);
-  bool verifyOtaPassword(const char* password);
 
   char *getHostname();
   bool getUseDHCP();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -99,14 +99,6 @@ void Settings::load()
       GET_BOOL(handle, "passwordChanged", _passwordChanged, currentVal);
   }
 
-  // Load OTA password (separate password for firmware updates)
-  size_t otaPasswordLength = sizeof(_otaPassword);
-  if (nvs_get_str(handle, "otaPassword", _otaPassword, &otaPasswordLength) != ESP_OK)
-  {
-    // No OTA password set yet - empty means must be set first
-    _otaPassword[0] = '\0';
-  }
-
   size_t hostnameLength = sizeof(_hostname);
   if (nvs_get_str(handle, "hostname", _hostname, &hostnameLength) != ESP_OK)
   {
@@ -172,9 +164,6 @@ void Settings::save()
   SET_STR(handle, "adminPassword", _adminPassword);
   SET_BOOL(handle, "passwordChanged", _passwordChanged);
 
-  // Save OTA password
-  SET_STR(handle, "otaPassword", _otaPassword);
-
   SET_STR(handle, "hostname", _hostname);
   SET_BOOL(handle, "useDHCP", _useDHCP);
   SET_IP_ADDR(handle, "localIP", _localIP);
@@ -236,27 +225,6 @@ void Settings::setAdminPassword(char *adminPassword)
 bool Settings::getPasswordChanged()
 {
   return _passwordChanged;
-}
-
-char *Settings::getOtaPassword()
-{
-  return _otaPassword;
-}
-
-void Settings::setOtaPassword(char *otaPassword)
-{
-  strncpy(_otaPassword, otaPassword, sizeof(_otaPassword) - 1);
-  _otaPassword[sizeof(_otaPassword) - 1] = '\0';
-}
-
-bool Settings::verifyOtaPassword(const char *password)
-{
-  // If OTA password is not set, deny access (must be explicitly set)
-  if (_otaPassword[0] == '\0') {
-    return false;
-  }
-  // Use secure_strcmp to prevent timing attacks
-  return (secure_strcmp(_otaPassword, password) == 0);
 }
 
 char *Settings::getHostname()


### PR DESCRIPTION
This change removes the deprecated OTA password functionality and addresses several critical security and stability issues.
- **OTA Password Removal**: Removed `_otaPassword` from `Settings` and all associated handlers (`/api/set-ota-password`, etc.) and validation logic in `webui.cpp`.
- **Buffer Overflow Fix**: Rewrote the CheckMK agent output generation in `src/monitoring.cpp` to use a safe `APPEND_CHECKMK` macro that enforces buffer bounds, preventing potential stack corruption.
- **JSON Safety**: Refactored the `sysinfo` JSON generation to use the `cJSON` library instead of `snprintf` with a large stack buffer, eliminating injection risks and reducing stack usage.
- **Stability**: Added checks for `cJSON_Print` returning NULL in all API handlers to prevent NULL pointer dereferences on memory exhaustion.

---
*PR created automatically by Jules for task [10154350463908632635](https://jules.google.com/task/10154350463908632635) started by @Xerolux*