### PR TITLE
Fix release workflow failure when tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,14 @@ jobs:
             echo "Committed version changes"
           fi
           
+          if git rev-parse "$VERSION_TAG" >/dev/null 2>&1; then
+            echo "Tag $VERSION_TAG already exists locally. Deleting..."
+            git tag -d "$VERSION_TAG"
+          fi
+
           git tag -a "$VERSION_TAG" -m "Release $VERSION_TAG"
           git push origin HEAD:main
-          git push origin "$VERSION_TAG"
+          git push -f origin "$VERSION_TAG"
           echo "Created and pushed tag $VERSION_TAG"
 
       - name: Setup Node.js


### PR DESCRIPTION
Modified `.github/workflows/release.yml` to handle existing tags gracefully. It now deletes the local tag if it exists and force-pushes the new tag to the remote repository. This resolves the issue where re-releasing a version would fail due to the tag already existing.

---
*PR created automatically by Jules for task [12025238405344536935](https://jules.google.com/task/12025238405344536935) started by @Xerolux*