### PR TITLE
fix(udp): stabilize CCU connection handling

### DIFF
--- a/include/rawuartudplistener.h
+++ b/include/rawuartudplistener.h
@@ -44,7 +44,6 @@ private:
     udp_pcb *_pcb;
     QueueHandle_t _udp_queue;
     TaskHandle_t _tHandle = NULL;
-    TaskHandle_t _mDNS_announce_handle = NULL;
 
     void handlePacket(pbuf *pb, ip4_addr_t addr, uint16_t port);
     void sendMessage(unsigned char command, unsigned char *buffer, size_t len);
@@ -61,6 +60,5 @@ public:
     void stop();
 
     void _udpQueueHandler();
-    void _mDNSAnnounceTask();  // Periodic mDNS announcements
     bool _udpReceivePacket(pbuf *pb, const ip_addr_t *addr, uint16_t port);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,9 +180,6 @@ void app_main()
     RawUartUdpListener rawUartUdpLister(&radioModuleConnector);
     rawUartUdpLister.start();
 
-    ESP_LOGI(TAG, "UDP listener started on port 3008");
-    ESP_LOGI(TAG, "CCU 3 should now be able to reconnect. If not, restart CCU software.");
-
     // Initialize log manager early to capture all logs (8KB ring buffer)
     LogManager::begin(8192);
 


### PR DESCRIPTION
- Fix critical bug: portMAX_DELAY in lwIP receive callback could block
  the entire network stack when the UDP queue was full. Changed to
  non-blocking send with drop warning.
- Fix stale state: _connectionStarted was not reset on keep-alive
  timeout, causing frames to be sent into the void after disconnect.
- Fix disconnect ordering: clear _connectionStarted before clearing
  remotePort to prevent race condition window.
- Increase keep-alive timeout from 5s to 10s to prevent false
  disconnects when CCU sends at 5s intervals.
- Send immediate keep-alive response when receiving one from CCU,
  improving the CCU's own connection health detection.
- Increase UDP queue from 32 to 64 entries for better burst handling.
- Reduce queue poll timeout from 100ms to 10ms for lower packet
  processing latency.
- Use else clause to skip keep-alive send after timeout fires.
- Remove mDNS announce task that only logged (saved 2KB stack).

https://claude.ai/code/session_01Jdb2zU3f8FLcLHryf6weUU