### PR TITLE
Add privacy disclaimer for external update server

### DIFF
--- a/webui/src/about.vue
+++ b/webui/src/about.vue
@@ -62,6 +62,17 @@
       </div>
     </div>
 
+    <!-- Privacy Info -->
+    <div class="about-section">
+      <div class="section-header">
+        <span class="section-icon">🔒</span>
+        <h3 class="section-title">{{ t('privacy.title') }}</h3>
+      </div>
+      <div class="info-card">
+        <p>{{ t('privacy.updateCheck') }}</p>
+      </div>
+    </div>
+
     <!-- Third Party Software -->
     <div class="about-section">
       <div class="section-header">

--- a/webui/src/firmwareupdate.vue
+++ b/webui/src/firmwareupdate.vue
@@ -142,6 +142,9 @@
               <span v-if="updateStore.isChecking" class="spinner-border spinner-border-sm"></span>
               {{ updateStore.isChecking ? t('firmware.checking') : t('firmware.checkNow') }}
             </button>
+            <div class="form-text mt-2 text-muted" style="font-size: 0.75rem; line-height: 1.2;">
+               {{ t('privacy.updateCheck') }}
+            </div>
             <div v-if="updateStore.lastCheck" class="last-check">
               {{ t('firmware.lastCheck') }}: {{ formatLastCheck(updateStore.lastCheck) }}
             </div>

--- a/webui/src/locales/de.js
+++ b/webui/src/locales/de.js
@@ -378,6 +378,12 @@ export default {
     empty: 'Noch keine Log-Einträge vorhanden.'
   },
 
+  // Privacy
+  privacy: {
+    title: 'Datenschutz',
+    updateCheck: 'Automatische Updates und Firmware-Checks verbinden sich mit dem Server xerolux.de. Dabei wird Ihre IP-Adresse übertragen, um die Verfügbarkeit neuer Versionen zu prüfen.'
+  },
+
   // Changelog
   changelog: {
     title: 'Änderungsprotokoll',

--- a/webui/src/locales/en.js
+++ b/webui/src/locales/en.js
@@ -378,6 +378,12 @@ export default {
     empty: 'No log entries yet.'
   },
 
+  // Privacy
+  privacy: {
+    title: 'Privacy',
+    updateCheck: 'Automatic updates and firmware checks connect to the server xerolux.de. Your IP address is transmitted to check for availability of new versions.'
+  },
+
   // Changelog
   changelog: {
     title: 'Changelog',


### PR DESCRIPTION
Added privacy disclaimers regarding the connection to `xerolux.de` for firmware updates.

1.  **About Page**: Added a new section "Datenschutz" / "Privacy" that explicitly states: "Automatic updates and firmware checks connect to the server xerolux.de. Your IP address is transmitted to check for availability of new versions."
2.  **Firmware Update Page**: Added a small text note below the manual update check button with the same information.
3.  **Localization**: Added English and German translations.

---
*PR created automatically by Jules for task [17894004646905472166](https://jules.google.com/task/17894004646905472166) started by @Xerolux*