### PR TITLE
Implement Configurable LED Programs and Remove Duplicate Toggle

### DIFF
--- a/include/settings.h
+++ b/include/settings.h
@@ -57,7 +57,7 @@ private:
   char _ntpServer[65] = {0};
 
   int32_t _ledBrightness;
-  bool _updateLedBlink;
+  int32_t _ledPrograms[7];
 
   bool _enableIPv6;
   char _ipv6Mode[10] = {0};
@@ -104,8 +104,8 @@ public:
   int getLEDBrightness();
   void setLEDBrightness(int brightness);
 
-  bool getUpdateLedBlink();
-  void setUpdateLedBlink(bool enabled);
+  int getLedProgram(int program);
+  void setLedProgram(int program, int state);
 
   // IPv6 getters
   bool getEnableIPv6();

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -74,6 +74,11 @@ void LED::start(Settings *settings)
 
     _highDuty = settings->getLEDBrightness() * (1 << ledc_timer.duty_resolution) / 100;
 
+    // Apply LED programs from settings
+    for (int i = 0; i < 7; i++) {
+        setProgram((led_program_t)i, (led_state_t)settings->getLedProgram(i));
+    }
+
     ledc_timer_config(&ledc_timer);
 
     if (!_switchTaskHandle)

--- a/src/updatecheck.cpp
+++ b/src/updatecheck.cpp
@@ -157,11 +157,7 @@ void UpdateCheck::_taskFunc()
       if (compareVersions(_sysInfo->getCurrentVersion(), _latestVersion) < 0)
       {
         ESP_LOGW(TAG, "An updated firmware with version %s is available!", _latestVersion);
-        if (_settings->getUpdateLedBlink()) {
-          _statusLED->setState(LED_STATE_BLINK_SLOW);
-        } else {
-          _statusLED->setState(LED_STATE_OFF);
-        }
+        _statusLED->setState(LED::getProgram(LED_PROG_UPDATE_AVAILABLE));
       }
       else if (compareVersions(_sysInfo->getCurrentVersion(), _latestVersion) > 0)
       {

--- a/src/webui.cpp
+++ b/src/webui.cpp
@@ -324,7 +324,15 @@ void add_settings(cJSON *root)
     cJSON_AddStringToObject(settings, "ntpServer", _settings->getNtpServer());
 
     cJSON_AddNumberToObject(settings, "ledBrightness", _settings->getLEDBrightness());
-    cJSON_AddBoolToObject(settings, "updateLedBlink", _settings->getUpdateLedBlink());
+
+    cJSON *ledPrograms = cJSON_AddObjectToObject(settings, "ledPrograms");
+    cJSON_AddNumberToObject(ledPrograms, "idle", _settings->getLedProgram(LED_PROG_IDLE));
+    cJSON_AddNumberToObject(ledPrograms, "ccu_disconnected", _settings->getLedProgram(LED_PROG_CCU_DISCONNECTED));
+    cJSON_AddNumberToObject(ledPrograms, "ccu_connected", _settings->getLedProgram(LED_PROG_CCU_CONNECTED));
+    cJSON_AddNumberToObject(ledPrograms, "update_available", _settings->getLedProgram(LED_PROG_UPDATE_AVAILABLE));
+    cJSON_AddNumberToObject(ledPrograms, "error", _settings->getLedProgram(LED_PROG_ERROR));
+    cJSON_AddNumberToObject(ledPrograms, "booting", _settings->getLedProgram(LED_PROG_BOOTING));
+    cJSON_AddNumberToObject(ledPrograms, "update_in_progress", _settings->getLedProgram(LED_PROG_UPDATE_IN_PROGRESS));
 
     // IPv6 Settings
     cJSON_AddBoolToObject(settings, "enableIPv6", _settings->getEnableIPv6());
@@ -456,9 +464,23 @@ esp_err_t post_settings_json_handler_func(httpd_req_t *req)
     cJSON *ledBrightnessItem = cJSON_GetObjectItem(root, "ledBrightness");
     int ledBrightness = ledBrightnessItem ? ledBrightnessItem->valueint : _settings->getLEDBrightness();
 
-    cJSON *updateLedBlinkItem = cJSON_GetObjectItem(root, "updateLedBlink");
-    if (updateLedBlinkItem && cJSON_IsBool(updateLedBlinkItem)) {
-        _settings->setUpdateLedBlink(cJSON_IsTrue(updateLedBlinkItem));
+    cJSON *ledPrograms = cJSON_GetObjectItem(root, "ledPrograms");
+    if (ledPrograms) {
+        cJSON *item;
+        item = cJSON_GetObjectItem(ledPrograms, "idle");
+        if (item) _settings->setLedProgram(LED_PROG_IDLE, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "ccu_disconnected");
+        if (item) _settings->setLedProgram(LED_PROG_CCU_DISCONNECTED, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "ccu_connected");
+        if (item) _settings->setLedProgram(LED_PROG_CCU_CONNECTED, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "update_available");
+        if (item) _settings->setLedProgram(LED_PROG_UPDATE_AVAILABLE, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "error");
+        if (item) _settings->setLedProgram(LED_PROG_ERROR, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "booting");
+        if (item) _settings->setLedProgram(LED_PROG_BOOTING, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "update_in_progress");
+        if (item) _settings->setLedProgram(LED_PROG_UPDATE_IN_PROGRESS, item->valueint);
     }
 
     // IPv6
@@ -635,6 +657,25 @@ esp_err_t post_restore_handler_func(httpd_req_t *req)
     cJSON *ledBrightnessItem = cJSON_GetObjectItem(root, "ledBrightness");
     int ledBrightness = ledBrightnessItem ? ledBrightnessItem->valueint : _settings->getLEDBrightness();
 
+    cJSON *ledPrograms = cJSON_GetObjectItem(root, "ledPrograms");
+    if (ledPrograms) {
+        cJSON *item;
+        item = cJSON_GetObjectItem(ledPrograms, "idle");
+        if (item) _settings->setLedProgram(LED_PROG_IDLE, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "ccu_disconnected");
+        if (item) _settings->setLedProgram(LED_PROG_CCU_DISCONNECTED, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "ccu_connected");
+        if (item) _settings->setLedProgram(LED_PROG_CCU_CONNECTED, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "update_available");
+        if (item) _settings->setLedProgram(LED_PROG_UPDATE_AVAILABLE, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "error");
+        if (item) _settings->setLedProgram(LED_PROG_ERROR, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "booting");
+        if (item) _settings->setLedProgram(LED_PROG_BOOTING, item->valueint);
+        item = cJSON_GetObjectItem(ledPrograms, "update_in_progress");
+        if (item) _settings->setLedProgram(LED_PROG_UPDATE_IN_PROGRESS, item->valueint);
+    }
+
     // IPv6
     bool enableIPv6 = cJSON_GetBoolValue(cJSON_GetObjectItem(root, "enableIPv6"));
     char *ipv6Mode = cJSON_GetStringValue(cJSON_GetObjectItem(root, "ipv6Mode"));
@@ -658,11 +699,6 @@ esp_err_t post_restore_handler_func(httpd_req_t *req)
         _settings->setNtpServer(ntpServer);
     }
     _settings->setLEDBrightness(ledBrightness);
-
-    cJSON *updateLedBlinkItem = cJSON_GetObjectItem(root, "updateLedBlink");
-    if (updateLedBlinkItem && cJSON_IsBool(updateLedBlinkItem)) {
-        _settings->setUpdateLedBlink(cJSON_IsTrue(updateLedBlinkItem));
-    }
 
     if (ipv6Mode) {
          _settings->setIPv6Settings(

--- a/webui/src/locales/de.js
+++ b/webui/src/locales/de.js
@@ -104,7 +104,8 @@ export default {
     // System Settings
     systemSettings: 'Systemeinstellungen',
     ledBrightness: 'LED Helligkeit',
-    updateLedBlink: 'LED bei Updates blinken lassen',
+    ledPrograms: 'LED Programme',
+    ledProgramsHelp: 'Passen Sie das LED-Verhalten für verschiedene Systemzustände an.',
     checkUpdates: 'Nach Updates suchen',
     allowPrerelease: 'Frühe Updates erlauben (Beta/Alpha)',
     language: 'Sprache',

--- a/webui/src/locales/en.js
+++ b/webui/src/locales/en.js
@@ -104,7 +104,8 @@ export default {
     // System Settings
     systemSettings: 'System Settings',
     ledBrightness: 'LED Brightness',
-    updateLedBlink: 'Blink LED for updates',
+    ledPrograms: 'LED Programs',
+    ledProgramsHelp: 'Customize the LED behavior for different system states.',
     checkUpdates: 'Check for updates',
     allowPrerelease: 'Allow Early Updates (Beta/Alpha)',
     language: 'Language',

--- a/webui/src/settings.vue
+++ b/webui/src/settings.vue
@@ -79,15 +79,6 @@
                 </div>
               </div>
 
-              <div class="form-group mt-3">
-                <div class="switch-row">
-                  <label class="switch-label">{{ t('settings.updateLedBlink') }}</label>
-                  <div class="form-check form-switch">
-                    <input class="form-check-input" type="checkbox" v-model="updateLedBlink">
-                  </div>
-                </div>
-              </div>
-
               <div class="form-group mt-4">
                 <label class="form-label fw-bold">{{ t('settings.ledPrograms') }}</label>
                 <div class="led-programs-grid">
@@ -490,7 +481,6 @@ const dcfOffset = ref(0)
 const gpsBaudrate = ref(9600)
 const ntpServer = ref('')
 const ledBrightness = ref(100)
-const updateLedBlink = ref(true)
 
 // LED Programs
 const ledPrograms = ref([
@@ -654,7 +644,6 @@ const loadSettings = () => {
   gpsBaudrate.value = settingsStore.gpsBaudrate
   ntpServer.value = settingsStore.ntpServer
   ledBrightness.value = settingsStore.ledBrightness
-  updateLedBlink.value = settingsStore.updateLedBlink !== undefined ? settingsStore.updateLedBlink : true
 
   // Load LED programs if available
   if (settingsStore.ledPrograms !== undefined) {
@@ -708,7 +697,6 @@ const saveSettingsClick = async () => {
       gpsBaudrate: gpsBaudrate.value,
       ntpServer: ntpServer.value,
       ledBrightness: ledBrightness.value,
-      updateLedBlink: updateLedBlink.value,
       // LED Programs
       ledPrograms: ledProgramValues.value,
       // IPv6 settings

--- a/webui/src/stores.js
+++ b/webui/src/stores.js
@@ -137,7 +137,6 @@ export const useSettingsStore = defineStore('settings', {
     gpsBaudrate: 9600,
     ntpServer: "",
     ledBrightness: 100,
-    updateLedBlink: true,
   }),
   actions: {
     async load() {


### PR DESCRIPTION
This change removes the duplicate "Blink LED on Update" toggle and consolidates LED configuration into a single "LED Programs" section. It ensures that all LED program states (Idle, Update Available, Error, etc.) are correctly saved to NVS and restored on boot. Legacy settings are migrated to preserve user preferences.

---
*PR created automatically by Jules for task [14146843738128276736](https://jules.google.com/task/14146843738128276736) started by @Xerolux*