### PR TITLE
Fix Changelog button visibility in Firmware page

### DIFF
--- a/webui/src/firmwareupdate.vue
+++ b/webui/src/firmwareupdate.vue
@@ -27,7 +27,7 @@
       <div class="version-badge">
         <span class="label">{{ t('firmware.version') }}</span>
         <span class="value">{{ sysInfoStore.currentVersion }}</span>
-        <BButton variant="outline-light" size="sm" @click="showChangelogModal = true" class="changelog-btn">
+        <BButton variant="outline-secondary" size="sm" @click="showChangelogModal = true" class="changelog-btn">
           📋 {{ t('changelog.title') }}
         </BButton>
       </div>
@@ -500,11 +500,25 @@ onUnmounted(() => {
   padding: 4px 12px;
   border: 1px solid var(--color-border);
   transition: all 0.2s;
+  color: #343a40;
+  background: transparent;
 }
 
 .version-badge .changelog-btn:hover {
-  border-color: var(--color-primary);
-  color: var(--color-primary);
+  border-color: #343a40;
+  background-color: #343a40;
+  color: #fff;
+}
+
+:global([data-bs-theme="dark"]) .version-badge .changelog-btn {
+  color: #e9ecef;
+  border-color: var(--color-border);
+}
+
+:global([data-bs-theme="dark"]) .version-badge .changelog-btn:hover {
+  background-color: #e9ecef;
+  color: #000;
+  border-color: #e9ecef;
 }
 
 /* Banners */


### PR DESCRIPTION
The "Changelog" (Änderungsprotokoll) button in the firmware update page was using `variant="outline-light"`, making it white and invisible on the light gray background. This change sets it to `outline-secondary` and explicitly styles it to be dark gray (`#343a40`) in light mode and light gray in dark mode, ensuring good contrast and visibility in both themes.

---
*PR created automatically by Jules for task [13196554163340517666](https://jules.google.com/task/13196554163340517666) started by @Xerolux*