### PR TITLE
fix: LED-Programme werden korrekt gespeichert und geladen

### DIFF
--- a/webui/src/settings.vue
+++ b/webui/src/settings.vue
@@ -374,6 +374,16 @@
       </div>
     </Transition>
 
+    <!-- Save Success Overlay -->
+    <Transition name="fade">
+      <div v-if="showSaveSuccess" class="success-overlay" @click="showSaveSuccess = false">
+        <div class="success-card">
+          <div class="success-icon">✓</div>
+          <h3>{{ t('settings.saveSuccess') }}</h3>
+        </div>
+      </div>
+    </Transition>
+
     <!-- Password Change Modal -->
     <PasswordChangeModal v-model="showPasswordModal" :force-redirect="false" />
 
@@ -526,6 +536,7 @@ const setLedProgramValue = (programId, value) => {
 }
 
 const showError = ref(null)  // Can be null or a string with error message
+const showSaveSuccess = ref(false)
 const showRestartModal = ref(false)
 const isRestarting = ref(false)
 
@@ -647,7 +658,7 @@ const loadSettings = () => {
 
   // Load LED programs if available
   if (settingsStore.ledPrograms !== undefined) {
-    ledProgramValues.value = settingsStore.ledPrograms
+    ledProgramValues.value = { ...settingsStore.ledPrograms }
   }
 
   // Load IPv6 settings if available
@@ -680,7 +691,7 @@ const saveSettingsClick = async () => {
   v$.value.$touch()
   if (v$.value.$error) return
 
-  showError.value = false
+  showError.value = null
 
   try {
     const settings = {
@@ -710,10 +721,16 @@ const saveSettingsClick = async () => {
     }
 
     await settingsStore.save(settings)
-    showRestartModal.value = true
+
+    // Show success popup and auto-dismiss after 2.5 seconds
+    showSaveSuccess.value = true
+    setTimeout(() => {
+      showSaveSuccess.value = false
+      showRestartModal.value = true
+    }, 2500)
   } catch (error) {
     // Extract specific error message from backend response
-    const errorMsg = error.response?.data || error.response?.data?.error || t('settings.saveError')
+    const errorMsg = error.response?.data?.error || error.response?.data || t('settings.saveError')
     showError.value = errorMsg
   }
 }

--- a/webui/src/stores.js
+++ b/webui/src/stores.js
@@ -137,6 +137,15 @@ export const useSettingsStore = defineStore('settings', {
     gpsBaudrate: 9600,
     ntpServer: "",
     ledBrightness: 100,
+    ledPrograms: {
+      idle: 1,
+      ccu_disconnected: 5,
+      ccu_connected: 6,
+      update_available: 4,
+      error: 10,
+      booting: 4,
+      update_in_progress: 5
+    },
   }),
   actions: {
     async load() {


### PR DESCRIPTION
Fehler 1 (kritisch): ledPrograms fehlte im Pinia-Store-State (stores.js).
Da Pinia nur deklarierte State-Properties über den Proxy freigibt, war
settingsStore.ledPrograms immer undefined. Damit schlug die Prüfung
`if (settingsStore.ledPrograms !== undefined)` in loadSettings() immer
fehl – LED-Programme wurden nie vom Server geladen, nur die lokalen
Standardwerte genutzt. Behoben: ledPrograms mit Standardwerten im
Store-State deklariert.

Fehler 2: loadSettings() wies ledProgramValues eine direkte Referenz
auf das reaktive Pinia-State-Objekt zu. Änderungen via setLedProgramValue
mutierten dadurch direkt den Store und lösten den tiefen Watcher aus
(Feedback-Schleife). Behoben: Objekt jetzt per Spread-Operator kopiert.

Fehler 3: showError.value = false statt null; Fehler-Extraktion war
logisch falsch reihenfolge-bedingt. Behoben.

Feature: Erfolgs-Popup "Daten gespeichert" nach dem Speichern
hinzugefügt (2,5 Sekunden sichtbar, dann erscheint der Neustart-Dialog).
Verwendet die bereits vorhandenen CSS-Klassen success-overlay/-card/-icon.

https://claude.ai/code/session_01NP1vs9bexBuYe2WxbN5VHe