### PR TITLE
Fix missing field initializers in I2C configuration structs

### DIFF
--- a/src/rtcdriver.cpp
+++ b/src/rtcdriver.cpp
@@ -59,6 +59,8 @@ static void i2c_master_init()
         .scl_io_num = HM_SCL_PIN,
         .clk_source = I2C_CLK_SRC_DEFAULT,
         .glitch_ignore_cnt = 7,
+        .intr_priority = 0,
+        .trans_queue_depth = 0,
         .flags = { .enable_internal_pullup = true, .allow_pd = false }
     };
 
@@ -113,6 +115,7 @@ bool Rtc::begin()
         .device_address = _address,
         .scl_speed_hz = 100000,
         .scl_wait_us = 0,
+        .flags = { .disable_ack_check = 0 }
     };
 
     esp_err_t ret = i2c_master_bus_add_device(i2c_bus, &dev_config, &device_handle);
@@ -139,6 +142,7 @@ struct timeval Rtc::GetTime()
         .device_address = _address,
         .scl_speed_hz = 100000,
         .scl_wait_us = 0,
+        .flags = { .disable_ack_check = 0 }
     };
 
     esp_err_t ret = i2c_master_bus_add_device(i2c_bus, &dev_config, &device_handle);
@@ -239,6 +243,7 @@ void Rtc::SetTime(struct timeval now)
         .device_address = _address,
         .scl_speed_hz = 100000,
         .scl_wait_us = 0,
+        .flags = { .disable_ack_check = 0 }
     };
 
     esp_err_t ret = i2c_master_bus_add_device(i2c_bus, &dev_config, &device_handle);
@@ -272,6 +277,8 @@ bool RtcRX8130::begin()
             .dev_addr_length = I2C_ADDR_BIT_LEN_7,
             .device_address = _address,
             .scl_speed_hz = 100000,
+            .scl_wait_us = 0,
+            .flags = { .disable_ack_check = 0 }
         };
 
         esp_err_t ret = i2c_master_bus_add_device(i2c_bus, &dev_config, &device_handle);


### PR DESCRIPTION
Explicitly initialized newly introduced fields (`intr_priority`, `trans_queue_depth`, `scl_wait_us`, and `flags`) in the I2C configuration structs (`i2c_master_bus_config_t` and `i2c_device_config_t`) in `src/rtcdriver.cpp`. This fixes the missing initializer compiler warnings under strict toolchains.

Additionally, this addresses the user's question regarding ESP-IDF v6.0. ESP-IDF v6.0 has recently been released by Espressif, however, it is not yet officially integrated or available via the standard PlatformIO `espressif32` platform (which currently uses ESP-IDF v5.5.3). It usually takes some time for PlatformIO to support new major ESP-IDF releases.

---
*PR created automatically by Jules for task [9194275931904878022](https://jules.google.com/task/9194275931904878022) started by @Xerolux*