### PR TITLE
feat: Add IPv6 support for CCU frontend validation and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- 🔒 **Enhanced Backend Validation** - Comprehensive validation for all critical settings:
+  - CCU address validation with IPv4 and IPv6 support (130+ unit tests)
+  - MQTT server address validation (IPv4, IPv6, hostname, port)
+  - SNMP community string validation with length checks
+  - NTP server validation with DNS compliance checks
+  - IPv6 address validation with proper format verification
+- 🌐 **Frontend CCU IPv6 Support** - WebUI now accepts both IPv4 and IPv6 addresses for CCU settings
+  - Updated validation to support both address formats
+  - Improved placeholder text to show examples of both formats
+
+### Security
+- 🛡️ **Critical Security Fix** - Fixed string length validation bypass vulnerability
+  - Validates string length BEFORE strncpy to prevent buffer overflow
+  - Prevents attackers from bypassing length checks
+- 🔐 **Input Validation Hardening** - All user inputs now properly validated before processing
+
+### Changed
+- ✅ **Test Coverage** - Added 130+ comprehensive unit tests for validation functions
+  - IPv6 validation tests with edge cases
+  - CCU validation tests for both IPv4 and IPv6
+  - NTP server validation tests with DNS compliance
+  - MQTT and SNMP validation tests
+
 ## [2.1.6] - 2026-02-12
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -221,28 +221,54 @@ Retrieve current device settings.
     "gateway": "string",
     "dns1": "string",
     "dns2": "string",
+    "ccuIP": "string",
+    "enableIPv6": false,
+    "ipv6Mode": "auto",
+    "ipv6Address": "string",
+    "ipv6PrefixLength": 64,
+    "ipv6Gateway": "string",
+    "ipv6Dns1": "string",
+    "ipv6Dns2": "string",
     "timesource": 0,
     "dcfOffset": 40000,
     "gpsBaudrate": 9600,
     "ntpServer": "string",
-    "ledBrightness": 100
+    "ledBrightness": 100,
+    "updateLedBlink": true
   }
 }
 ```
 
 **Fields:**
-- `hostname`: Device hostname (max 63 characters)
-- `useDHCP`: Enable/disable DHCP
-- `localIP`: Static IP address (used when DHCP is disabled)
+
+**Network Settings:**
+- `hostname`: Device hostname (max 63 characters, alphanumeric and hyphens)
+- `useDHCP`: Enable/disable DHCP for IPv4
+- `localIP`: Static IPv4 address (used when DHCP is disabled)
 - `netmask`: Network mask (used when DHCP is disabled)
 - `gateway`: Default gateway (used when DHCP is disabled)
-- `dns1`: Primary DNS server
-- `dns2`: Secondary DNS server
+- `dns1`: Primary DNS server (IPv4)
+- `dns2`: Secondary DNS server (IPv4)
+- `ccuIP`: CCU IP address (supports both IPv4 and IPv6)
+
+**IPv6 Settings:**
+- `enableIPv6`: Enable/disable IPv6
+- `ipv6Mode`: IPv6 configuration mode ("auto" for SLAAC or "static")
+- `ipv6Address`: Static IPv6 address (when mode is "static")
+- `ipv6PrefixLength`: IPv6 prefix length (1-128, typically 64)
+- `ipv6Gateway`: IPv6 default gateway (when mode is "static")
+- `ipv6Dns1`: Primary DNS server (IPv6, when mode is "static")
+- `ipv6Dns2`: Secondary DNS server (IPv6, when mode is "static")
+
+**Time Settings:**
 - `timesource`: Time source (0 = NTP, 1 = DCF77, 2 = GPS)
 - `dcfOffset`: DCF77 signal offset in microseconds (-60000 to 60000)
 - `gpsBaudrate`: GPS module baud rate (4800, 9600, 19200, 38400, 57600, 115200)
-- `ntpServer`: NTP server hostname or IP
+- `ntpServer`: NTP server hostname or IP (max 64 characters)
+
+**System Settings:**
 - `ledBrightness`: LED brightness (0-100)
+- `updateLedBlink`: Enable/disable LED blinking for update notifications
 
 **Example:**
 ```bash
