### PR TITLE
fix: correct four bugs found in GPS, IPv6 validation, OTA, and CPU task

### DIFF
--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -130,7 +130,7 @@ bool parseRMCTime(unsigned char *buffer, uint16_t len, timeval *tv)
                 time.tm_min = ((buffer[fieldStart + 2] - '0') * 10) + (buffer[fieldStart + 3] - '0');
                 time.tm_hour = ((buffer[fieldStart + 0] - '0') * 10) + (buffer[fieldStart + 1] - '0');
 
-                tv->tv_usec = ((buffer[fieldStart + 4] - '7') * 100000) + ((buffer[fieldStart + 8] - '0') * 10000);
+                tv->tv_usec = ((buffer[fieldStart + 7] - '0') * 100000) + ((buffer[fieldStart + 8] - '0') * 10000);
             }
             else if (fieldIndex == 9)
             {

--- a/src/sysinfo.cpp
+++ b/src/sysinfo.cpp
@@ -52,11 +52,7 @@ static const UBaseType_t MAX_TASKS = 32;
 
 void updateCPUUsageTask(void *arg)
 {
-    TaskStatus_t *taskStatus = (TaskStatus_t *)malloc(MAX_TASKS * sizeof(TaskStatus_t));
-    if (!taskStatus) {
-        vTaskDelete(NULL);
-        return;
-    }
+    static TaskStatus_t taskStatus[MAX_TASKS];
 
     TaskHandle_t idle0Task = xTaskGetIdleTaskHandleForCore(0);
     TaskHandle_t idle1Task = xTaskGetIdleTaskHandleForCore(1);

--- a/src/updatecheck.cpp
+++ b/src/updatecheck.cpp
@@ -205,6 +205,7 @@ void UpdateCheck::performOnlineUpdate()
     config.url = url;
     config.crt_bundle_attach = esp_crt_bundle_attach;
     config.keep_alive_enable = true;
+    config.timeout_ms = 60000; // 60-second timeout to prevent indefinite stall
 
     esp_https_ota_config_t ota_config = {};
     ota_config.http_config = &config;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -637,9 +637,15 @@ bool validateIPv6Address(const char *ipv6)
                 ESP_LOGW(TAG, "Invalid IPv6: segment too long (%d hex digits)", segmentLen);
                 return false;
             }
-            if (segmentLen > 0 || i == 0)  // Allow empty segment only at start after ::
+            if (segmentLen > 0)
             {
                 segmentCount++;
+            }
+            else
+            {
+                // A single colon with no preceding hex digits is invalid (e.g. ":1::1" or ":::")
+                ESP_LOGW(TAG, "Invalid IPv6: empty segment without double colon");
+                return false;
             }
             segmentLen = 0;
         }


### PR DESCRIPTION
- gps.cpp:133: Fix GPS sub-second timestamp calculation. The NMEA RMC
  time field is HHMMSS.ss, so tenths-of-seconds are at offset 7, not 4.
  Also fix the baseline character from '7' to '0', which caused large
  negative (i.e. invalid) tv_usec values for most GPS timestamps.

- validation.cpp:640: Remove erroneous `|| i == 0` from the IPv6 segment
  counter condition. A single colon at position 0 is not a valid IPv6
  segment delimiter; the previous code accepted addresses like
  `:1:2:3:4:5:6:7` as valid by silently counting a phantom empty segment.
  Now an empty segment encountered with a plain colon returns false.

- updatecheck.cpp: Add a 60-second timeout to the OTA HTTP client config.
  Without a timeout the device could block indefinitely if the download
  server stalls or becomes unresponsive.

- sysinfo.cpp:55: Replace heap-allocated TaskStatus_t array with a static
  array in updateCPUUsageTask. The malloc'd buffer was never freed because
  the task is an infinite loop, creating a permanent heap leak on every
  boot.

https://claude.ai/code/session_01RZ7ZBcmy5nJYsLu9TsqXYP