### PR TITLE
fix: suppress spurious IPv6 warnings for hostname server addresses

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -387,7 +387,10 @@ bool validateServerAddress(const char *server, size_t maxLength)
     }
 
     // Check if host is a valid IPv6 address (without brackets)
-    if (validateIPv6Address(host))
+    // Only attempt IPv6 validation if host contains a colon; bare IPv6 always
+    // has at least one colon, so this avoids spurious "invalid character" warnings
+    // when the host is a plain hostname (e.g. pool.ntp.org).
+    if (strchr(host, ':') != NULL && validateIPv6Address(host))
     {
         return true;
     }


### PR DESCRIPTION
In validateServerAddress(), calling validateIPv6Address() unconditionally caused misleading "Invalid IPv6: invalid character 'p'" warnings whenever a plain hostname (e.g. pool.ntp.org) was validated. Since all bare IPv6 addresses must contain at least one colon, guard the call with a strchr() check to skip IPv6 validation for colon-free strings.

This mirrors the existing guard already present in validateCcuAddress().

https://claude.ai/code/session_01S5x3Rw6WF46RpqUsNkyPMY