### PR TITLE
Fix firmware update URL format in WebUI

### DIFF
--- a/webui/src/firmwareupdate.vue
+++ b/webui/src/firmwareupdate.vue
@@ -367,7 +367,7 @@ const factoryResetClick = async () => {
 const setGithubUrl = () => {
   const version = sysInfoStore.latestVersion
   if (version && version !== 'n/a') {
-    otaUrl.value = `https://github.com/Xerolux/HB-RF-ETH-ng/releases/download/v${version}/firmware.bin`
+    otaUrl.value = `https://github.com/Xerolux/HB-RF-ETH-ng/releases/download/v${version}/firmware_${version}.bin`
   }
 }
 


### PR DESCRIPTION
Updated `webui/src/firmwareupdate.vue` to use the correct filename format `firmware_${version}.bin` for GitHub release downloads, matching the release artifacts naming convention. This fixes the issue where the download link was incorrect (404).Verified using Playwright with mocked backend response.

---
*PR created automatically by Jules for task [11300825056805144995](https://jules.google.com/task/11300825056805144995) started by @Xerolux*