### PR TITLE
Update documentation with screenshots and rescue script info

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ Die Benutzeroberfläche wurde speziell für mobile Endgeräte optimiert und biet
 
 ![Mobile Tour](docs/mobile_tour.gif)
 
+### Screenshots
+| Login | Dashboard |
+| :---: | :---: |
+| ![Login](screenshots/01_Login.png) | ![Dashboard](screenshots/02_Dashboard.png) |
+
+| Settings | Monitoring |
+| :---: | :---: |
+| ![Settings](screenshots/04_Settings.png) | ![Monitoring](screenshots/05_Monitoring.png) |
+
+| Firmware Update | System Log |
+| :---: | :---: |
+| ![Firmware Update](screenshots/06_FirmwareUpdate.png) | ![System Log](screenshots/07_SystemLog.png) |
+
+| About | Changelog |
+| :---: | :---: |
+| ![About](screenshots/08_About.png) | ![Changelog](screenshots/09_Changelog.png) |
+
 ### Bekannte Einschränkungen
 * Nach einem Neustart der Platine (z.B. bei Stromausfall) findet kein automatischer Reconnect statt, in diesem Fall muss die CCU Software daher neu gestartet werden.
 * Die Stromversorgung mittels des Funkmoduls RPI-RF-MOD darf nur erfolgen, wenn keine andere Stromversorgung (USB oder PoE) angeschlossen ist.
@@ -175,6 +192,30 @@ Firmware Updates sind fertig kompiliert in den [Releases](https://github.com/Xer
 - Die Standard-Authentifizierung schützt Firmware-Updates ausreichend
 - Die Firmware validiert alle Updates vor der Installation
 - Bei fehlerhaften Updates wird die OTA-Operation korrekt abgebrochen
+
+### Notfall-Wiederherstellung (Rescue Script)
+Sollte die WebUI nicht mehr erreichbar sein, aber die Platine noch im Netzwerk antworten (Ping), kann die Firmware über das mitgelieferte Python-Script `test_ota_function.py` neu installiert werden.
+
+**Voraussetzung:**
+- Python 3 installiert
+- Platine ist im Netzwerk erreichbar
+- Admin-Passwort ist bekannt
+
+**Anwendung:**
+Das Script befindet sich im Root-Verzeichnis des Repositories.
+
+```bash
+# Syntax
+python3 test_ota_function.py <IP-ADRESSE> <PASSWORD> [--url <FIRMWARE_URL>]
+
+# Beispiel (mit Standard-URL zur neuesten Firmware)
+python3 test_ota_function.py 192.168.1.100 meinPasswort
+
+# Beispiel (mit eigener URL)
+python3 test_ota_function.py 192.168.1.100 meinPasswort --url http://192.168.1.50/firmware.bin
+```
+
+Das Script authentifiziert sich, triggert das OTA-Update und überwacht den Fortschritt bis zum erfolgreichen Neustart.
 
 ### Kompatible CCU-Systeme
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -355,6 +355,32 @@ After a device restart (e.g., power failure), the CCU does not automatically rec
    - Perform factory reset (see below)
    - Re-flash firmware
 
+### Emergency Firmware Update (Rescue Script)
+
+If the WebUI is inaccessible but the device is still reachable on the network (pingable), you can use the `test_ota_function.py` script included in the repository to trigger a firmware update via the API.
+
+**Prerequisites:**
+- Python 3 installed
+- Device is reachable on the network
+- Admin password is known
+
+**Usage:**
+
+The script is located in the root directory of the repository.
+
+```bash
+# Syntax
+python3 test_ota_function.py <DEVICE_IP> <PASSWORD> [--url <FIRMWARE_URL>]
+
+# Example (using default URL for latest firmware)
+python3 test_ota_function.py 192.168.1.100 myPassword
+
+# Example (using custom URL)
+python3 test_ota_function.py 192.168.1.100 myPassword --url http://192.168.1.50/firmware.bin
+```
+
+The script will authenticate, trigger the OTA update, and monitor progress until the device restarts.
+
 ---
 
 ## Time Synchronization


### PR DESCRIPTION
Updated README.md to include a new Screenshots section and a section explaining how to use `test_ota_function.py` for emergency firmware recovery. Also updated docs/TROUBLESHOOTING.md with the same recovery instructions in English.

---
*PR created automatically by Jules for task [13813608554993877925](https://jules.google.com/task/13813608554993877925) started by @Xerolux*