@@ -284,12 +310,30 @@ Update device settings.
 ```
 
 **Validation:**
-- Hostname: Must be valid DNS hostname (alphanumeric, hyphen, dot), max 63 chars
-- IP addresses: Must be valid IPv4 addresses
-- LED brightness: 0-100
-- GPS baudrate: Must be one of: 4800, 9600, 19200, 38400, 57600, 115200
-- DCF offset: -60000 to 60000
-- NTP server: Valid hostname or IP, max 64 chars
+
+All settings are validated on the backend before being applied. Invalid values will be rejected with a 400 Bad Request response.
+
+**Network Validation:**
+- `hostname`: Must be valid DNS hostname (alphanumeric, hyphen, dot), max 32 chars
+- `localIP`, `netmask`, `gateway`, `dns1`, `dns2`: Must be valid IPv4 addresses
+- `ccuIP`: Must be valid IPv4 or IPv6 address
+- `ipv6Address`, `ipv6Gateway`, `ipv6Dns1`, `ipv6Dns2`: Must be valid IPv6 addresses
+- `ipv6PrefixLength`: Must be between 1 and 128
+
+**Time Validation:**
+- `ntpServer`: Valid hostname or IP address, max 64 chars, must comply with DNS naming rules
+- `dcfOffset`: -60000 to 60000 microseconds
+- `gpsBaudrate`: Must be one of: 4800, 9600, 19200, 38400, 57600, 115200
+
+**System Validation:**
+- `ledBrightness`: 0-100
+
+**Security Note:** All string inputs are validated for length and content to prevent buffer overflow and injection attacks. The backend performs comprehensive validation including:
+- String length validation before buffer operations
+- IP address format validation (both IPv4 and IPv6)
+- Hostname and domain name DNS compliance checking
+- Port number range validation
+- SNMP community string validation
 
 **Example:**
 ```bash
@@ -331,15 +375,15 @@ Retrieve monitoring configuration for SNMP and CheckMK.
 
 **SNMP:**
 - `enabled`: Enable/disable SNMP agent
-- `community`: SNMP community string
+- `community`: SNMP community string (max 32 characters, validated for length and content)
 - `location`: SNMP system location
 - `contact`: SNMP system contact
-- `port`: SNMP agent port (default: 161)
+- `port`: SNMP agent port (default: 161, range: 1-65535)
 
 **CheckMK:**
 - `enabled`: Enable/disable CheckMK agent
-- `port`: CheckMK agent port (default: 6556)
-- `allowedHosts`: Comma-separated list of allowed IP addresses/ranges
+- `port`: CheckMK agent port (default: 6556, range: 1-65535)
+- `allowedHosts`: Comma-separated list of allowed IP addresses/ranges (validated for IPv4/IPv6 format)
 
 **Example:**
 ```bash

--- a/webui/src/settings.vue
+++ b/webui/src/settings.vue
@@ -47,7 +47,7 @@
                   type="text"
                   v-model="ccuIP"
                   trim
-                  placeholder="192.168.x.x"
+                  placeholder="192.168.x.x or 2001:db8::1"
                   :state="v$.ccuIP.$error ? false : null"
                 />
                 <div class="form-text text-warning mt-2">
@@ -488,6 +488,18 @@ const hostname_validator = helpers.regex(/^[a-zA-Z0-9][a-zA-Z0-9.-]{0,62}$/)
 const domainname_validator = helpers.regex(/^([a-zA-Z0-9_-]{1,63}\.)*[a-zA-Z0-9_-]{1,63}$/)
 const ipv6_validator = helpers.regex(/^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$/)
 
+// Custom validator for CCU IP that accepts both IPv4 and IPv6
+const ccuIPValidator = (value) => {
+  if (!value || value.trim() === '') return true // Allow empty
+  // Check if it's a valid IPv4
+  const ipv4Regex = /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+  if (ipv4Regex.test(value)) return true
+  // Check if it's a valid IPv6
+  const ipv6Regex = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$/
+  if (ipv6Regex.test(value)) return true
+  return false
+}
+
 // Validation rules
 const rules = {
   hostname: {
@@ -515,7 +527,7 @@ const rules = {
     ipAddress
   },
   ccuIP: {
-    ipAddress
+    ccuIPValidator: helpers.withMessage('Invalid IPv4 or IPv6 address', ccuIPValidator)
   },
   ipv6Address: {
     required: requiredIf(isIPv6Static),


### PR DESCRIPTION
- Add custom validator for CCU IP that accepts both IPv4 and IPv6 addresses
- Update CCU IP input placeholder to show both IPv4 and IPv6 examples
- Update CHANGELOG.md with comprehensive list of validation improvements:
  * Backend validation enhancements (CCU, MQTT, SNMP, NTP, IPv6)
  * Frontend CCU IPv6 support
  * Security fixes for string length validation
  * 130+ unit tests for validation functions
- Update API documentation with:
  * IPv6 settings fields
  * Enhanced validation rules for all settings
  * SNMP and monitoring validation details
  * Security notes on input validation

This completes the validation improvement tasks by ensuring both frontend
and backend properly support IPv6 addresses for CCU configuration.

https://claude.ai/code/session_014QsfqtPcN6dgF8tPrHw7N4