### PR TITLE
Enhance system restart to hard-reset Ethernet and Radio peripherals

### DIFF
--- a/include/system_reset.h
+++ b/include/system_reset.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void full_system_restart();

--- a/src/system_reset.cpp
+++ b/src/system_reset.cpp
@@ -1,0 +1,34 @@
+#include "system_reset.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "esp_system.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "pins.h"
+
+static const char *TAG = "SystemReset";
+
+void full_system_restart() {
+    ESP_LOGI(TAG, "Initiating full system restart...");
+
+    // Configure pins as output
+    gpio_config_t io_conf = {};
+    io_conf.intr_type = GPIO_INTR_DISABLE;
+    io_conf.mode = GPIO_MODE_OUTPUT;
+    io_conf.pin_bit_mask = (1ULL << ETH_POWER_PIN) | (1ULL << HM_RST_PIN);
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+    gpio_config(&io_conf);
+
+    ESP_LOGI(TAG, "Resetting peripherals (ETH: GPIO %d, Radio: GPIO %d)...", ETH_POWER_PIN, HM_RST_PIN);
+
+    // Assert Reset (Active Low)
+    gpio_set_level(ETH_POWER_PIN, 0);
+    gpio_set_level(HM_RST_PIN, 0);
+
+    // Hold reset for 500ms to ensure peripherals are fully reset
+    vTaskDelay(pdMS_TO_TICKS(500));
+
+    ESP_LOGI(TAG, "Peripherals reset complete. Restarting ESP32...");
+    esp_restart();
+}

--- a/src/updatecheck.cpp
+++ b/src/updatecheck.cpp
@@ -29,6 +29,7 @@
 #include "string.h"
 #include "cJSON.h"
 #include "reset_info.h"
+#include "system_reset.h"
 
 static const char *TAG = "UpdateCheck";
 
@@ -227,7 +228,7 @@ void UpdateCheck::performOnlineUpdate()
     if (ret == ESP_OK) {
         ESP_LOGI(TAG, "OTA Update successful, restarting...");
         ResetInfo::storeResetReason(RESET_REASON_FIRMWARE_UPDATE);
-        esp_restart();
+        full_system_restart();
     } else {
         ESP_LOGE(TAG, "OTA Update failed");
         ResetInfo::storeResetReason(RESET_REASON_UPDATE_FAILED);

--- a/src/webui.cpp
+++ b/src/webui.cpp
@@ -36,6 +36,7 @@
 #include "rate_limiter.h"
 #include "security_headers.h"
 #include "reset_info.h"
+#include "system_reset.h"
 #include "esp_http_client.h"
 #include "esp_https_ota.h"
 #include "esp_crt_bundle.h"
@@ -685,7 +686,7 @@ esp_err_t post_restore_handler_func(httpd_req_t *req)
 
     // Restart
     vTaskDelay(1000 / portTICK_PERIOD_MS);
-    esp_restart();
+    full_system_restart();
 
     return ESP_OK;
 }
@@ -711,7 +712,7 @@ httpd_uri_t post_restore_handler = {
 
 void delayed_restart_task(void *pvParameter) {
     vTaskDelay(3000 / portTICK_PERIOD_MS);
-    esp_restart();
+    full_system_restart();
     vTaskDelete(NULL);
 }
 
@@ -906,7 +907,7 @@ esp_err_t post_restart_handler_func(httpd_req_t *req)
 
     // Restart after a short delay to allow response to be sent
     vTaskDelay(1000 / portTICK_PERIOD_MS);
-    esp_restart();
+    full_system_restart();
 
     return ESP_OK;
 }
@@ -938,7 +939,7 @@ esp_err_t post_factory_reset_handler_func(httpd_req_t *req)
 
     // Restart after a short delay to allow response to be sent
     vTaskDelay(1000 / portTICK_PERIOD_MS);
-    esp_restart();
+    full_system_restart();
 
     return ESP_OK;
 }
@@ -1070,7 +1071,7 @@ static esp_err_t post_ota_url_handler_func(httpd_req_t *req)
             free(a->url);
             delete a;
             vTaskDelay(1000 / portTICK_PERIOD_MS);
-            esp_restart();
+            full_system_restart();
         } else {
             ESP_LOGE(TAG, "OTA Update failed: %s", esp_err_to_name(ret));
             ResetInfo::storeResetReason(RESET_REASON_UPDATE_FAILED);


### PR DESCRIPTION
This change improves the reliability of the system restart mechanism. Previously, `esp_restart()` only performed a software reset of the ESP32, which might leave external peripherals like the Ethernet PHY or Radio Module in a hung state if they were the cause of the issue.

The new `full_system_restart()` function:
1.  Configures `ETH_POWER_PIN` (GPIO 13) and `HM_RST_PIN` (GPIO 23) as outputs.
2.  Drives them Low (Active Reset) for 500ms.
3.  Calls `esp_restart()`.

This ensures that the network interface and radio module are hard-reset during a reboot, mimicking a power cycle. This addresses the user report that "connection works faster/better after power cycle than restart".

---
*PR created automatically by Jules for task [15135729924444262786](https://jules.google.com/task/15135729924444262786) started by @Xerolux*