### PR TITLE
Add setting to disable update LED blink

### DIFF
--- a/include/settings.h
+++ b/include/settings.h
@@ -59,6 +59,7 @@ private:
   int32_t _ledBrightness;
   bool _checkUpdates;
   bool _allowPrerelease;
+  bool _updateLedBlink;
 
   bool _enableIPv6;
   char _ipv6Mode[10] = {0};
@@ -110,6 +111,9 @@ public:
 
   bool getAllowPrerelease();
   void setAllowPrerelease(bool allowPrerelease);
+
+  bool getUpdateLedBlink();
+  void setUpdateLedBlink(bool enabled);
 
   // IPv6 getters
   bool getEnableIPv6();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -127,6 +127,7 @@ void Settings::load()
 
   GET_BOOL(handle, "checkUpdates", _checkUpdates, true);
   GET_BOOL(handle, "allowPrerelease", _allowPrerelease, false);
+  GET_BOOL(handle, "updateLedBlink", _updateLedBlink, true);
 
   GET_INT(handle, "ledBrightness", _ledBrightness, 100);
 
@@ -184,6 +185,7 @@ void Settings::save()
 
   SET_BOOL(handle, "checkUpdates", _checkUpdates);
   SET_BOOL(handle, "allowPrerelease", _allowPrerelease);
+  SET_BOOL(handle, "updateLedBlink", _updateLedBlink);
 
   SET_INT(handle, "ledBrightness", _ledBrightness);
 
@@ -405,6 +407,16 @@ bool Settings::getAllowPrerelease()
 void Settings::setAllowPrerelease(bool allowPrerelease)
 {
   _allowPrerelease = allowPrerelease;
+}
+
+bool Settings::getUpdateLedBlink()
+{
+  return _updateLedBlink;
+}
+
+void Settings::setUpdateLedBlink(bool enabled)
+{
+  _updateLedBlink = enabled;
 }
 
 // IPv6 Getters

--- a/src/updatecheck.cpp
+++ b/src/updatecheck.cpp
@@ -159,7 +159,11 @@ void UpdateCheck::_taskFunc()
         if (compareVersions(_sysInfo->getCurrentVersion(), _latestVersion) < 0)
         {
           ESP_LOGW(TAG, "An updated firmware with version %s is available!", _latestVersion);
-          _statusLED->setState(LED_STATE_BLINK_SLOW);
+          if (_settings->getUpdateLedBlink()) {
+            _statusLED->setState(LED_STATE_BLINK_SLOW);
+          } else {
+            _statusLED->setState(LED_STATE_OFF);
+          }
         }
         else if (compareVersions(_sysInfo->getCurrentVersion(), _latestVersion) > 0)
         {

--- a/src/webui.cpp
+++ b/src/webui.cpp
@@ -324,6 +324,7 @@ void add_settings(cJSON *root)
     cJSON_AddStringToObject(settings, "ntpServer", _settings->getNtpServer());
 
     cJSON_AddNumberToObject(settings, "ledBrightness", _settings->getLEDBrightness());
+    cJSON_AddBoolToObject(settings, "updateLedBlink", _settings->getUpdateLedBlink());
 
     cJSON_AddBoolToObject(settings, "checkUpdates", _settings->getCheckUpdates());
     cJSON_AddBoolToObject(settings, "allowPrerelease", _settings->getAllowPrerelease());
@@ -448,6 +449,11 @@ esp_err_t post_settings_json_handler_func(httpd_req_t *req)
 
         cJSON *ledBrightnessItem = cJSON_GetObjectItem(root, "ledBrightness");
         int ledBrightness = ledBrightnessItem ? ledBrightnessItem->valueint : _settings->getLEDBrightness();
+
+        cJSON *updateLedBlinkItem = cJSON_GetObjectItem(root, "updateLedBlink");
+        if (updateLedBlinkItem && cJSON_IsBool(updateLedBlinkItem)) {
+            _settings->setUpdateLedBlink(cJSON_IsTrue(updateLedBlinkItem));
+        }
 
         // IPv6
         bool enableIPv6 = cJSON_GetBoolValue(cJSON_GetObjectItem(root, "enableIPv6"));

--- a/webui/src/locales/de.js
+++ b/webui/src/locales/de.js
@@ -104,6 +104,7 @@ export default {
     // System Settings
     systemSettings: 'Systemeinstellungen',
     ledBrightness: 'LED Helligkeit',
+    updateLedBlink: 'LED bei Updates blinken lassen',
     checkUpdates: 'Nach Updates suchen',
     allowPrerelease: 'Frühe Updates erlauben (Beta/Alpha)',
     language: 'Sprache',

--- a/webui/src/locales/en.js
+++ b/webui/src/locales/en.js
@@ -104,6 +104,7 @@ export default {
     // System Settings
     systemSettings: 'System Settings',
     ledBrightness: 'LED Brightness',
+    updateLedBlink: 'Blink LED for updates',
     checkUpdates: 'Check for updates',
     allowPrerelease: 'Allow Early Updates (Beta/Alpha)',
     language: 'Language',

--- a/webui/src/settings.vue
+++ b/webui/src/settings.vue
@@ -78,6 +78,15 @@
                   <span class="brightness-value">{{ ledBrightness }}%</span>
                 </div>
               </div>
+
+              <div class="form-group mt-3">
+                <div class="switch-row">
+                  <label class="switch-label">{{ t('settings.updateLedBlink') }}</label>
+                  <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" v-model="updateLedBlink">
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -475,6 +484,7 @@ const dcfOffset = ref(0)
 const gpsBaudrate = ref(9600)
 const ntpServer = ref('')
 const ledBrightness = ref(100)
+const updateLedBlink = ref(true)
 
 const showSuccess = ref(null)
 const showError = ref(null)
@@ -583,6 +593,7 @@ const loadSettings = () => {
   gpsBaudrate.value = settingsStore.gpsBaudrate
   ntpServer.value = settingsStore.ntpServer
   ledBrightness.value = settingsStore.ledBrightness
+  updateLedBlink.value = settingsStore.updateLedBlink !== undefined ? settingsStore.updateLedBlink : true
 
   // Load IPv6 settings if available
   if (settingsStore.enableIPv6 !== undefined) {
@@ -632,6 +643,7 @@ const saveSettingsClick = async () => {
       gpsBaudrate: gpsBaudrate.value,
       ntpServer: ntpServer.value,
       ledBrightness: ledBrightness.value,
+      updateLedBlink: updateLedBlink.value,
       // IPv6 settings
       enableIPv6: enableIPv6.value,
       ipv6Mode: ipv6Mode.value,

--- a/webui/src/stores.js
+++ b/webui/src/stores.js
@@ -137,6 +137,7 @@ export const useSettingsStore = defineStore('settings', {
     gpsBaudrate: 9600,
     ntpServer: "",
     ledBrightness: 100,
+    updateLedBlink: true,
   }),
   actions: {
     async load() {


### PR DESCRIPTION
Implemented a new feature to toggle the green LED blinking when a firmware update is available. This setting is available in the WebUI under System Settings. The default behavior is enabled (blinking). Disabling it will turn off the LED if it was blinking due to an update.

---
*PR created automatically by Jules for task [5120122469442983935](https://jules.google.com/task/5120122469442983935) started by @Xerolux*