### PR TITLE
i18n: add missing updateLedBlink translation key to 8 locale files

### DIFF
--- a/webui/src/locales/cs.js
+++ b/webui/src/locales/cs.js
@@ -104,6 +104,7 @@ export default {
     // System Settings
     systemSettings: 'Nastavení systému',
     ledBrightness: 'Jas LED',
+    updateLedBlink: 'Blikat LED při aktualizacích',
     checkUpdates: 'Zkontrolovat aktualizace',
     allowPrerelease: 'Povolit dřívější aktualizace (Beta/Alpha)',
     language: 'Jazyk',

--- a/webui/src/locales/es.js
+++ b/webui/src/locales/es.js
@@ -104,6 +104,7 @@ export default {
     // System Settings
     systemSettings: 'Configuración del sistema',
     ledBrightness: 'Brillo del LED',
+    updateLedBlink: 'Parpadear LED en actualizaciones',
     checkUpdates: 'Buscar actualizaciones',
     allowPrerelease: 'Permitir actualizaciones tempranas (Beta/Alpha)',
     language: 'Idioma',

--- a/webui/src/locales/fr.js
+++ b/webui/src/locales/fr.js
@@ -104,6 +104,7 @@ export default {
     // System Settings
     systemSettings: 'Paramètres système',
     ledBrightness: 'Luminosité LED',
+    updateLedBlink: 'LED clignotante lors des mises à jour',
     checkUpdates: 'Vérifier les mises à jour',
     allowPrerelease: 'Autoriser les mises à jour anticipées (Beta/Alpha)',
     language: 'Langue',

--- a/webui/src/locales/it.js
+++ b/webui/src/locales/it.js
@@ -104,6 +104,7 @@ export default {
     // System Settings
     systemSettings: 'Impostazioni di Sistema',
     ledBrightness: 'Luminosità LED',
+    updateLedBlink: 'LED lampeggiante per aggiornamenti',
     checkUpdates: 'Controlla aggiornamenti',
     allowPrerelease: 'Consenti aggiornamenti anticipati (Beta/Alpha)',
     language: 'Lingua',

--- a/webui/src/locales/nl.js
+++ b/webui/src/locales/nl.js
@@ -104,6 +104,7 @@ export default {
     // System Settings
     systemSettings: 'Systeeminstellingen',
     ledBrightness: 'LED Helderheid',
+    updateLedBlink: 'LED knipperen bij updates',
     checkUpdates: 'Controleren op updates',
     allowPrerelease: 'Vroege updates toestaan (Beta/Alpha)',
     language: 'Taal',

--- a/webui/src/locales/no.js
+++ b/webui/src/locales/no.js
@@ -104,6 +104,7 @@ export default {
     // System Settings
     systemSettings: 'Systeminnstillinger',
     ledBrightness: 'LED-lysstyrke',
+    updateLedBlink: 'Blink LED for oppdateringer',
     checkUpdates: 'Se etter oppdateringer',
     allowPrerelease: 'Tillat tidlige oppdateringer (Beta/Alpha)',
     language: 'Språk',

--- a/webui/src/locales/pl.js
+++ b/webui/src/locales/pl.js
@@ -104,6 +104,7 @@ export default {
     // System Settings
     systemSettings: 'Ustawienia systemu',
     ledBrightness: 'Jasność LED',
+    updateLedBlink: 'Migaj LED podczas aktualizacji',
     checkUpdates: 'Sprawdź aktualizacje',
     allowPrerelease: 'Zezwalaj na wczesne aktualizacje (Beta/Alpha)',
     language: 'Język',

--- a/webui/src/locales/sv.js
+++ b/webui/src/locales/sv.js
@@ -104,6 +104,7 @@ export default {
     // System Settings
     systemSettings: 'Systeminställningar',
     ledBrightness: 'LED Ljusstyrka',
+    updateLedBlink: 'Blinka LED vid uppdateringar',
     checkUpdates: 'Sök efter uppdateringar',
     allowPrerelease: 'Tillåt tidiga uppdateringar (Beta/Alpha)',
     language: 'Språk',


### PR DESCRIPTION
The updateLedBlink key ('Blink LED for updates') was present in English
and German locales but missing from cs, es, fr, it, nl, no, pl, and sv.
This caused a fallback to the key name in those languages' UIs.

https://claude.ai/code/session_018VvheSKGwp4Be2hnQgMZcL