### PR TITLE
fix: revert platformio.ini to espressif32@^6.13.0 (ESP-IDF 5.5.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,9 @@ HB-RF-ETH-ng/
 | Tool | Version |
 |------|---------|
 | PlatformIO | Latest |
-| ESP-IDF framework | 6.0.0 (via `framework-espidf@~3.60000.0`) |
+| ESP-IDF framework | 5.5.3 (via `framework-espidf@~3.50503.0`) |
 | Xtensa GCC toolchain | 14.2.0+20251107 |
-| Platform package | `espressif32@^7.0.0` |
+| Platform package | `espressif32@^6.13.0` |
 
 ### Building the Firmware
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Hierbei gilt, dass bei einer debmatic oder piVCCU3 Installation immer nur ein Fu
 - Moderne WebUI auf Basis von Vue 3, Vite und Bootstrap 5
 - Monitoring via MQTT und CheckMK
 - OTA-Updates per Datei-Upload oder über den integrierten Online-Update-Dienst
-- ESP-IDF 6.0.x Toolchain über PlatformIO
+- ESP-IDF 5.5.x Toolchain über PlatformIO
 
 ### Update- und Release-Hinweise
 - Die WebUI prüft neue Versionen standardmäßig über den gehosteten Update-Dienst unter `https://xerolux.de/firmware/HB-RF-ETH-ng/`.

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -83,7 +83,7 @@ Willkommen im Wiki der modernisierten HB-RF-ETH-ng Firmware. Hier finden Sie all
 * **Hardware-Überwachung** - Echtzeit-Temperatur, Spannung, CPU- und Speicheranzeige
 
 ### Technische Basis
-* **ESP-IDF 6.0.x** auf Espressif32 Platform ^7.0.0
+* **ESP-IDF 5.5.x** auf Espressif32 Platform ^6.13.0
 * **GCC 14.2.0** Toolchain (xtensa-esp-elf)
 * **Vue.js 3.5.30** mit Composition API, Vue Router 5, Pinia 3, Vue i18n 11
 * **Bootstrap Vue Next 0.44.0** UI-Komponentenbibliothek

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,9 +12,9 @@
 default_envs = hb-rf-eth-ng
 
 [env]
-platform = espressif32@^7.0.0
+platform = espressif32@^6.13.0
 platform_packages =
-    platformio/framework-espidf@~3.60000.0
+    platformio/framework-espidf@~3.50503.0
     platformio/toolchain-xtensa-esp-elf@14.2.0+20251107
 framework = espidf
 

--- a/sdkconfig.hb-rf-eth-ng
+++ b/sdkconfig.hb-rf-eth-ng
@@ -1,6 +1,6 @@
 #
 # Automatically generated file. DO NOT EDIT.
-# Espressif IoT Development Framework (ESP-IDF) 6.0.0 Project Configuration
+# Espressif IoT Development Framework (ESP-IDF) 5.5.3 Project Configuration
 #
 CONFIG_SOC_CAPS_ECO_VER_MAX=301
 CONFIG_SOC_ADC_SUPPORTED=y
@@ -253,7 +253,7 @@ CONFIG_IDF_TOOLCHAIN_GCC=y
 CONFIG_IDF_TARGET_ARCH_XTENSA=y
 CONFIG_IDF_TARGET_ARCH="xtensa"
 CONFIG_IDF_TARGET="esp32"
-CONFIG_IDF_INIT_VERSION="6.0.0"
+CONFIG_IDF_INIT_VERSION="5.5.2"
 CONFIG_IDF_TARGET_ESP32=y
 CONFIG_IDF_FIRMWARE_CHIP_ID=0x0000
 


### PR DESCRIPTION
ESP-IDF 6.0 is not yet packaged in PlatformIO registry (latest espressif32 platform is v6.13.0 with ESP-IDF 5.5.3, released Feb 2025). espressif32@^7.0.0 / framework-espidf@~3.60000.0 do not exist yet.

All source-code migration changes are kept and are fully compatible with ESP-IDF 5.5.3 (pdMS_TO_TICKS, LEDC_LOW_SPEED_MODE, explicit component REQUIRES, etc.). Once PlatformIO publishes ESP-IDF 6.0 support, only this single platformio.ini change is needed.

https://claude.ai/code/session_01RrUg49dyfPGZtEbRbYvh8k

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
