### PR TITLE
Fix settings save behavior and ensure global initialization

### DIFF
--- a/webui/src/header.vue
+++ b/webui/src/header.vue
@@ -237,7 +237,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { useLoginStore, useThemeStore, useUpdateStore, useSysInfoStore } from './stores.js'
+import { useLoginStore, useThemeStore, useUpdateStore, useSysInfoStore, useSettingsStore } from './stores.js'
 import { availableLocales } from './locales/index.js'
 
 const { t, locale } = useI18n()
@@ -247,6 +247,7 @@ const loginStore = useLoginStore()
 const themeStore = useThemeStore()
 const updateStore = useUpdateStore()
 const sysInfoStore = useSysInfoStore()
+const settingsStore = useSettingsStore()
 
 const showBanner = ref(true)
 const dismissedVersion = ref(localStorage.getItem('dismissedUpdate'))
@@ -312,6 +313,13 @@ onMounted(async () => {
   // Check if banner was dismissed
   if (dismissedVersion.value === updateStore.latestVersion) {
     showBanner.value = false
+  }
+
+  // Load settings
+  try {
+    await settingsStore.load()
+  } catch (e) {
+    console.error('Failed to load settings', e)
   }
 
   // Get current version from sysInfo

--- a/webui/src/stores.js
+++ b/webui/src/stores.js
@@ -151,8 +151,8 @@ export const useSettingsStore = defineStore('settings', {
     },
     async save(settings) {
       try {
-        const response = await axios.post("/settings.json", settings)
-        Object.assign(this.$state, response.data.settings)
+        await axios.post("/settings.json", settings)
+        Object.assign(this.$state, settings)
       } catch (error) {
         console.error('Failed to save settings:', error.response?.status || error.message)
         throw error


### PR DESCRIPTION
Fixed an issue where saving settings would clear the local store state because the backend response does not include the settings object. The store now optimistically updates with the payload sent to the backend.
Also ensured that `useSettingsStore` is initialized and loaded in `header.vue`, guaranteeing that settings are loaded when the application starts.
Verified that `settings.vue` correctly binds and sends all settings fields.


---
*PR created automatically by Jules for task [18184805781162808288](https://jules.google.com/task/18184805781162808288) started by @Xerolux*