### PR TITLE
chore: upgrade dev tools and dependencies to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: webui/package-lock.json
 
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Lint Markdown files
-        uses: DavidAnson/markdownlint-cli2-action@v22
+        uses: DavidAnson/markdownlint-cli2-action@v23
         with:
           globs: |
             **/*.md

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './docs'
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: webui/package-lock.json
 
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: webui/package-lock.json
 
@@ -132,7 +132,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Python for version update
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Update all version numbers and changelog
         run: |
@@ -89,7 +89,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: webui/package-lock.json
 
@@ -172,7 +172,7 @@ jobs:
           echo "IS_DRAFT=$IS_DRAFT" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.get_version.outputs.VERSION_TAG }}
           name: HB-RF-ETH-ng ${{ steps.get_version.outputs.VERSION_TAG }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Run npm audit
         run: |
@@ -62,7 +62,7 @@ jobs:
         if: matrix.language == 'cpp'
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install PlatformIO
         if: matrix.language == 'cpp'
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Check for npm updates
         run: |
@@ -109,7 +109,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install PlatformIO
         run: |

--- a/webui/package.json
+++ b/webui/package.json
@@ -13,19 +13,19 @@
   "dependencies": {
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.4",
-    "axios": "^1.14.0",
+    "axios": "^1.15.0",
     "bootstrap": "^5.3.3",
-    "bootstrap-vue-next": "^0.44.0",
-    "marked": "^17.0.6",
+    "bootstrap-vue-next": "^0.44.2",
+    "marked": "^18.0.0",
     "pinia": "^3.0.4",
     "vue": "^3.5.32",
-    "vue-i18n": "^11.3.0",
+    "vue-i18n": "^11.3.2",
     "vue-router": "^5.0.4"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.59.1",
     "@vitejs/plugin-vue": "^6.0.5",
     "esbuild": "^0.28.0",
-    "vite": "^8.0.5"
+    "vite": "^8.0.8"
   }
 }


### PR DESCRIPTION
- Node.js CI: 20 → 24 (Active LTS) in all workflows
- Python CI: 3.11 → 3.13 in all workflows
- softprops/action-gh-release: v2 → v3
- DavidAnson/markdownlint-cli2-action: v22 → v23
- actions/upload-pages-artifact: v4 → v5
- axios: ^1.14.0 → ^1.15.0
- bootstrap-vue-next: ^0.44.0 → ^0.44.2
- marked: ^17.0.6 → ^18.0.0
- vue-i18n: ^11.3.0 → ^11.3.2
- vite: ^8.0.5 → ^8.0.8
- @playwright/test: ^1.58.2 → ^1.59.1

https://claude.ai/code/session_012CrSDkQhUb4yaoKjnFkKg9