### PR TITLE
Fix manual update check CORS error

### DIFF
--- a/src/webui.cpp
+++ b/src/webui.cpp
@@ -1316,6 +1316,86 @@ httpd_uri_t post_change_password_handler = {
     .user_ctx = NULL};
 
 
+struct UpdateCheckContext {
+    httpd_req_t *req;
+    bool failed;
+    bool header_sent;
+};
+
+static esp_err_t _update_check_http_event_handler(esp_http_client_event_t *evt)
+{
+    UpdateCheckContext *ctx = (UpdateCheckContext *)evt->user_data;
+
+    switch(evt->event_id) {
+        case HTTP_EVENT_ON_DATA:
+            if (!ctx->failed && esp_http_client_get_status_code(evt->client) == 200) {
+                esp_err_t err = httpd_resp_send_chunk(ctx->req, (const char *)evt->data, evt->data_len);
+                if (err != ESP_OK) {
+                    ctx->failed = true;
+                    return ESP_FAIL;
+                }
+                ctx->header_sent = true;
+            }
+            break;
+        default:
+            break;
+    }
+    return ESP_OK;
+}
+
+esp_err_t get_check_update_handler_func(httpd_req_t *req)
+{
+    add_security_headers(req);
+
+    if (validate_auth(req) != ESP_OK) {
+        httpd_resp_set_status(req, "401 Not authorized");
+        httpd_resp_sendstr(req, "401 Not authorized");
+        return ESP_OK;
+    }
+
+    UpdateCheckContext ctx = { req, false, false };
+
+    esp_http_client_config_t config = {};
+    configure_ota_http_client(config, "https://xerolux.de/firmware/HB-RF-ETH-ng/version.txt");
+    config.event_handler = _update_check_http_event_handler;
+    config.user_data = &ctx;
+    config.timeout_ms = 10000;
+    config.buffer_size = 4096;
+
+    httpd_resp_set_type(req, "text/plain");
+    httpd_resp_set_hdr(req, "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    esp_err_t err = esp_http_client_perform(client);
+
+    int status_code = esp_http_client_get_status_code(client);
+
+    if (err == ESP_OK && status_code == 200) {
+        httpd_resp_send_chunk(req, NULL, 0);
+    } else {
+        if (!ctx.header_sent) {
+            if (err != ESP_OK) {
+                 ESP_LOGE(TAG, "Failed to check for updates: %s", esp_err_to_name(err));
+                 httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to check for updates");
+            } else {
+                 ESP_LOGE(TAG, "Failed to check for updates: HTTP %d", status_code);
+                 httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Update server returned error");
+            }
+        } else {
+            httpd_resp_send_chunk(req, NULL, 0);
+        }
+    }
+
+    esp_http_client_cleanup(client);
+    return ESP_OK;
+}
+
+httpd_uri_t get_check_update_handler = {
+    .uri = "/api/check_update",
+    .method = HTTP_GET,
+    .handler = get_check_update_handler_func,
+    .user_ctx = NULL};
+
 struct ChangelogContext {
     httpd_req_t *req;
     bool failed;
@@ -1489,7 +1569,7 @@ void WebUI::start()
 
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.lru_purge_enable = true;
-    config.max_uri_handlers = 22;
+    config.max_uri_handlers = 24;
     config.uri_match_fn = httpd_uri_match_wildcard;
 
     _httpd_handle = NULL;
@@ -1511,6 +1591,7 @@ void WebUI::start()
 
         httpd_register_uri_handler(_httpd_handle, &get_backup_handler);
         httpd_register_uri_handler(_httpd_handle, &post_restore_handler);
+        httpd_register_uri_handler(_httpd_handle, &get_check_update_handler);
         httpd_register_uri_handler(_httpd_handle, &get_changelog_handler);
         httpd_register_uri_handler(_httpd_handle, &get_log_handler);
         httpd_register_uri_handler(_httpd_handle, &get_log_download_handler);

--- a/webui/src/stores.js
+++ b/webui/src/stores.js
@@ -230,10 +230,9 @@ export const useUpdateStore = defineStore('update', {
       this.checkError = null
 
       try {
-        const response = await fetch('https://xerolux.de/firmware/HB-RF-ETH-ng/version.txt?t=' + Date.now())
-        if (!response.ok) throw new Error('Failed to fetch version')
+        const response = await axios.get('/api/check_update?t=' + Date.now(), { responseType: 'text' })
 
-        const latestVersion = await response.text()
+        const latestVersion = response.data
         this.latestVersion = latestVersion.trim()
         this.lastCheck = new Date().toISOString()
 
@@ -241,7 +240,7 @@ export const useUpdateStore = defineStore('update', {
         this.updateAvailable = this.compareVersions(currentVersion, this.latestVersion) < 0
       } catch (error) {
         console.error('Update check failed:', error)
-        this.checkError = error.message
+        this.checkError = error.message || 'Unknown error'
       } finally {
         this.isChecking = false
       }


### PR DESCRIPTION
Implemented a backend proxy for the firmware update check to resolve CORS issues encountered by the frontend. The `checkForUpdate` action now queries `/api/check_update`, which internally fetches the version file from `xerolux.de`.

---
*PR created automatically by Jules for task [7791240020154419042](https://jules.google.com/task/7791240020154419042) started by @Xerolux*