### PR TITLE
Fix duplicate settings saved notification and update project description

### DIFF
--- a/webui/src/locales/de.js
+++ b/webui/src/locales/de.js
@@ -284,7 +284,7 @@ export default {
     title: 'Über',
     version: 'Version 2.1.6',
     fork: 'Modernisierte Fork',
-    forkDescription: 'Diese Version ist eine modernisierte Fork von Xerolux (2025), basierend auf der originalen HB-RF-ETH Firmware. Aktualisiert auf ESP-IDF 5.3, moderne Toolchains und aktuelle WebUI-Technologien (Vue 3, Vite, Pinia).',
+    forkDescription: 'Diese Version ist eine modernisierte Fork von Xerolux (2025), basierend auf der originalen HB-RF-ETH Firmware. Aktualisiert auf ESP-IDF 5.5.1, moderne Toolchains und aktuelle WebUI-Technologien (Vue 3, Vite, Pinia).',
     original: 'Original-Autor',
     firmwareLicense: 'Die',
     hardwareLicense: 'Die',

--- a/webui/src/locales/en.js
+++ b/webui/src/locales/en.js
@@ -284,7 +284,7 @@ export default {
     title: 'About',
     version: 'Version 2.1.6',
     fork: 'Modernized Fork',
-    forkDescription: 'This version is a modernized fork by Xerolux (2025), based on the original HB-RF-ETH firmware. Updated to ESP-IDF 5.3, modern toolchains and current WebUI technologies (Vue 3, Vite, Pinia).',
+    forkDescription: 'This version is a modernized fork by Xerolux (2025), based on the original HB-RF-ETH firmware. Updated to ESP-IDF 5.5.1, modern toolchains and current WebUI technologies (Vue 3, Vite, Pinia).',
     original: 'Original Author',
     firmwareLicense: 'The',
     hardwareLicense: 'The',

--- a/webui/src/settings.vue
+++ b/webui/src/settings.vue
@@ -341,7 +341,7 @@
 
     <!-- Floating Action Bar for Save -->
     <Transition name="slide-up">
-      <div class="floating-footer" v-if="!showSuccess">
+      <div class="floating-footer">
         <div class="footer-container">
           <BAlert
             variant="danger"
@@ -361,18 +361,6 @@
           >
             {{ t('common.save') }}
           </BButton>
-        </div>
-      </div>
-    </Transition>
-
-    <!-- Success Toast/Overlay -->
-    <Transition name="fade">
-      <div v-if="showSuccess" class="success-overlay">
-        <div class="success-card">
-          <div class="success-icon">✓</div>
-          <h3>{{ t('common.success') }}</h3>
-          <p>{{ t('settings.saveSuccess') }}</p>
-          <BButton variant="outline-primary" @click="showSuccess = false">OK</BButton>
         </div>
       </div>
     </Transition>
@@ -486,7 +474,6 @@ const ntpServer = ref('')
 const ledBrightness = ref(100)
 const updateLedBlink = ref(true)
 
-const showSuccess = ref(null)
 const showError = ref(null)
 const showRestartModal = ref(false)
 const isRestarting = ref(false)
@@ -627,7 +614,6 @@ const saveSettingsClick = async () => {
   if (v$.value.$error) return
 
   showError.value = false
-  showSuccess.value = false
 
   try {
     const settings = {
@@ -656,12 +642,7 @@ const saveSettingsClick = async () => {
     }
 
     await settingsStore.save(settings)
-    showSuccess.value = true
-
-    // Show restart modal after a short delay
-    setTimeout(() => {
-      showRestartModal.value = true
-    }, 1000)
+    showRestartModal.value = true
   } catch (error) {
     showError.value = true
   }


### PR DESCRIPTION
*   Updated `webui/src/locales/de.js` and `webui/src/locales/en.js` with the corrected project description (Xerolux 2025, ESP-IDF 5.5.1).
*   Removed the redundant "Settings saved successfully" overlay in `webui/src/settings.vue` to prevent it from appearing before the "Restart Required" modal, resolving the "notification appears twice" issue.
*   Directly trigger the "Restart Required" modal after settings are saved successfully.

---
*PR created automatically by Jules for task [18118100980245511402](https://jules.google.com/task/18118100980245511402) started by @Xerolux*