### PR TITLE
Suppress benign httpd_txrx warnings

### DIFF
--- a/src/webui.cpp
+++ b/src/webui.cpp
@@ -1443,6 +1443,10 @@ void WebUI::start()
     // Initialize rate limiter
     rate_limiter_init();
 
+    // Suppress noisy httpd warnings
+    esp_log_level_set("httpd_txrx", ESP_LOG_ERROR);
+    esp_log_level_set("httpd_uri", ESP_LOG_ERROR);
+
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.lru_purge_enable = true;
     config.max_uri_handlers = 22;


### PR DESCRIPTION
Suppressed noisy `httpd_txrx` and `httpd_uri` warnings by setting their log level to `ESP_LOG_ERROR`. These warnings are typically caused by benign connection resets from client browsers and do not indicate a server issue. This cleans up the logs without hiding actual errors.

---
*PR created automatically by Jules for task [10468831411338400622](https://jules.google.com/task/10468831411338400622) started by @Xerolux*