### PR TITLE
feat(mqtt): Phase A + B - LWT/Birth, command token, OTA state, extend…

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -366,7 +366,14 @@ Retrieve monitoring configuration for MQTT and CheckMK.
     "password": "",
     "topicPrefix": "hb-rf-eth",
     "haDiscoveryEnabled": false,
-    "haDiscoveryPrefix": "homeassistant"
+    "haDiscoveryPrefix": "homeassistant",
+    "tlsEnable": false,
+    "tlsSkipVerify": false,
+    "tlsCaCertsSet": false,
+    "tlsCertfileSet": false,
+    "tlsKeyfileSet": false,
+    "commandEnabled": true,
+    "commandTokenSet": false
   },
   "checkmk": {
     "enabled": false,
@@ -387,6 +394,13 @@ Retrieve monitoring configuration for MQTT and CheckMK.
 - `topicPrefix`: Topic prefix for published entities and status messages
 - `haDiscoveryEnabled`: Enable Home Assistant auto-discovery payloads
 - `haDiscoveryPrefix`: Discovery prefix used for Home Assistant
+- `tlsEnable`: Connect to the broker via TLS (port 8883 by default)
+- `tlsSkipVerify`: Skip TLS certificate / hostname verification (insecure; lab only)
+- `tlsCaCertsSet`: `true` if a custom CA bundle is stored (PEM). Use `tlsCaCertsClear=true` to remove.
+- `tlsCertfileSet`: `true` if a client certificate (mTLS) is stored
+- `tlsKeyfileSet`: `true` if a client key (mTLS) is stored
+- `commandEnabled`: When `false`, the device does **not** subscribe to `<prefix>/command/#` and silently drops every command. Default: `true`.
+- `commandTokenSet`: `true` if a shared-secret token has been configured. The token itself is never returned by the API. Send `commandTokenClear=true` to remove it, or a new `commandToken` value to replace it.
 
 **CheckMK:**
 - `enabled`: Enable/disable CheckMK agent
@@ -416,7 +430,12 @@ Update monitoring configuration.
       "password": "secret",
       "topicPrefix": "hb-rf-eth",
       "haDiscoveryEnabled": true,
-      "haDiscoveryPrefix": "homeassistant"
+      "haDiscoveryPrefix": "homeassistant",
+      "tlsEnable": false,
+      "tlsSkipVerify": false,
+      "commandEnabled": true,
+      "commandToken": "my-shared-secret-123",
+      "commandTokenClear": false
   },
   "checkmk": {
     "enabled": true,
@@ -425,6 +444,10 @@ Update monitoring configuration.
   }
 }
 ```
+
+**Command token validation:** the token must be 8–63 characters long and may
+only contain `A–Z a–z 0–9 - _ .`. It is embedded verbatim in MQTT payloads
+and Home Assistant discovery JSON, so any other character is rejected.
 
 **Response (200 OK):**
 ```json

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -638,3 +638,38 @@ If problems persist:
    - Isolate management interface
    - Use firewall rules
    - Disable unused monitoring services
+
+7. **MQTT Command Security (Phase A)**
+
+   The MQTT user/password configured in the WebUI authenticates the **device**
+   against the broker - it does NOT prevent other clients from publishing to
+   `<prefix>/command/#`. Anyone with publish rights on that topic can
+   restart the device, trigger OTA, or even factory-reset it. Three
+   complementary levers are available:
+
+   - **Broker ACL (most important).** Configure your broker so that only the
+     HB-RF-ETH-ng user may publish to `<prefix>/command/#`. Example
+     Mosquitto ACL:
+     ```text
+     user hb-rf-eth
+     topic hb-rf-eth/# rw
+     topic homeassistant/# rw
+     ```
+   - **Command token (device-side).** In *Monitoring → MQTT → Command
+     Topics* set a shared-secret token. Every command payload must then
+     match the token exactly. Allowed charset: `A-Z a-z 0-9 - _ .`,
+     length 8–63. Without the token the device rejects the command and
+     publishes an event to `<prefix>/event/command_rejected`.
+   - **Disable commands entirely.** Uncheck *Enable* under *Command Topics*
+     to stop the device from subscribing to the command tree. Restart /
+     Factory Reset / OTA are then only possible via WebUI.
+
+   TLS / mTLS can be enabled independently in *Monitoring → MQTT → TLS / SSL*
+   to encrypt the broker connection and to authenticate the device with a
+   client certificate. TLS is optional and is NOT required for the
+   command token to work.
+
+   When a command token is configured, the HA discovery JSON publishes the
+   token verbatim as `payload_press` / `payload_install` so the HA buttons
+   continue to work. Lock down write access to `homeassistant/#` on the
+   broker so other clients cannot read the token via the discovery topic.

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -248,21 +248,50 @@ Die Firmware verwendet folgende Topic-Struktur:
 
 ```
 hb-rf-eth/                      (Standard Topic Prefix)
-├── status/                     (Status-Metriken)
-│   ├── cpu_usage
-│   ├── memory_usage
-│   ├── temperature
-│   ├── supply_voltage
-│   ├── uptime
-│   ├── uptime_text
+├── status/                     (Status-Metriken, retained, alle 5-60s)
+│   ├── online                  "online" / "offline" (LWT-Birth-Marker)
+│   ├── serial
 │   ├── version
 │   ├── latest_version
 │   ├── update_available
-│   └── board_revision
-└── command/                    (Commands für HA)
-    ├── restart
-    ├── factory_reset
-    └── update
+│   ├── board_revision
+│   ├── cpu_usage
+│   ├── memory_usage
+│   ├── free_heap
+│   ├── min_free_heap
+│   ├── supply_voltage
+│   ├── temperature
+│   ├── uptime
+│   ├── uptime_text
+│   ├── last_reset_reason
+│   ├── eth_connected           "true" / "false"
+│   ├── eth_link_speed          Mbit/s
+│   ├── eth_duplex              "Full" / "Half"
+│   ├── ip_address
+│   ├── gateway
+│   ├── radio_module_type       "HM-MOD-RPI-PCB" / "RPI-RF-MOD" / "none"
+│   ├── radio_module_serial
+│   ├── radio_module_firmware
+│   ├── ntp_synced              "true" / "false"
+│   ├── last_ntp_sync           Unix-Sekunden
+│   ├── ota_state               "idle" / "checking" / "starting" /
+│   │                                       "downloading" / "flashing" /
+│   │                                       "success" / "failed"
+│   ├── ota_progress            0..100 (-1 = unbekannt)
+│   └── ota_error               Fehler-Text (nur bei failed)
+├── event/                      (Ereignisse, NICHT retained)
+│   ├── restart
+│   ├── factory_reset
+│   ├── update_started
+│   ├── update_downloading
+│   ├── update_finished         "success" / "failed: ..."
+│   ├── check_update
+│   └── command_rejected        bei ungültigem Token
+└── command/                    (Commands – nur wenn commandEnabled)
+    ├── restart                 Payload: <token> oder leer
+    ├── factory_reset           Payload: <token> oder leer
+    ├── update                  Payload: <token> oder leer
+    └── check_update            Payload: <token> oder leer
 
 homeassistant/                  (HA Discovery Prefix)
 ├── sensor/
@@ -316,9 +345,35 @@ cards:
 ### Sicherheitshinweise
 
 - Die HA-Integration ist standardmäßig **DEAKTIVIERT** und muss explizit aktiviert werden
-- Commands (Restart, Factory Reset, Update) sind nur per MQTT möglich, wenn HA Discovery aktiviert ist
-- Alle Commands werden im Systemlog protokolliert
-- Die WebUI-Authentifizierung bleibt weiterhin aktiv
+- Commands (Restart, Factory Reset, Update, Check Update) sind nur dann per
+  MQTT möglich, wenn `commandEnabled` aktiv ist (Standard: ja)
+- Optional kann ein **Kommando-Token** gesetzt werden: jeder Kommando-Payload
+  muss dann exakt diesem Token entsprechen. Ohne Token gilt: jeder MQTT-Client
+  mit Publish-Rechten auf `<prefix>/command/#` kann das Gerät steuern
+- Bei gesetztem Token veröffentlicht das HA Discovery JSON den Token als
+  `payload_press` / `payload_install` – die Broker-ACL muss deshalb
+  sicherstellen, dass nur das Gerät auf `homeassistant/#` publishen darf
+- TLS/mTLS ist optional und unabhängig vom Token (z. B. für self-hosted
+  Mosquitto mit self-signed Cert)
+- Alle Commands werden im Systemlog protokolliert; bei ungültigem Token wird
+  zusätzlich ein Event auf `<prefix>/event/command_rejected` gepublished
+- Die WebUI-Authentifizierung bleibt unabhängig von MQTT jederzeit aktiv
+
+#### Empfohlene Broker-ACL (Mosquitto-Beispiel)
+
+```
+# /etc/mosquitto/acls/hb-rf-eth.acl
+user hb-rf-eth
+topic hb-rf-eth/# rw
+topic homeassistant/# rw
+
+pattern hb-rf-eth/%u/#
+
+# Alle anderen User dürfen nur lesen / nicht publishen
+user readonly
+topic read hb-rf-eth/#
+topic read homeassistant/#
+```
 
 ### Fehlersuche
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -427,6 +427,69 @@ components:
               type: string
               description: Discovery prefix used for Home Assistant
               example: homeassistant
+            tlsEnable:
+              type: boolean
+              description: Connect to broker via TLS (port 8883 by default)
+              example: false
+            tlsSkipVerify:
+              type: boolean
+              description: Skip TLS cert/hostname verification (INSECURE, lab only)
+              example: false
+            tlsCaCerts:
+              type: string
+              description: Custom CA bundle (PEM). Empty = built-in Mozilla bundle. Write-only.
+              format: pem
+            tlsCaCertsClear:
+              type: boolean
+              description: Drop any stored custom CA bundle
+            tlsCertfile:
+              type: string
+              description: mTLS client certificate (PEM). Write-only.
+              format: pem
+            tlsCertfileClear:
+              type: boolean
+              description: Drop any stored mTLS client certificate
+            tlsKeyfile:
+              type: string
+              description: mTLS client key (PEM). Write-only.
+              format: pem
+            tlsKeyfileClear:
+              type: boolean
+              description: Drop any stored mTLS client key
+            tlsCaCertsSet:
+              type: boolean
+              description: Read-only flag indicating a custom CA bundle is stored
+              readOnly: true
+            tlsCertfileSet:
+              type: boolean
+              description: Read-only flag indicating a client cert is stored
+              readOnly: true
+            tlsKeyfileSet:
+              type: boolean
+              description: Read-only flag indicating a client key is stored
+              readOnly: true
+            commandEnabled:
+              type: boolean
+              description: >
+                When false, the device does not subscribe to
+                <prefix>/command/# and silently drops every command.
+                Default true.
+              example: true
+            commandToken:
+              type: string
+              description: >
+                Shared-secret that command payloads must match exactly.
+                Allowed charset: A-Z a-z 0-9 - _ . (8..63 chars).
+                Write-only; the stored value is never returned by the API.
+              maxLength: 63
+              writeOnly: true
+            commandTokenClear:
+              type: boolean
+              description: Drop any stored command token
+            commandTokenSet:
+              type: boolean
+              description: Read-only flag indicating a command token is configured
+              readOnly: true
         checkmk:
           type: object
           description: CheckMK agent configuration

--- a/include/monitoring.h
+++ b/include/monitoring.h
@@ -15,6 +15,9 @@
 // Forward declarations
 class SysInfo;
 class UpdateCheck;
+class Ethernet;
+class RadioModuleDetector;
+class SystemClock;
 
 // CheckMK Agent Configuration
 typedef struct {
@@ -38,6 +41,15 @@ typedef struct {
     char tls_ca_certs[2048];    // MQTT TLS CA bundle (PEM); empty = use built-in ESP-IDF CA bundle
     char tls_certfile[2048];    // MQTT TLS client cert (mTLS), PEM; empty = no client cert
     char tls_keyfile[2048];     // MQTT TLS client key (mTLS), PEM; empty = no client key
+    // --- Command topic security (Phase A) ---
+    // When false, the device will not subscribe to <prefix>/command/# at all
+    // and ignores any command message (default: true to preserve previous
+    // behaviour where commands were tied to HA discovery being enabled).
+    bool command_enabled;
+    // Optional shared-secret that callers must place in the command payload
+    // (or in a "token" JSON field) for a command to be accepted. Empty means
+    // "no token required" - in that case rely on broker-side ACL + TLS/mTLS.
+    char command_token[65];
 } mqtt_config_t;
 
 // Monitoring configuration
@@ -48,6 +60,15 @@ typedef struct {
 
 // Initialize monitoring subsystem
 esp_err_t monitoring_init(const monitoring_config_t *config, SysInfo* sysInfo, UpdateCheck* updateCheck);
+
+// Register additional data providers so MQTT can publish richer status topics
+// (Ethernet link/IP, radio module info, system clock / NTP sync state).
+// All pointers are optional; pass NULL for any provider that is unavailable.
+// Must be called BEFORE monitoring_init() so the MQTT publish task can use
+// them from the very first status cycle.
+void monitoring_set_providers(Ethernet* ethernet,
+                              RadioModuleDetector* radioModuleDetector,
+                              SystemClock* systemClock);
 
 // Update configuration (synchronous - blocks caller)
 esp_err_t monitoring_update_config(const monitoring_config_t *config);

--- a/include/mqtt_handler.h
+++ b/include/mqtt_handler.h
@@ -20,7 +20,16 @@ esp_err_t mqtt_handler_start(const mqtt_config_t *config);
 // Stop MQTT client
 esp_err_t mqtt_handler_stop(void);
 
-// Publish status update
+// Publish status update (status sensors + LWT "online" marker)
 void mqtt_handler_publish_status(void);
+
+// Publish a one-shot event payload under <prefix>/<subtopic> (non-retained).
+// Used for transient events like OTA started / finished / command rejected.
+void mqtt_handler_publish_event(const char *subtopic, const char *payload);
+
+// Force a single immediate status publish cycle (e.g. after a setting changed
+// or after OTA state changed). Safe to call from any task; returns immediately
+// and schedules the publish on the periodic task if it is running.
+void mqtt_handler_trigger_status_publish(void);
 
 #endif // MQTT_HANDLER_H

--- a/include/updatecheck.h
+++ b/include/updatecheck.h
@@ -44,6 +44,26 @@ struct ReleaseInfo {
     char error[128];            // human-readable last error (empty when valid)
 };
 
+// OTA state machine, published via MQTT status/ota_state. Thread-safe
+// snapshot via getOtaState(). The MQTT / web layers read this without
+// locking; updates go through the internal mutex.
+typedef enum {
+    OTA_STATE_IDLE = 0,         // No OTA activity
+    OTA_STATE_CHECKING,         // refresh() in flight (querying GitHub)
+    OTA_STATE_STARTING,         // esp_https_ota_begin about to be called
+    OTA_STATE_DOWNLOADING,      // esp_https_ota_perform loop running
+    OTA_STATE_FLASHING,         // Writing final chunks + switching partition
+    OTA_STATE_SUCCESS,          // OTA finished, restart pending
+    OTA_STATE_FAILED,           // OTA failed; check ota_error for details
+} ota_state_t;
+
+struct OtaSnapshot {
+    ota_state_t state = OTA_STATE_IDLE;
+    int progress_pct = 0;       // 0..100 (bytes downloaded / image size); -1 if unknown
+    int error_code = 0;         // esp_err_t value when state == OTA_STATE_FAILED
+    char error_text[64] = {0};  // human readable, e.g. "ESP_ERR_OTA_VALIDATE_FAILED"
+};
+
 class UpdateCheck
 {
 private:
@@ -62,7 +82,18 @@ private:
     // Mirror of _release.version for the legacy const char* accessor.
     char _latestVersion[32] = "n/a";
 
+    // OTA progress / state (guarded by _stateMutex). Read by MQTT publish task
+    // and the HTTP layer; written by performOnlineUpdate() running on its own
+    // task.
+    ota_state_t _otaState = OTA_STATE_IDLE;
+    int _otaProgress = -1;
+    int _otaErrorCode = 0;
+    char _otaErrorText[64] = {0};
+
     bool _doFetch(ReleaseInfo* out);
+    void _setOtaStateLocked(ota_state_t state);
+    void _setOtaProgressLocked(int percent);
+    void _setOtaErrorLocked(int code, const char* text);
 
 public:
     UpdateCheck(Settings* settings, SysInfo* sysInfo, LED *statusLED);
@@ -82,7 +113,14 @@ public:
     // Returns a thread-safe snapshot of the currently cached release info.
     ReleaseInfo getReleaseInfo();
 
+    // Returns a thread-safe snapshot of the OTA state machine. The MQTT layer
+    // publishes this as status/ota_state + status/ota_progress so that
+    // Home Assistant can show update progress and react on completion.
+    OtaSnapshot getOtaState();
+
     // Triggers OTA from the cached downloadUrl (the GitHub asset URL).
+    // Updates the OTA state machine while running. Blocks until OTA either
+    // succeeds (and restarts) or fails.
     void performOnlineUpdate();
 
     // Legacy accessor: returns a pointer to the cached version string

--- a/include/validation.h
+++ b/include/validation.h
@@ -62,3 +62,9 @@ bool validateServerAddress(const char *server, size_t maxLength);
 // CCU address validation (hostname, IPv4, IPv6, WITHOUT port)
 // Used for HomeMatic CCU connection - does not allow port specification
 bool validateCcuAddress(const char *address);
+
+// MQTT command token validation. The token is embedded in plain-text MQTT
+// payloads and HA discovery JSON, so we restrict the alphabet to characters
+// that are unambiguously safe in any context (no spaces, quotes, slashes,
+// control chars). Length: 8..63 characters. Allowed: A-Z a-z 0-9 - _ .
+bool validateMqttCommandToken(const char *token);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -220,6 +220,11 @@ void app_main()
     static WebUI webUI(&settings, &statusLED, &sysInfo, &updateCheck, &ethernet, &rawUartUdpLister, &radioModuleConnector, &radioModuleDetector);
     webUI.start();
 
+    // Register data providers for MQTT status topics (Ethernet link/IP,
+    // radio module info, system clock / NTP sync state). Must happen before
+    // monitoring_init() so the very first status publish cycle sees them.
+    monitoring_set_providers(&ethernet, &radioModuleDetector, &clk);
+
     // Initialize monitoring (CheckMK, MQTT)
     monitoring_init(NULL, &sysInfo, &updateCheck);
 

--- a/main/monitoring.cpp
+++ b/main/monitoring.cpp
@@ -24,6 +24,9 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <atomic>
+#include "ethernet.h"
+#include "radiomoduledetector.h"
+#include "systemclock.h"
 
 static const char *TAG = "MONITORING";
 
@@ -52,10 +55,29 @@ static volatile int checkmk_listen_sock = -1;
 #define NVS_MQTT_TLS_CA     "mqtt_tls_ca"
 #define NVS_MQTT_TLS_CRT    "mqtt_tls_crt"
 #define NVS_MQTT_TLS_KEY    "mqtt_tls_key"
+#define NVS_MQTT_CMD_EN     "mqtt_cmd_en"   // command topic enabled
+#define NVS_MQTT_CMD_TOK    "mqtt_cmd_tok"  // optional shared-secret
 
 // Global pointers
 static SysInfo* g_sysInfo = NULL;
 static UpdateCheck* g_updateCheck = NULL;
+static Ethernet* g_ethernet = NULL;
+static RadioModuleDetector* g_radioModuleDetector = NULL;
+static SystemClock* g_systemClock = NULL;
+
+// Provider accessors for mqtt_handler.cpp
+Ethernet* monitoring_get_ethernet(void) { return g_ethernet; }
+RadioModuleDetector* monitoring_get_radiomodule(void) { return g_radioModuleDetector; }
+SystemClock* monitoring_get_systemclock(void) { return g_systemClock; }
+
+void monitoring_set_providers(Ethernet* ethernet,
+                              RadioModuleDetector* radioModuleDetector,
+                              SystemClock* systemClock)
+{
+    g_ethernet = ethernet;
+    g_radioModuleDetector = radioModuleDetector;
+    g_systemClock = systemClock;
+}
 
 // Get firmware version from app descriptor
 static const char* get_firmware_version(void)
@@ -338,6 +360,12 @@ static esp_err_t save_config_to_nvs(const monitoring_config_t *config)
     nvs_set_blob(nvs_handle, NVS_MQTT_TLS_CRT, config->mqtt.tls_certfile,  strlen(config->mqtt.tls_certfile) + 1);
     nvs_set_blob(nvs_handle, NVS_MQTT_TLS_KEY, config->mqtt.tls_keyfile,   strlen(config->mqtt.tls_keyfile) + 1);
 
+    // Command-topic security (Phase A). Default for command_enabled is true
+    // so existing installations keep working after the upgrade. The token
+    // is optional; if empty no token check is applied.
+    nvs_set_u8(nvs_handle, NVS_MQTT_CMD_EN, config->mqtt.command_enabled ? 1 : 0);
+    nvs_set_str(nvs_handle, NVS_MQTT_CMD_TOK, config->mqtt.command_token);
+
     err = nvs_commit(nvs_handle);
     nvs_close(nvs_handle);
 
@@ -370,6 +398,13 @@ static esp_err_t load_config_from_nvs(monitoring_config_t *config)
         config->mqtt.tls_ca_certs[0] = '\0';
         config->mqtt.tls_certfile[0] = '\0';
         config->mqtt.tls_keyfile[0] = '\0';
+
+        // Phase A defaults: commands enabled, no token. This preserves the
+        // pre-Phase-A behaviour where any client with broker publish rights
+        // could trigger a restart / OTA. Operators who care should set a
+        // token or restrict the broker ACL.
+        config->mqtt.command_enabled = true;
+        config->mqtt.command_token[0] = '\0';
 
         return ESP_OK;
     }
@@ -454,6 +489,19 @@ static esp_err_t load_config_from_nvs(monitoring_config_t *config)
     blob_len = sizeof(config->mqtt.tls_keyfile);
     if (nvs_get_blob(nvs_handle, NVS_MQTT_TLS_KEY, config->mqtt.tls_keyfile, &blob_len) != ESP_OK) {
         config->mqtt.tls_keyfile[0] = '\0';
+    }
+
+    // Phase A: command-topic security. command_enabled defaults to true for
+    // upgrades from a pre-Phase-A build (no NVS key present yet) so that
+    // existing MQTT integrations do not silently lose restart/update.
+    if (nvs_get_u8(nvs_handle, NVS_MQTT_CMD_EN, &u8_val) == ESP_OK) {
+        config->mqtt.command_enabled = (u8_val != 0);
+    } else {
+        config->mqtt.command_enabled = true;
+    }
+    str_len = sizeof(config->mqtt.command_token);
+    if (nvs_get_str(nvs_handle, NVS_MQTT_CMD_TOK, config->mqtt.command_token, &str_len) != ESP_OK) {
+        config->mqtt.command_token[0] = '\0';
     }
 
     nvs_close(nvs_handle);

--- a/main/monitoring_api.cpp
+++ b/main/monitoring_api.cpp
@@ -129,6 +129,11 @@ esp_err_t get_monitoring_handler_func(httpd_req_t *req)
     cJSON_AddBoolToObject(mqtt, "tlsCaCertsSet",   strlen(config.mqtt.tls_ca_certs)  > 0);
     cJSON_AddBoolToObject(mqtt, "tlsCertfileSet",  strlen(config.mqtt.tls_certfile)  > 0);
     cJSON_AddBoolToObject(mqtt, "tlsKeyfileSet",   strlen(config.mqtt.tls_keyfile)   > 0);
+    // Command-topic security. Token is reported only as a boolean "set" flag
+    // to avoid leaking the shared secret through the API. The frontend
+    // sends "commandTokenClear=true" to remove it, or a new value to replace.
+    cJSON_AddBoolToObject(mqtt, "commandEnabled", config.mqtt.command_enabled);
+    cJSON_AddBoolToObject(mqtt, "commandTokenSet", strlen(config.mqtt.command_token) > 0);
     cJSON_AddItemToObject(root, "mqtt", mqtt);
 
     // CheckMK config
@@ -384,6 +389,35 @@ esp_err_t post_monitoring_handler_func(httpd_req_t *req)
                 return send_json_error(req, "MQTT TLS client key too long");
             }
             copy_string_field(config.mqtt.tls_keyfile, sizeof(config.mqtt.tls_keyfile), tlsKeyfile->valuestring);
+        }
+
+        // ---- Phase A: command-topic security ----------------------------
+        cJSON *commandEnabled = cJSON_GetObjectItem(mqtt, "commandEnabled");
+        if (commandEnabled != NULL && cJSON_IsBool(commandEnabled))
+        {
+            config.mqtt.command_enabled = cJSON_IsTrue(commandEnabled);
+        }
+
+        cJSON *commandTokenClear = cJSON_GetObjectItem(mqtt, "commandTokenClear");
+        if (commandTokenClear != NULL && cJSON_IsTrue(commandTokenClear))
+        {
+            config.mqtt.command_token[0] = '\0';
+        }
+        cJSON *commandToken = cJSON_GetObjectItem(mqtt, "commandToken");
+        if (commandToken != NULL && cJSON_IsString(commandToken) && strlen(commandToken->valuestring) > 0)
+        {
+            // The command token ends up in plain-text MQTT payloads AND HA
+            // discovery JSON. Restrict the alphabet so it cannot break out
+            // of the JSON string or be confused with topic separators.
+            if (!validateMqttCommandToken(commandToken->valuestring))
+            {
+                cJSON_Delete(root);
+                return send_json_error(req, "MQTT command token invalid (8..63 chars, "
+                                           "allowed: A-Z a-z 0-9 - _ .)");
+            }
+            copy_string_field(config.mqtt.command_token,
+                              sizeof(config.mqtt.command_token),
+                              commandToken->valuestring);
         }
     }
 

--- a/main/mqtt_handler.cpp
+++ b/main/mqtt_handler.cpp
@@ -16,8 +16,15 @@
 #include "esp_crt_bundle.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "freertos/semphr.h"
 #include "cJSON.h"
+#include "lwip/ip4_addr.h"
+#include "ethernet.h"
+#include "radiomoduledetector.h"
+#include "systemclock.h"
 #include "semver.h"
+
+#include <string.h>
 
 static const char *TAG = "MQTT";
 
@@ -26,11 +33,34 @@ static volatile bool mqtt_running = false;
 static volatile TaskHandle_t mqtt_publish_task_handle = NULL;
 static mqtt_config_t current_mqtt_config;
 
+// Latch set by mqtt_handler_trigger_status_publish() so the periodic task
+// emits an immediate cycle out-of-band (after OTA state changes etc.).
+static volatile bool mqtt_publish_request = false;
+
 // Forward declarations
 extern SysInfo* monitoring_get_sysinfo(void);
 extern UpdateCheck* monitoring_get_updatecheck(void);
+extern Ethernet* monitoring_get_ethernet(void);
+extern RadioModuleDetector* monitoring_get_radiomodule(void);
+extern SystemClock* monitoring_get_systemclock(void);
 
 void mqtt_handler_publish_ha_discovery(void);
+static void publish_ota_state(void);
+
+// Helper: map OTA state enum to short string for status topic + HA.
+static const char* ota_state_str(ota_state_t s)
+{
+    switch (s) {
+    case OTA_STATE_CHECKING:    return "checking";
+    case OTA_STATE_STARTING:    return "starting";
+    case OTA_STATE_DOWNLOADING: return "downloading";
+    case OTA_STATE_FLASHING:    return "flashing";
+    case OTA_STATE_SUCCESS:     return "success";
+    case OTA_STATE_FAILED:      return "failed";
+    case OTA_STATE_IDLE:
+    default:                    return "idle";
+    }
+}
 
 static void log_error_if_nonzero(const char *message, int error_code)
 {
@@ -46,10 +76,8 @@ static void perform_factory_reset()
 {
     ESP_LOGI(TAG, "Performing factory reset");
 
-    // Store reset reason before factory reset
     ResetInfo::storeResetReason(RESET_REASON_FACTORY_RESET);
 
-    // Clear NVS namespace for settings
     nvs_handle_t nvs_handle;
     esp_err_t err = nvs_open("settings", NVS_READWRITE, &nvs_handle);
     if (err == ESP_OK) {
@@ -61,19 +89,58 @@ static void perform_factory_reset()
         ESP_LOGE(TAG, "Failed to open NVS settings namespace: %s", esp_err_to_name(err));
     }
 
-    // Give some time for operations to complete
     vTaskDelay(pdMS_TO_TICKS(1000));
 }
 
-static void handle_mqtt_command(const char* command)
+// Validate the command payload against the optional shared-secret token.
+//
+// Semantics:
+//   * If command_token is empty -> always accept (broker ACL must protect).
+//   * Otherwise the payload (trimmed) must equal the configured token.
+//
+// HA integration: when a token is set, the HA discovery config publishes the
+// token as payload_press / payload_install, so buttons "just work" in HA.
+// This means the HA discovery topic contains the token in clear-text - lock
+// down broker ACLs so only the device may publish to <ha_prefix>/#.
+static bool command_token_ok(const char *payload, int payload_len)
 {
-    ESP_LOGI(TAG, "Received MQTT command: %s", command);
+    if (current_mqtt_config.command_token[0] == '\0') {
+        return true;
+    }
+    if (payload == NULL || payload_len <= 0) {
+        return false;
+    }
+    // Compare with length limit
+    size_t expected = strlen(current_mqtt_config.command_token);
+    if ((size_t)payload_len != expected) {
+        return false;
+    }
+    return strncmp(payload, current_mqtt_config.command_token, expected) == 0;
+}
+
+static void handle_mqtt_command(const char* command, const char* payload, int payload_len)
+{
+    ESP_LOGI(TAG, "Received MQTT command: %s (payload %d bytes)", command, payload_len);
+
+    if (!command_token_ok(payload, payload_len)) {
+        ESP_LOGW(TAG, "Command %s rejected: missing/invalid token", command);
+        char msg[96];
+        snprintf(msg, sizeof(msg), "rejected cmd=%s reason=invalid_token", command);
+        mqtt_handler_publish_event("event/command_rejected", msg);
+        return;
+    }
 
     if (strcmp(command, "restart") == 0) {
         ESP_LOGI(TAG, "Restart command received via MQTT");
+        ResetInfo::storeResetReason(RESET_REASON_USER_RESTART);
+        mqtt_handler_publish_event("event/restart", "requested");
+        // Give the broker a moment to flush the publish before we tear down TCP.
+        vTaskDelay(pdMS_TO_TICKS(300));
         esp_restart();
     } else if (strcmp(command, "factory_reset") == 0) {
         ESP_LOGI(TAG, "Factory reset command received via MQTT");
+        mqtt_handler_publish_event("event/factory_reset", "requested");
+        vTaskDelay(pdMS_TO_TICKS(300));
         perform_factory_reset();
         esp_restart();
     } else if (strcmp(command, "update") == 0) {
@@ -89,9 +156,26 @@ static void handle_mqtt_command(const char* command)
             }, "mqtt_ota", 8192, updateCheck, 5, NULL);
             if (created != pdPASS) {
                 ESP_LOGE(TAG, "Failed to create OTA update task");
+                mqtt_handler_publish_event("event/update_failed", "task_create_failed");
+            } else {
+                mqtt_handler_publish_event("event/update_started", "requested");
             }
         } else {
             ESP_LOGW(TAG, "UpdateCheck not available");
+            mqtt_handler_publish_event("event/update_failed", "updatecheck_unavailable");
+        }
+    } else if (strcmp(command, "check_update") == 0) {
+        // Refresh release info from GitHub without flashing.
+        ESP_LOGI(TAG, "Check-update command received via MQTT");
+        UpdateCheck* updateCheck = monitoring_get_updatecheck();
+        if (updateCheck) {
+            xTaskCreate([](void *p) {
+                static_cast<UpdateCheck *>(p)->refresh();
+                vTaskDelete(NULL);
+            }, "mqtt_chkupd", 6144, updateCheck, 4, NULL);
+            mqtt_handler_publish_event("event/check_update", "requested");
+        } else {
+            mqtt_handler_publish_event("event/check_update", "updatecheck_unavailable");
         }
     } else {
         ESP_LOGW(TAG, "Unknown MQTT command: %s", command);
@@ -106,14 +190,20 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
     switch ((esp_mqtt_event_id_t)event_id) {
     case MQTT_EVENT_CONNECTED:
         ESP_LOGI(TAG, "MQTT_EVENT_CONNECTED");
-        // Subscribe to command topic if HA discovery is enabled
-        if (current_mqtt_config.ha_discovery_enabled) {
+        // Birth message: announce we are online (retained so subscribers see
+        // it immediately, even before the next status cycle). The matching
+        // LWT below flips this to "offline" if the connection drops
+        // unexpectedly (power loss, network outage, crash).
+        if (current_mqtt_config.command_enabled || current_mqtt_config.ha_discovery_enabled) {
+            // Subscribe to command topic whenever commands OR HA discovery
+            // are enabled. Previously this was gated on ha_discovery only,
+            // which blocked plain-MQTT users from triggering restart/update.
             char command_topic[128];
             snprintf(command_topic, sizeof(command_topic), "%s/command/#", current_mqtt_config.topic_prefix);
             esp_mqtt_client_subscribe(client, command_topic, 1);
             ESP_LOGI(TAG, "Subscribed to command topic: %s", command_topic);
         }
-        // Publish initial status
+        // Publish initial status (includes online marker)
         mqtt_handler_publish_status();
         // Publish HA discovery config if enabled
         if (current_mqtt_config.ha_discovery_enabled) {
@@ -125,23 +215,20 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
         break;
     case MQTT_EVENT_DATA:
         ESP_LOGI(TAG, "MQTT_EVENT_DATA");
-        // Handle incoming commands
-        // Note: event->topic is NOT null-terminated per ESP-IDF MQTT API.
-        // Use event->topic_len for safe length-bounded operations.
-        if (current_mqtt_config.ha_discovery_enabled) {
+        if (current_mqtt_config.command_enabled) {
+            // Note: event->topic is NOT null-terminated per ESP-IDF MQTT API.
             char command_topic_prefix[128];
             snprintf(command_topic_prefix, sizeof(command_topic_prefix), "%s/command/", current_mqtt_config.topic_prefix);
             size_t prefix_len = strlen(command_topic_prefix);
 
             if ((size_t)event->topic_len > prefix_len &&
                 strncmp(event->topic, command_topic_prefix, prefix_len) == 0) {
-                // Extract the command into a null-terminated buffer
                 char command[64];
                 size_t cmd_len = (size_t)event->topic_len - prefix_len;
                 if (cmd_len >= sizeof(command)) cmd_len = sizeof(command) - 1;
                 memcpy(command, event->topic + prefix_len, cmd_len);
                 command[cmd_len] = '\0';
-                handle_mqtt_command(command);
+                handle_mqtt_command(command, event->data, event->data_len);
             }
         }
         break;
@@ -161,16 +248,108 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
 
 void mqtt_publish_task(void *pvParameters)
 {
+    // Track which OTA state we last published so we emit an out-of-cycle
+    // status update the moment it changes (rather than waiting up to 60 s).
+    ota_state_t last_ota_state = OTA_STATE_IDLE;
+    int last_ota_progress = -1;
+
     while (mqtt_running) {
         mqtt_handler_publish_status();
-        // Publish every 60 seconds, but check mqtt_running more often to exit promptly
-        for (int i = 0; i < 60 && mqtt_running; i++) {
-            vTaskDelay(pdMS_TO_TICKS(1000));
+        publish_ota_state();
+
+        // Re-publish the moment the OTA state changes - users get instant
+        // feedback when an update starts, finishes or fails.
+        OtaSnapshot ota = monitoring_get_updatecheck()
+            ? monitoring_get_updatecheck()->getOtaState() : OtaSnapshot{};
+        if (ota.state != last_ota_state) {
+            mqtt_handler_publish_status();
+            publish_ota_state();
+            // Emit a discrete event for state transitions that integrations
+            // may want to trigger on (notification, automation, ...).
+            if (ota.state == OTA_STATE_SUCCESS) {
+                mqtt_handler_publish_event("event/update_finished", "success");
+            } else if (ota.state == OTA_STATE_FAILED) {
+                char buf[160];
+                snprintf(buf, sizeof(buf), "failed: %s (code=0x%x)",
+                         ota.error_text[0] ? ota.error_text : "unknown",
+                         ota.error_code);
+                mqtt_handler_publish_event("event/update_finished", buf);
+            } else if (ota.state == OTA_STATE_DOWNLOADING && last_ota_state == OTA_STATE_STARTING) {
+                mqtt_handler_publish_event("event/update_downloading", "started");
+            }
+            last_ota_state = ota.state;
+        }
+        // Emit progress events at most every ~5 % to avoid MQTT flooding.
+        if (ota.state == OTA_STATE_DOWNLOADING &&
+            ota.progress_pct >= 0 &&
+            (ota.progress_pct - last_ota_progress >= 5 ||
+             ota.progress_pct < last_ota_progress)) {
+            publish_ota_state();
+            last_ota_progress = ota.progress_pct;
+        } else if (ota.state != OTA_STATE_DOWNLOADING) {
+            last_ota_progress = -1;
+        }
+
+        // Sleep with quick wake-ups so we can react fast to trigger_publish
+        // requests and so the OTA-state-changed detection runs every second
+        // while an update is in flight.
+        int delay_ms = (ota.state == OTA_STATE_IDLE) ? 5000 : 1000;
+        for (int i = 0; i < 12 && mqtt_running; i++) {
+            if (mqtt_publish_request) {
+                mqtt_publish_request = false;
+                break;  // run a fresh publish cycle immediately
+            }
+            int step = delay_ms / 12;
+            if (step < 50) step = 50;
+            vTaskDelay(pdMS_TO_TICKS(step));
         }
     }
     mqtt_publish_task_handle = NULL;
     vTaskDelete(NULL);
 }
+
+void mqtt_handler_trigger_status_publish(void)
+{
+    if (!mqtt_running) return;
+    mqtt_publish_request = true;
+}
+
+void mqtt_handler_publish_event(const char *subtopic, const char *payload)
+{
+    if (!mqtt_running || client == NULL || !subtopic || !payload) {
+        return;
+    }
+    char topic[160];
+    snprintf(topic, sizeof(topic), "%s/%s", current_mqtt_config.topic_prefix, subtopic);
+    // Non-retained, QoS 0: events are transient by definition.
+    esp_mqtt_client_publish(client, topic, payload, 0, 0, 0);
+}
+
+// Publish one value under <prefix>/<subtopic> with retain=1, QoS=0.
+// Defined as a macro so the compiler can inline the snprintf chains.
+#define PUBLISH_STR(subtopic, value) \
+    do { \
+        snprintf(topic, sizeof(topic), "%s/%s", current_mqtt_config.topic_prefix, subtopic); \
+        esp_mqtt_client_publish(client, topic, value, 0, 0, 1); \
+    } while (0)
+
+#define PUBLISH_INT(subtopic, value) \
+    do { \
+        snprintf(payload, sizeof(payload), "%d", (int)(value)); \
+        PUBLISH_STR(subtopic, payload); \
+    } while (0)
+
+#define PUBLISH_UINT64(subtopic, value) \
+    do { \
+        snprintf(payload, sizeof(payload), "%llu", (unsigned long long)(value)); \
+        PUBLISH_STR(subtopic, payload); \
+    } while (0)
+
+#define PUBLISH_DOUBLE(subtopic, value, prec) \
+    do { \
+        snprintf(payload, sizeof(payload), "%.*f", prec, value); \
+        PUBLISH_STR(subtopic, payload); \
+    } while (0)
 
 void mqtt_handler_publish_status(void)
 {
@@ -180,70 +359,144 @@ void mqtt_handler_publish_status(void)
 
     SysInfo* sysInfo = monitoring_get_sysinfo();
     UpdateCheck* updateCheck = monitoring_get_updatecheck();
+    Ethernet* eth = monitoring_get_ethernet();
+    RadioModuleDetector* radio = monitoring_get_radiomodule();
+    SystemClock* clk = monitoring_get_systemclock();
 
     if (sysInfo == NULL) {
         ESP_LOGW(TAG, "SysInfo not available");
         return;
     }
 
-    char topic[128];
-    char payload[64];
+    char topic[160];
+    char payload[96];
 
-    // Helper macro to publish
-    // QoS=0 (fire-and-forget): status data is refreshed every 60s so
-    // occasional loss is acceptable, and QoS=0 is non-blocking which
-    // prevents the publish task from getting stuck waiting for PUBACK.
-    // retain=1 so HA sensors always show the last known value.
-    #define PUBLISH(subtopic, value) \
-        snprintf(topic, sizeof(topic), "%s/%s", current_mqtt_config.topic_prefix, subtopic); \
-        esp_mqtt_client_publish(client, topic, value, 0, 0, 1)
+    // Birth/online marker. The matching LWT (set in mqtt_handler_start)
+    // overwrites this with "offline" if the connection drops uncleanly.
+    PUBLISH_STR("status/online", "online");
 
-    // Helper macro to publish double
-    #define PUBLISH_DOUBLE(subtopic, value, prec) \
-        snprintf(payload, sizeof(payload), "%.*f", prec, value); \
-        PUBLISH(subtopic, payload)
-
-    // Helper macro to publish int
-    #define PUBLISH_INT(subtopic, value) \
-        snprintf(payload, sizeof(payload), "%d", value); \
-        PUBLISH(subtopic, payload)
-
-    // Helper macro to publish string
-    #define PUBLISH_STR(subtopic, value) \
-        PUBLISH(subtopic, value)
-
-    // Status Page Topics
+    // ---- Identity ---------------------------------------------------------
     PUBLISH_STR("status/serial", sysInfo->getSerialNumber());
     PUBLISH_STR("status/version", sysInfo->getCurrentVersion());
+    PUBLISH_STR("status/board_revision", sysInfo->getBoardRevisionString());
 
+    // ---- Update info ------------------------------------------------------
     if (updateCheck) {
-        const char* latest = updateCheck->getLatestVersion();
+        ReleaseInfo rel = updateCheck->getReleaseInfo();
+        const char* latest = rel.valid ? rel.version : "n/a";
         PUBLISH_STR("status/latest_version", latest);
-
-        bool updateAvailable = (strcmp(latest, "n/a") != 0 && compareVersions(latest, sysInfo->getCurrentVersion()) > 0);
+        bool updateAvailable = rel.valid &&
+            compareVersions(latest, sysInfo->getCurrentVersion()) > 0;
         PUBLISH_STR("status/update_available", updateAvailable ? "true" : "false");
     }
 
+    // ---- System metrics ---------------------------------------------------
     PUBLISH_DOUBLE("status/cpu_usage", sysInfo->getCpuUsage(), 1);
     PUBLISH_DOUBLE("status/memory_usage", sysInfo->getMemoryUsage(), 1);
     PUBLISH_DOUBLE("status/supply_voltage", sysInfo->getSupplyVoltage(), 2);
     PUBLISH_DOUBLE("status/temperature", sysInfo->getTemperature(), 1);
-    PUBLISH_INT("status/uptime", (int)sysInfo->getUptimeSeconds());
-    PUBLISH_STR("status/board_revision", sysInfo->getBoardRevisionString());
+    PUBLISH_UINT64("status/uptime", sysInfo->getUptimeSeconds());
 
     // Uptime formatted
-    uint32_t days, hours, minutes;
-    uint64_t uptime_s = sysInfo->getUptimeSeconds();
-    days = uptime_s / 86400;
-    uptime_s %= 86400;
-    hours = uptime_s / 3600;
-    uptime_s %= 3600;
-    minutes = uptime_s / 60;
+    {
+        uint64_t uptime_s = sysInfo->getUptimeSeconds();
+        uint32_t days  = (uint32_t)(uptime_s / 86400); uptime_s %= 86400;
+        uint32_t hours = (uint32_t)(uptime_s / 3600);  uptime_s %= 3600;
+        uint32_t mins  = (uint32_t)(uptime_s / 60);
+        snprintf(payload, sizeof(payload), "%lu d, %lu h, %lu m",
+                 (unsigned long)days, (unsigned long)hours, (unsigned long)mins);
+        PUBLISH_STR("status/uptime_text", payload);
+    }
 
-    snprintf(payload, sizeof(payload), "%lu d, %lu h, %lu m", (unsigned long)days, (unsigned long)hours, (unsigned long)minutes);
-    PUBLISH_STR("status/uptime_text", payload);
+    // Heap details - useful for memory leak monitoring in HA graphs.
+    {
+        multi_heap_info_t info;
+        heap_caps_get_info(&info, MALLOC_CAP_INTERNAL);
+        PUBLISH_UINT64("status/free_heap", info.total_free_bytes);
+        PUBLISH_UINT64("status/min_free_heap", esp_get_minimum_free_heap_size());
+    }
 
+    // Reset reason (combines app-level stored reason + ESP hardware reason).
+    if (sysInfo->getResetReason()) {
+        PUBLISH_STR("status/last_reset_reason", sysInfo->getResetReason());
+    }
+
+    // ---- Ethernet ---------------------------------------------------------
+    if (eth) {
+        PUBLISH_STR("status/eth_connected", eth->isConnected() ? "true" : "false");
+        PUBLISH_INT("status/eth_link_speed", eth->getLinkSpeedMbps());
+        if (eth->getDuplexMode()) {
+            PUBLISH_STR("status/eth_duplex", eth->getDuplexMode());
+        }
+        ip4_addr_t ip, nm, gw, dns1, dns2;
+        eth->getNetworkSettings(&ip, &nm, &gw, &dns1, &dns2);
+        snprintf(payload, sizeof(payload), IPSTR, IP2STR(&ip));
+        PUBLISH_STR("status/ip_address", payload);
+        snprintf(payload, sizeof(payload), IPSTR, IP2STR(&gw));
+        PUBLISH_STR("status/gateway", payload);
+    }
+
+    // ---- Radio module -----------------------------------------------------
+    if (radio) {
+        const char* type = "none";
+        switch (radio->getRadioModuleType()) {
+            case RADIO_MODULE_HM_MOD_RPI_PCB: type = "HM-MOD-RPI-PCB"; break;
+            case RADIO_MODULE_RPI_RF_MOD:     type = "RPI-RF-MOD";     break;
+            case RADIO_MODULE_HMIP_RFUSB:     type = "HmIP-RFUSB";     break;
+            case RADIO_MODULE_NONE:           type = "none";           break;
+            default:                          type = "unknown";        break;
+        }
+        PUBLISH_STR("status/radio_module_type", type);
+        if (radio->getSerial()) {
+            PUBLISH_STR("status/radio_module_serial", radio->getSerial());
+        }
+        const uint8_t* fw = radio->getFirmwareVersion();
+        if (fw && (fw[0] || fw[1] || fw[2])) {
+            snprintf(payload, sizeof(payload), "%d.%d.%d", fw[0], fw[1], fw[2]);
+            PUBLISH_STR("status/radio_module_firmware", payload);
+        }
+    }
+
+    // ---- System clock / NTP sync state -----------------------------------
+    if (clk) {
+        struct timeval sync = clk->getLastSyncTime();
+        bool synced = (sync.tv_sec > 0);
+        PUBLISH_STR("status/ntp_synced", synced ? "true" : "false");
+        if (synced) {
+            PUBLISH_UINT64("status/last_ntp_sync", (unsigned long long)sync.tv_sec);
+        } else {
+            PUBLISH_STR("status/last_ntp_sync", "0");
+        }
+    }
 }
+
+// Publish the OTA state + progress under dedicated subtopics so HA can render
+// a progress bar and automations can trigger on completion.
+static void publish_ota_state(void)
+{
+    if (!mqtt_running || client == NULL) return;
+    UpdateCheck* updateCheck = monitoring_get_updatecheck();
+    if (!updateCheck) return;
+
+    OtaSnapshot ota = updateCheck->getOtaState();
+    char topic[160];
+    char payload[64];
+
+    PUBLISH_STR("status/ota_state", ota_state_str(ota.state));
+    if (ota.progress_pct >= 0) {
+        PUBLISH_INT("status/ota_progress", ota.progress_pct);
+    } else {
+        PUBLISH_STR("status/ota_progress", "-1");
+    }
+    if (ota.state == OTA_STATE_FAILED && ota.error_text[0]) {
+        PUBLISH_STR("status/ota_error", ota.error_text);
+    }
+}
+
+#undef PUBLISH_STR
+#undef PUBLISH_INT
+#undef PUBLISH_UINT64
+#undef PUBLISH_DOUBLE
 
 void mqtt_handler_publish_ha_discovery(void)
 {
@@ -258,6 +511,14 @@ void mqtt_handler_publish_ha_discovery(void)
 
     ESP_LOGI(TAG, "Publishing Home Assistant discovery configs");
 
+    // The token callers must send as payload_press / payload_install so HA
+    // buttons work even when a command_token is configured. Empty token ->
+    // plain "restart" etc. (legacy behaviour).
+    const char* restart_payload  = current_mqtt_config.command_token[0] ? current_mqtt_config.command_token : "restart";
+    const char* reset_payload    = current_mqtt_config.command_token[0] ? current_mqtt_config.command_token : "factory_reset";
+    const char* update_payload   = current_mqtt_config.command_token[0] ? current_mqtt_config.command_token : "update";
+    const char* chkupd_payload   = current_mqtt_config.command_token[0] ? current_mqtt_config.command_token : "check_update";
+
     // Device Info
     cJSON *device = cJSON_CreateObject();
     char identifiers[64];
@@ -267,14 +528,9 @@ void mqtt_handler_publish_ha_discovery(void)
     cJSON_AddStringToObject(device, "model", "HB-RF-ETH-ng");
     cJSON_AddStringToObject(device, "manufacturer", "Xerolux");
     cJSON_AddStringToObject(device, "sw_version", sysInfo->getCurrentVersion());
-    // Use board revision as hardware version
     cJSON_AddStringToObject(device, "hw_version", sysInfo->getBoardRevisionString());
-    // configuration_url
-    // Since we don't know the IP/hostname easily here without including settings/ethernet,
-    // we skip config_url or use a generic one if possible.
-    // Actually we can leave it out.
 
-    // Helper lambda to publish discovery config
+    // Helper: publish a sensor / binary_sensor / button / update config.
     auto publish_config = [&](const char* component, const char* object_id, const char* name,
                               const char* device_class, const char* state_class,
                               const char* unit_of_measurement, const char* value_template,
@@ -287,13 +543,8 @@ void mqtt_handler_publish_ha_discovery(void)
         snprintf(unique_id, sizeof(unique_id), "%s_%s", identifiers, object_id);
         cJSON_AddStringToObject(root, "unique_id", unique_id);
 
-        char state_topic[128];
+        char state_topic[160];
         snprintf(state_topic, sizeof(state_topic), "%s/status/%s", current_mqtt_config.topic_prefix, object_id);
-
-        // Adjust state topic if value_template is generic (not matching specific status topic)
-        // Here we assume object_id matches the subtopic in status/... unless we need logic
-        // But our status topics are flat: prefix/status/cpu_usage
-
         cJSON_AddStringToObject(root, "state_topic", state_topic);
 
         if (device_class) cJSON_AddStringToObject(root, "device_class", device_class);
@@ -306,46 +557,55 @@ void mqtt_handler_publish_ha_discovery(void)
         cJSON_AddItemToObject(root, "device", cJSON_Duplicate(device, 1));
 
         char *json_str = cJSON_PrintUnformatted(root);
-
         char topic[256];
         snprintf(topic, sizeof(topic), "%s/%s/hb-rf-eth-%s/%s/config",
                  current_mqtt_config.ha_discovery_prefix, component, sysInfo->getSerialNumber(), object_id);
-
         esp_mqtt_client_publish(client, topic, json_str, 0, 1, 1);
-
         free(json_str);
         cJSON_Delete(root);
     };
 
-    // CPU Usage
+    // ---- Sensors: system metrics ----------------------------------------
     publish_config("sensor", "cpu_usage", "CPU Usage", NULL, "measurement", "%", NULL, "diagnostic", "mdi:cpu-64-bit");
-
-    // Memory Usage
     publish_config("sensor", "memory_usage", "Memory Usage", NULL, "measurement", "%", NULL, "diagnostic", "mdi:memory");
-
-    // Supply Voltage
+    publish_config("sensor", "free_heap", "Free Heap", "data_size", "measurement", "B", NULL, "diagnostic", "mdi:memory");
     publish_config("sensor", "supply_voltage", "Supply Voltage", "voltage", "measurement", "V", NULL, "diagnostic", NULL);
-
-    // Temperature
     publish_config("sensor", "temperature", "Temperature", "temperature", "measurement", "°C", NULL, "diagnostic", NULL);
-
-    // Uptime (seconds)
     publish_config("sensor", "uptime", "Uptime", "duration", "total_increasing", "s", NULL, "diagnostic", "mdi:clock-outline");
-
-    // Uptime (text)
     publish_config("sensor", "uptime_text", "Uptime (Text)", NULL, NULL, NULL, NULL, "diagnostic", "mdi:clock-outline");
+    publish_config("sensor", "version", "Current Version", NULL, NULL, NULL, NULL, "diagnostic", "mdi:package-variant");
+    publish_config("sensor", "latest_version", "Latest Version", NULL, NULL, NULL, NULL, "diagnostic", "mdi:package-up");
+    publish_config("sensor", "board_revision", "Board Revision", NULL, NULL, NULL, NULL, "diagnostic", "mdi:expansion-card");
 
-    // Update Available
-    // Binary sensor for update available
-    // For binary sensor, we need payload_on="true", payload_off="false"
+    // ---- Sensors: network -----------------------------------------------
+    publish_config("binary_sensor", "online", "Online", "connectivity", NULL, NULL,
+                   "{{ value_json }}", "diagnostic", "mdi:lan-connect");
+    publish_config("binary_sensor", "eth_connected", "Ethernet Link", "connectivity", NULL, NULL,
+                   "{{ value_json }}", "diagnostic", "mdi:ethernet");
+    publish_config("sensor", "eth_link_speed", "Ethernet Speed", "data_rate", "measurement", "Mbit/s", NULL, "diagnostic", "mdi:speedometer");
+    publish_config("sensor", "ip_address", "IP Address", NULL, NULL, NULL, NULL, "diagnostic", "mdi:ip");
+
+    // ---- Sensors: radio module ------------------------------------------
+    publish_config("sensor", "radio_module_type", "Radio Module", NULL, NULL, NULL, NULL, "diagnostic", "mdi:radio-tower");
+    publish_config("sensor", "radio_module_serial", "Radio Serial", NULL, NULL, NULL, NULL, "diagnostic", "mdi:barcode");
+    publish_config("sensor", "radio_module_firmware", "Radio Firmware", NULL, NULL, NULL, NULL, "diagnostic", "mdi:chip");
+
+    // ---- Sensors: time / NTP --------------------------------------------
+    publish_config("binary_sensor", "ntp_synced", "NTP Synced", NULL, NULL, NULL,
+                   "{{ value_json }}", "diagnostic", "mdi:clock-check");
+
+    // ---- Sensors: OTA ----------------------------------------------------
+    publish_config("sensor", "ota_progress", "OTA Progress", NULL, "measurement", "%", NULL, "diagnostic", "mdi:progress-download");
+
+    // ---- Update Available (binary) --------------------------------------
     {
-         cJSON *root = cJSON_CreateObject();
+        cJSON *root = cJSON_CreateObject();
         cJSON_AddStringToObject(root, "name", "Update Available");
         char unique_id[128];
         snprintf(unique_id, sizeof(unique_id), "%s_update_available", identifiers);
         cJSON_AddStringToObject(root, "unique_id", unique_id);
 
-        char state_topic[128];
+        char state_topic[160];
         snprintf(state_topic, sizeof(state_topic), "%s/status/update_available", current_mqtt_config.topic_prefix);
         cJSON_AddStringToObject(root, "state_topic", state_topic);
 
@@ -360,78 +620,55 @@ void mqtt_handler_publish_ha_discovery(void)
         char topic[256];
         snprintf(topic, sizeof(topic), "%s/binary_sensor/hb-rf-eth-%s/update_available/config",
                  current_mqtt_config.ha_discovery_prefix, sysInfo->getSerialNumber());
-
         esp_mqtt_client_publish(client, topic, json_str, 0, 1, 1);
         free(json_str);
         cJSON_Delete(root);
     }
 
-    // Current Version
-    publish_config("sensor", "version", "Current Version", NULL, NULL, NULL, NULL, "diagnostic", "mdi:package-variant");
-
-    // Latest Version
-    publish_config("sensor", "latest_version", "Latest Version", NULL, NULL, NULL, NULL, "diagnostic", "mdi:package-up");
-
-    // Board Revision
-    publish_config("sensor", "board_revision", "Board Revision", NULL, NULL, NULL, NULL, "diagnostic", "mdi:expansion-card");
-
-    // HA Buttons - Restart Button
-    {
+    // ---- Buttons ---------------------------------------------------------
+    auto publish_button = [&](const char* object_id, const char* name,
+                              const char* command, const char* payload_str,
+                              const char* device_class = "restart",
+                              const char* icon = nullptr) {
         cJSON *root = cJSON_CreateObject();
-        cJSON_AddStringToObject(root, "name", "Restart");
+        cJSON_AddStringToObject(root, "name", name);
         char unique_id[128];
-        snprintf(unique_id, sizeof(unique_id), "%s_restart", identifiers);
+        snprintf(unique_id, sizeof(unique_id), "%s_%s", identifiers, object_id);
         cJSON_AddStringToObject(root, "unique_id", unique_id);
 
-        char command_topic[128];
-        snprintf(command_topic, sizeof(command_topic), "%s/command/restart", current_mqtt_config.topic_prefix);
+        char command_topic[160];
+        snprintf(command_topic, sizeof(command_topic), "%s/command/%s",
+                 current_mqtt_config.topic_prefix, command);
         cJSON_AddStringToObject(root, "command_topic", command_topic);
+        cJSON_AddStringToObject(root, "payload_press", payload_str);
 
         cJSON_AddStringToObject(root, "entity_category", "config");
-        cJSON_AddStringToObject(root, "device_class", "restart");
-        cJSON_AddStringToObject(root, "payload_press", "restart");
+        if (device_class) cJSON_AddStringToObject(root, "device_class", device_class);
+        if (icon) cJSON_AddStringToObject(root, "icon", icon);
 
         cJSON_AddItemToObject(root, "device", cJSON_Duplicate(device, 1));
 
         char *json_str = cJSON_PrintUnformatted(root);
         char topic[256];
-        snprintf(topic, sizeof(topic), "%s/button/hb-rf-eth-%s/restart/config",
-                 current_mqtt_config.ha_discovery_prefix, sysInfo->getSerialNumber());
-
+        snprintf(topic, sizeof(topic), "%s/button/hb-rf-eth-%s/%s/config",
+                 current_mqtt_config.ha_discovery_prefix, sysInfo->getSerialNumber(), object_id);
         esp_mqtt_client_publish(client, topic, json_str, 0, 1, 1);
         free(json_str);
         cJSON_Delete(root);
+    };
+
+    // When commands are disabled, the device ignores every payload - so we
+    // must NOT publish buttons that look clickable. Hide them by skipping.
+    if (current_mqtt_config.command_enabled) {
+        publish_button("restart", "Restart", "restart", restart_payload, "restart", "mdi:restart");
+        publish_button("factory_reset", "Factory Reset", "factory_reset", reset_payload, "restart", "mdi:lock-reset");
+        publish_button("check_update", "Check for Update", "check_update", chkupd_payload, "update", "mdi:refresh");
     }
 
-    // HA Buttons - Factory Reset Button
-    {
-        cJSON *root = cJSON_CreateObject();
-        cJSON_AddStringToObject(root, "name", "Factory Reset");
-        char unique_id[128];
-        snprintf(unique_id, sizeof(unique_id), "%s_factory_reset", identifiers);
-        cJSON_AddStringToObject(root, "unique_id", unique_id);
-
-        char command_topic[128];
-        snprintf(command_topic, sizeof(command_topic), "%s/command/factory_reset", current_mqtt_config.topic_prefix);
-        cJSON_AddStringToObject(root, "command_topic", command_topic);
-
-        cJSON_AddStringToObject(root, "entity_category", "config");
-        cJSON_AddStringToObject(root, "device_class", "restart");
-        cJSON_AddStringToObject(root, "payload_press", "factory_reset");
-
-        cJSON_AddItemToObject(root, "device", cJSON_Duplicate(device, 1));
-
-        char *json_str = cJSON_PrintUnformatted(root);
-        char topic[256];
-        snprintf(topic, sizeof(topic), "%s/button/hb-rf-eth-%s/factory_reset/config",
-                 current_mqtt_config.ha_discovery_prefix, sysInfo->getSerialNumber());
-
-        esp_mqtt_client_publish(client, topic, json_str, 0, 1, 1);
-        free(json_str);
-        cJSON_Delete(root);
-    }
-
-    // HA Update Entity - uses update entity type for firmware updates
+    // ---- HA Update entity -----------------------------------------------
+    // Combines "current vs latest version" with an Install button that
+    // triggers OTA via MQTT. Uses latest_version as state so the entity shows
+    // the version number directly. enabled_by_default follows command_enabled.
     {
         cJSON *root = cJSON_CreateObject();
         cJSON_AddStringToObject(root, "name", "Firmware Update");
@@ -439,20 +676,22 @@ void mqtt_handler_publish_ha_discovery(void)
         snprintf(unique_id, sizeof(unique_id), "%s_firmware_update", identifiers);
         cJSON_AddStringToObject(root, "unique_id", unique_id);
 
-        char command_topic[128];
-        snprintf(command_topic, sizeof(command_topic), "%s/command/update", current_mqtt_config.topic_prefix);
-        cJSON_AddStringToObject(root, "command_topic", command_topic);
-
-        char state_topic[128];
+        char state_topic[160];
         snprintf(state_topic, sizeof(state_topic), "%s/status/latest_version", current_mqtt_config.topic_prefix);
         cJSON_AddStringToObject(root, "state_topic", state_topic);
 
+        char command_topic[160];
+        snprintf(command_topic, sizeof(command_topic), "%s/command/update", current_mqtt_config.topic_prefix);
+        cJSON_AddStringToObject(root, "command_topic", command_topic);
+        cJSON_AddStringToObject(root, "payload_install", update_payload);
+
         cJSON_AddStringToObject(root, "entity_category", "config");
         cJSON_AddStringToObject(root, "device_class", "firmware");
-        cJSON_AddStringToObject(root, "payload_install", "update");
-
-        // Add latest version as state
         cJSON_AddStringToObject(root, "value_template", "{{ value_json }}");
+        cJSON_AddStringToObject(root, "latest_version_template", "{{ value_json }}");
+        if (!current_mqtt_config.command_enabled) {
+            cJSON_AddBoolToObject(root, "enabled_by_default", false);
+        }
 
         cJSON_AddItemToObject(root, "device", cJSON_Duplicate(device, 1));
 
@@ -460,7 +699,6 @@ void mqtt_handler_publish_ha_discovery(void)
         char topic[256];
         snprintf(topic, sizeof(topic), "%s/update/hb-rf-eth-%s/firmware_update/config",
                  current_mqtt_config.ha_discovery_prefix, sysInfo->getSerialNumber());
-
         esp_mqtt_client_publish(client, topic, json_str, 0, 1, 1);
         free(json_str);
         cJSON_Delete(root);
@@ -495,7 +733,7 @@ esp_err_t mqtt_handler_start(const mqtt_config_t *config)
     memcpy(&current_mqtt_config, config, sizeof(mqtt_config_t));
 
     esp_mqtt_client_config_t mqtt_cfg = {};
-    mqtt_cfg.broker.address.uri = NULL; // We construct URI or use host/port
+    mqtt_cfg.broker.address.uri = NULL;
     mqtt_cfg.broker.address.hostname = current_mqtt_config.server;
     mqtt_cfg.broker.address.port = current_mqtt_config.port;
     mqtt_cfg.broker.address.transport = MQTT_TRANSPORT_OVER_TCP;
@@ -519,9 +757,6 @@ esp_err_t mqtt_handler_start(const mqtt_config_t *config)
         }
     }
 
-    // Limit TCP connect timeout so stop/restart completes quickly even when
-    // the broker is unreachable, and space out reconnect attempts to avoid
-    // hammering the network stack (which also causes CCU proxy slowdowns).
     mqtt_cfg.network.timeout_ms = 2000;
     mqtt_cfg.network.reconnect_timeout_ms = 30000;
 
@@ -530,6 +765,19 @@ esp_err_t mqtt_handler_start(const mqtt_config_t *config)
     }
     if (strlen(current_mqtt_config.password) > 0) {
         mqtt_cfg.credentials.authentication.password = current_mqtt_config.password;
+    }
+
+    // Last Will & Testament: broker publishes "offline" on the status/online
+    // topic if the client drops without sending DISCONNECT. Retained so
+    // subscribers see the device as offline even after a HA restart.
+    {
+        char lwt_topic[160];
+        snprintf(lwt_topic, sizeof(lwt_topic), "%s/status/online", current_mqtt_config.topic_prefix);
+        mqtt_cfg.session.last_will.topic = lwt_topic;
+        mqtt_cfg.session.last_will.msg = "offline";
+        mqtt_cfg.session.last_will.msg_len = 7;
+        mqtt_cfg.session.last_will.qos = 1;
+        mqtt_cfg.session.last_will.retain = 1;
     }
 
     client = esp_mqtt_client_init(&mqtt_cfg);
@@ -548,11 +796,10 @@ esp_err_t mqtt_handler_start(const mqtt_config_t *config)
 
     mqtt_running = true;
 
-    // Start publishing task
-    // xTaskCreate requires a non-volatile TaskHandle_t*; assign to volatile global afterwards.
-    // Priority 4: below httpd (5) so periodic publishing doesn't delay HTTP responses
+    // 6 KB stack: the publish task now formats many snprintf strings + an
+    // Ethernet IP lookup; 4 KB was getting close to the limit.
     TaskHandle_t pub_handle = NULL;
-    xTaskCreate(mqtt_publish_task, "mqtt_publish", 4096, NULL, 4, &pub_handle);
+    xTaskCreate(mqtt_publish_task, "mqtt_publish", 6144, NULL, 4, &pub_handle);
     mqtt_publish_task_handle = pub_handle;
 
     return ESP_OK;
@@ -567,26 +814,14 @@ esp_err_t mqtt_handler_stop(void)
     ESP_LOGI(TAG, "Stopping MQTT client");
     mqtt_running = false;
 
-    // Stop the MQTT client BEFORE waiting for the publish task.
-    // If QoS>0 publishes are in flight, esp_mqtt_client_stop() disconnects
-    // the underlying transport, causing any pending publish to return
-    // immediately. Without this, the publish task can be stuck waiting for
-    // a PUBACK from an unreachable broker, making the force-delete below
-    // fire while the task is inside lwIP - corrupting network state.
     if (client) {
         esp_mqtt_client_stop(client);
     }
 
-    // Wait for publish task to exit on its own (max 3 seconds).
-    // With QoS=0 publishes and the client already stopped, this should
-    // complete within one loop iteration.
     for (int i = 0; i < 30 && mqtt_publish_task_handle != NULL; i++) {
         vTaskDelay(pdMS_TO_TICKS(100));
     }
 
-    // Use a local snapshot of the handle to avoid a race where the task
-    // sets mqtt_publish_task_handle=NULL between our NULL check and
-    // vTaskDelete() call.
     TaskHandle_t pub_handle = (TaskHandle_t)mqtt_publish_task_handle;
     if (pub_handle != NULL) {
         ESP_LOGW(TAG, "MQTT publish task did not exit cleanly, force deleting");

--- a/main/updatecheck.cpp
+++ b/main/updatecheck.cpp
@@ -238,6 +238,15 @@ bool UpdateCheck::refresh()
         return false;
     }
 
+    // Reflect "checking" state for MQTT / WebUI. Only flip the state if no
+    // OTA is currently running so we never clobber OTA_DOWNLOADING etc.
+    if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+        if (_otaState == OTA_STATE_IDLE) {
+            _setOtaStateLocked(OTA_STATE_CHECKING);
+        }
+        xSemaphoreGive(_stateMutex);
+    }
+
     ReleaseInfo fresh = {};
     bool ok = _doFetch(&fresh);
     int64_t now = esp_timer_get_time() / 1000;
@@ -264,6 +273,11 @@ bool UpdateCheck::refresh()
                 _latestVersion[sizeof(_latestVersion) - 1] = 0;
             }
         }
+        // Clear CHECKING state unless an OTA ran in parallel (very unlikely
+        // but defensive). Reset back to IDLE so MQTT can show "idle".
+        if (_otaState == OTA_STATE_CHECKING) {
+            _setOtaStateLocked(OTA_STATE_IDLE);
+        }
         xSemaphoreGive(_stateMutex);
     }
 
@@ -277,6 +291,51 @@ bool UpdateCheck::isFetchInProgress()
     // xSemaphoreGetMutexHolder returns the owning task handle or NULL. We
     // don't care who owns it - any non-NULL value means "busy".
     return xSemaphoreGetMutexHolder(_fetchLock) != NULL;
+}
+
+void UpdateCheck::_setOtaStateLocked(ota_state_t state)
+{
+    _otaState = state;
+    if (state == OTA_STATE_IDLE) {
+        _otaProgress = -1;
+        _otaErrorText[0] = '\0';
+        _otaErrorCode = 0;
+    }
+}
+
+void UpdateCheck::_setOtaProgressLocked(int percent)
+{
+    if (percent < 0) percent = 0;
+    if (percent > 100) percent = 100;
+    _otaProgress = percent;
+}
+
+void UpdateCheck::_setOtaErrorLocked(int code, const char* text)
+{
+    _otaErrorCode = code;
+    if (text) {
+        strncpy(_otaErrorText, text, sizeof(_otaErrorText) - 1);
+        _otaErrorText[sizeof(_otaErrorText) - 1] = '\0';
+    } else {
+        _otaErrorText[0] = '\0';
+    }
+}
+
+OtaSnapshot UpdateCheck::getOtaState()
+{
+    OtaSnapshot snap;
+    if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+        snap.state = _otaState;
+        snap.progress_pct = _otaProgress;
+        snap.error_code = _otaErrorCode;
+        strncpy(snap.error_text, _otaErrorText, sizeof(snap.error_text) - 1);
+        snap.error_text[sizeof(snap.error_text) - 1] = '\0';
+        xSemaphoreGive(_stateMutex);
+    } else {
+        snap.state = OTA_STATE_IDLE;
+        snap.progress_pct = -1;
+    }
+    return snap;
 }
 
 bool UpdateCheck::_doFetch(ReleaseInfo *out)
@@ -441,11 +500,23 @@ void UpdateCheck::performOnlineUpdate()
     if (!info.valid || info.downloadUrl[0] == 0) {
         ESP_LOGE(TAG, "No firmware asset URL available (latest: %s)",
                  info.valid ? info.version : "n/a");
+        if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+            _setOtaStateLocked(OTA_STATE_FAILED);
+            _setOtaErrorLocked(ESP_ERR_NOT_FOUND, "no firmware asset URL");
+            xSemaphoreGive(_stateMutex);
+        }
         return;
     }
 
     ESP_LOGI(TAG, "Starting OTA update from %s", info.downloadUrl);
     _statusLED->setState(LED_STATE_BLINK_FAST);
+
+    // Mark "starting" so MQTT / WebUI can show the new state immediately.
+    if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+        _setOtaStateLocked(OTA_STATE_STARTING);
+        _setOtaProgressLocked(0);
+        xSemaphoreGive(_stateMutex);
+    }
 
     esp_http_client_config_t config = {};
     configure_ota_http_client(config, info.downloadUrl);
@@ -455,13 +526,88 @@ void UpdateCheck::performOnlineUpdate()
     esp_https_ota_config_t ota_config = {};
     ota_config.http_config = &config;
 
-    esp_err_t ret = esp_https_ota(&ota_config);
+    // Use the advanced esp_https_ota API so we can report real progress to
+    // MQTT / WebUI. The simple esp_https_ota(&ota_config) call is a thin
+    // wrapper around these steps but hides all intermediate state.
+    esp_https_ota_handle_t ota_handle = NULL;
+    esp_err_t ret = esp_https_ota_begin(&ota_config, &ota_handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "esp_https_ota_begin failed: %s", esp_err_to_name(ret));
+        if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+            _setOtaStateLocked(OTA_STATE_FAILED);
+            _setOtaErrorLocked(ret, esp_err_to_name(ret));
+            xSemaphoreGive(_stateMutex);
+        }
+        ResetInfo::storeResetReason(RESET_REASON_UPDATE_FAILED);
+        _statusLED->setState(LED_STATE_ON);
+        return;
+    }
+
+    int image_size = esp_https_ota_get_image_size(ota_handle);
+    ESP_LOGI(TAG, "OTA image size: %d bytes", image_size);
+
+    if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+        _setOtaStateLocked(OTA_STATE_DOWNLOADING);
+        xSemaphoreGive(_stateMutex);
+    }
+
+    // Loop until the full image has been streamed into the OTA partition.
+    // perform() pulls one buffer chunk at a time and writes it to flash.
+    while (true) {
+        ret = esp_https_ota_perform(ota_handle);
+        if (ret != ESP_ERR_HTTPS_OTA_IN_PROGRESS) {
+            break;
+        }
+        if (image_size > 0) {
+            int read = esp_https_ota_get_image_len_read(ota_handle);
+            int pct = (int)((uint64_t)read * 100 / (uint64_t)image_size);
+            if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+                _setOtaProgressLocked(pct);
+                xSemaphoreGive(_stateMutex);
+            }
+        }
+    }
+
+    bool complete = esp_https_ota_is_complete_data_received(ota_handle);
+    if (ret != ESP_OK || !complete) {
+        ESP_LOGE(TAG, "OTA perform failed: ret=%s complete=%d",
+                 esp_err_to_name(ret), complete ? 1 : 0);
+        const char* err_text = (ret == ESP_OK) ? "download incomplete" : esp_err_to_name(ret);
+        int err_code = (ret == ESP_OK) ? ESP_ERR_HTTPS_OTA_INCOMPLETE : ret;
+        if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+            _setOtaStateLocked(OTA_STATE_FAILED);
+            _setOtaErrorLocked(err_code, err_text);
+            xSemaphoreGive(_stateMutex);
+        }
+        esp_https_ota_abort(ota_handle);
+        ResetInfo::storeResetReason(RESET_REASON_UPDATE_FAILED);
+        _statusLED->setState(LED_STATE_ON);
+        return;
+    }
+
+    // All bytes streamed - now validate and switch the boot partition.
+    if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+        _setOtaStateLocked(OTA_STATE_FLASHING);
+        _setOtaProgressLocked(100);
+        xSemaphoreGive(_stateMutex);
+    }
+
+    ret = esp_https_ota_finish(ota_handle);
     if (ret == ESP_OK) {
         ESP_LOGI(TAG, "OTA Update successful, restarting...");
+        if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+            _setOtaStateLocked(OTA_STATE_SUCCESS);
+            xSemaphoreGive(_stateMutex);
+        }
         ResetInfo::storeResetReason(RESET_REASON_FIRMWARE_UPDATE);
         full_system_restart();
     } else {
-        ESP_LOGE(TAG, "OTA Update failed: %s", esp_err_to_name(ret));
+        ESP_LOGE(TAG, "esp_https_ota_finish failed: %s", esp_err_to_name(ret));
+        if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+            _setOtaStateLocked(OTA_STATE_FAILED);
+            _setOtaErrorLocked(ret, esp_err_to_name(ret));
+            xSemaphoreGive(_stateMutex);
+        }
         ResetInfo::storeResetReason(RESET_REASON_UPDATE_FAILED);
         _statusLED->setState(LED_STATE_ON);
     }

--- a/main/validation.cpp
+++ b/main/validation.cpp
@@ -704,3 +704,26 @@ bool validateIPv6Address(const char *ipv6)
 
     return true;
 }
+
+bool validateMqttCommandToken(const char *token)
+{
+    // The command token is published verbatim inside HA discovery JSON
+    // payloads AND compared byte-by-byte against incoming MQTT payloads.
+    // Restrict the alphabet so the token is unambiguous in any context.
+    if (token == NULL || token[0] == '\0') {
+        return false;
+    }
+    size_t len = strlen(token);
+    if (len < 8 || len > 63) {
+        return false;
+    }
+    for (size_t i = 0; i < len; i++) {
+        char c = token[i];
+        bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                  (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.';
+        if (!ok) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/test/test_monitoring_validation/test_monitoring_validation.cpp
+++ b/test/test_monitoring_validation/test_monitoring_validation.cpp
@@ -1,8 +1,9 @@
 /*
  *  test_monitoring_validation.cpp
  *
- *  Unit tests for monitoring (MQTT/SNMP) validation
- *  Verifies validateServerAddress and validateSnmpCommunity
+ *  Unit tests for monitoring (MQTT) validation
+ *  - validateServerAddress (broker host / IP / port)
+ *  - validateMqttCommandToken (Phase A: shared-secret for MQTT commands)
  *
  *  These tests use the PlatformIO Unity test framework.
  */
@@ -132,128 +133,76 @@ void test_mqtt_invalid_too_long(void)
 }
 
 // ==========================================
-// Valid SNMP Community Tests
+// Valid Command Token Tests (Phase A)
 // ==========================================
 
-void test_snmp_valid_simple(void)
+void test_token_valid_alphanumeric(void)
 {
-    // Simple community strings
-    TEST_ASSERT_TRUE(validateSnmpCommunity("public"));
-    TEST_ASSERT_TRUE(validateSnmpCommunity("private"));
-    TEST_ASSERT_TRUE(validateSnmpCommunity("community"));
+    TEST_ASSERT_TRUE(validateMqttCommandToken("MyToken123"));
+    TEST_ASSERT_TRUE(validateMqttCommandToken("abcdefgh"));
+    TEST_ASSERT_TRUE(validateMqttCommandToken("ABCDEFGH"));
 }
 
-void test_snmp_valid_alphanumeric(void)
+void test_token_valid_with_separators(void)
 {
-    // Alphanumeric community strings
-    TEST_ASSERT_TRUE(validateSnmpCommunity("public123"));
-    TEST_ASSERT_TRUE(validateSnmpCommunity("MyComm456"));
-    TEST_ASSERT_TRUE(validateSnmpCommunity("ABC123xyz"));
+    // - _ . allowed in any position
+    TEST_ASSERT_TRUE(validateMqttCommandToken("my-token-123"));
+    TEST_ASSERT_TRUE(validateMqttCommandToken("my_token_456"));
+    TEST_ASSERT_TRUE(validateMqttCommandToken("my.token.789"));
+    TEST_ASSERT_TRUE(validateMqttCommandToken("a.b-c_d"));
 }
 
-void test_snmp_valid_with_hyphen(void)
+void test_token_valid_boundary_lengths(void)
 {
-    // With hyphens in middle
-    TEST_ASSERT_TRUE(validateSnmpCommunity("my-community"));
-    TEST_ASSERT_TRUE(validateSnmpCommunity("snmp-read-only"));
-    TEST_ASSERT_TRUE(validateSnmpCommunity("test-123"));
-}
-
-void test_snmp_valid_with_underscore(void)
-{
-    // With underscores in middle
-    TEST_ASSERT_TRUE(validateSnmpCommunity("my_community"));
-    TEST_ASSERT_TRUE(validateSnmpCommunity("snmp_read_only"));
-    TEST_ASSERT_TRUE(validateSnmpCommunity("test_123"));
-}
-
-void test_snmp_valid_mixed(void)
-{
-    // Mixed valid characters
-    TEST_ASSERT_TRUE(validateSnmpCommunity("my-snmp_community123"));
-    TEST_ASSERT_TRUE(validateSnmpCommunity("ABC_123-xyz"));
+    // Min length is 8, max is 63
+    TEST_ASSERT_TRUE(validateMqttCommandToken("12345678"));
+    TEST_ASSERT_TRUE(validateMqttCommandToken("1234567-"));  // separator at end is OK
+    char t[64];
+    memset(t, 'a', 63);
+    t[63] = '\0';
+    TEST_ASSERT_TRUE(validateMqttCommandToken(t));
 }
 
 // ==========================================
-// Invalid SNMP Community Tests
+// Invalid Command Token Tests (Phase A)
 // ==========================================
 
-void test_snmp_invalid_empty(void)
+void test_token_invalid_empty(void)
 {
-    // Empty or NULL
-    TEST_ASSERT_FALSE(validateSnmpCommunity(""));
-    TEST_ASSERT_FALSE(validateSnmpCommunity(NULL));
+    TEST_ASSERT_FALSE(validateMqttCommandToken(""));
+    TEST_ASSERT_FALSE(validateMqttCommandToken(NULL));
 }
 
-void test_snmp_invalid_start_with_hyphen(void)
+void test_token_invalid_too_short(void)
 {
-    // Starts with hyphen
-    TEST_ASSERT_FALSE(validateSnmpCommunity("-community"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("-public"));
+    // < 8 chars rejected (must resist trivial brute force and accidental
+    // single-char tokens like "-")
+    TEST_ASSERT_FALSE(validateMqttCommandToken("short"));
+    TEST_ASSERT_FALSE(validateMqttCommandToken("1234567"));
+    TEST_ASSERT_FALSE(validateMqttCommandToken("-"));
 }
 
-void test_snmp_invalid_end_with_hyphen(void)
+void test_token_invalid_too_long(void)
 {
-    // Ends with hyphen
-    TEST_ASSERT_FALSE(validateSnmpCommunity("community-"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("public-"));
+    // > 63 chars rejected (NVS key/value size + sane upper bound)
+    char t[70];
+    memset(t, 'a', 69);
+    t[69] = '\0';
+    TEST_ASSERT_FALSE(validateMqttCommandToken(t));
 }
 
-void test_snmp_invalid_start_with_underscore(void)
+void test_token_invalid_special_chars(void)
 {
-    // Starts with underscore
-    TEST_ASSERT_FALSE(validateSnmpCommunity("_community"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("_public"));
-}
-
-void test_snmp_invalid_end_with_underscore(void)
-{
-    // Ends with underscore
-    TEST_ASSERT_FALSE(validateSnmpCommunity("community_"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("public_"));
-}
-
-void test_snmp_invalid_special_chars(void)
-{
-    // Invalid special characters
-    TEST_ASSERT_FALSE(validateSnmpCommunity("public@123"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("public#snmp"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("public.snmp"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("public!"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("public$"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("public%"));
-}
-
-void test_snmp_invalid_spaces(void)
-{
-    // Spaces not allowed
-    TEST_ASSERT_FALSE(validateSnmpCommunity("public snmp"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("my community"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity(" public"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("public "));
-}
-
-void test_snmp_invalid_too_long(void)
-{
-    // String too long (MAX_SNMP_COMMUNITY_LENGTH = 32)
-    char longComm[50];
-    memset(longComm, 'a', sizeof(longComm) - 1);
-    longComm[sizeof(longComm) - 1] = '\0';
-    TEST_ASSERT_FALSE(validateSnmpCommunity(longComm));
-}
-
-void test_snmp_invalid_only_hyphens(void)
-{
-    // Only hyphens (starts/ends with hyphen)
-    TEST_ASSERT_FALSE(validateSnmpCommunity("-"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("---"));
-}
-
-void test_snmp_invalid_only_underscores(void)
-{
-    // Only underscores (starts/ends with underscore)
-    TEST_ASSERT_FALSE(validateSnmpCommunity("_"));
-    TEST_ASSERT_FALSE(validateSnmpCommunity("___"));
+    // Anything outside [A-Za-z0-9-_.] must be rejected so the token is
+    // unambiguous inside JSON payloads, MQTT topics and plain text.
+    TEST_ASSERT_FALSE(validateMqttCommandToken("token!123"));
+    TEST_ASSERT_FALSE(validateMqttCommandToken("token with space"));
+    TEST_ASSERT_FALSE(validateMqttCommandToken("token\"quote"));
+    TEST_ASSERT_FALSE(validateMqttCommandToken("token/slash"));
+    TEST_ASSERT_FALSE(validateMqttCommandToken("token#hash"));
+    TEST_ASSERT_FALSE(validateMqttCommandToken("token@at"));
+    TEST_ASSERT_FALSE(validateMqttCommandToken("token$colon:"));
+    TEST_ASSERT_FALSE(validateMqttCommandToken("token+plus"));
 }
 
 // ==========================================
@@ -280,23 +229,15 @@ void setup()
     RUN_TEST(test_mqtt_invalid_ipv6);
     RUN_TEST(test_mqtt_invalid_too_long);
 
-    // SNMP Community Tests
-    RUN_TEST(test_snmp_valid_simple);
-    RUN_TEST(test_snmp_valid_alphanumeric);
-    RUN_TEST(test_snmp_valid_with_hyphen);
-    RUN_TEST(test_snmp_valid_with_underscore);
-    RUN_TEST(test_snmp_valid_mixed);
+    // MQTT Command Token Tests (Phase A)
+    RUN_TEST(test_token_valid_alphanumeric);
+    RUN_TEST(test_token_valid_with_separators);
+    RUN_TEST(test_token_valid_boundary_lengths);
 
-    RUN_TEST(test_snmp_invalid_empty);
-    RUN_TEST(test_snmp_invalid_start_with_hyphen);
-    RUN_TEST(test_snmp_invalid_end_with_hyphen);
-    RUN_TEST(test_snmp_invalid_start_with_underscore);
-    RUN_TEST(test_snmp_invalid_end_with_underscore);
-    RUN_TEST(test_snmp_invalid_special_chars);
-    RUN_TEST(test_snmp_invalid_spaces);
-    RUN_TEST(test_snmp_invalid_too_long);
-    RUN_TEST(test_snmp_invalid_only_hyphens);
-    RUN_TEST(test_snmp_invalid_only_underscores);
+    RUN_TEST(test_token_invalid_empty);
+    RUN_TEST(test_token_invalid_too_short);
+    RUN_TEST(test_token_invalid_too_long);
+    RUN_TEST(test_token_invalid_special_chars);
 
     UNITY_END();
 }

--- a/webui/src/locales/de.js
+++ b/webui/src/locales/de.js
@@ -315,6 +315,16 @@ export default {
       haDiscoveryPrefix: 'Discovery Präfix',
       haDiscoveryPrefixHelp: 'Standard: homeassistant',
       serverRequired: 'Bitte einen MQTT-Server angeben, wenn MQTT aktiviert ist.',
+      commands: {
+        title: 'Kommando-Topics',
+        enableHelp: 'Erlaubt Fernsteuerung (Restart, Factory-Reset, OTA) über MQTT. Ohne Token oder Broker-ACL kann jeder Client im Netz das Gerät steuern.',
+        token: 'Kommando-Token',
+        tokenPlaceholder: 'optional – gemeinsames Geheimnis',
+        tokenHelp: 'Wenn gesetzt, muss der Payload eines Kommandos genau diesem Token entsprechen. Erlaubt: A-Z a-z 0-9 - _ .',
+        tokenPresent: '✓ Vorhanden – neu eingeben zum Ersetzen',
+        clear: 'Löschen',
+        aclHint: 'Hinweis: Ohne Broker-ACL + Token kann jeder MQTT-Client das Gerät neustarten oder ein Update auslösen. Bitte am Broker eine ACL setzen, die Publish-Rechte auf das Kommando-Topic nur dem Gerät gibt.'
+      },
       tls: {
         title: 'TLS / SSL',
         enable: 'TLS aktivieren',

--- a/webui/src/locales/en.js
+++ b/webui/src/locales/en.js
@@ -315,6 +315,16 @@ export default {
       haDiscoveryPrefix: 'Discovery Prefix',
       haDiscoveryPrefixHelp: 'Default: homeassistant',
       serverRequired: 'Please enter an MQTT server address when MQTT is enabled.',
+      commands: {
+        title: 'Command Topics',
+        enableHelp: 'Allows remote control (restart, factory reset, OTA) over MQTT. Without a token or broker ACL, any client on the network can control the device.',
+        token: 'Command Token',
+        tokenPlaceholder: 'optional – shared secret',
+        tokenHelp: 'When set, command payloads must exactly match this token. Allowed: A-Z a-z 0-9 - _ .',
+        tokenPresent: '✓ Present – enter new value to replace',
+        clear: 'Clear',
+        aclHint: 'Note: without a broker ACL + token, any MQTT client can restart the device or trigger an OTA. Please configure an ACL on the broker that grants publish rights on the command topic only to this device.'
+      },
       tls: {
         title: 'TLS / SSL',
         enable: 'Enable TLS',

--- a/webui/src/monitoring.vue
+++ b/webui/src/monitoring.vue
@@ -234,6 +234,47 @@
                 </div>
               </Transition>
             </div>
+
+            <div class="col-12 mt-4">
+              <div class="command-section">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                  <div>
+                    <h4>{{ t('monitoring.mqtt.commands.title') }}</h4>
+                    <div class="form-text mb-0">{{ t('monitoring.mqtt.commands.enableHelp') }}</div>
+                  </div>
+                  <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" v-model="mqttConfig.commandEnabled">
+                  </div>
+                </div>
+
+                <Transition name="expand">
+                  <div v-if="mqttConfig.commandEnabled">
+                    <div v-if="!mqttConfig.tlsEnable" class="alert-warning-soft mt-3">
+                      <div>{{ t('monitoring.mqtt.commands.aclHint') }}</div>
+                    </div>
+
+                    <div class="mt-3">
+                      <label class="form-label">{{ t('monitoring.mqtt.commands.token') }}</label>
+                      <div class="d-flex gap-2 align-items-center">
+                        <BFormInput v-model="mqttConfig.commandToken" type="text"
+                          :placeholder="t('monitoring.mqtt.commands.tokenPlaceholder')" />
+                        <button v-if="mqttConfig.commandTokenSet && !mqttConfig.commandToken"
+                                type="button" class="btn-link-danger"
+                                @click="clearCommandToken">
+                          {{ t('monitoring.mqtt.commands.clear') }}
+                        </button>
+                      </div>
+                      <div class="form-text">
+                        <span v-if="mqttConfig.commandTokenSet" class="cert-present-hint">
+                                          {{ t('monitoring.mqtt.commands.tokenPresent') }}
+                                        </span>
+                        {{ t('monitoring.mqtt.commands.tokenHelp') }}
+                      </div>
+                    </div>
+                  </div>
+                </Transition>
+              </div>
+            </div>
           </div>
         </div>
       </Transition>
@@ -275,7 +316,7 @@ const diagnosticBusy = ref({ checkmk: false, mqtt: false })
 const hasChanges = ref(false)
 const originalConfig = ref('')
 
-const tlsClearFlags = ref({ tlsCaCertsClear: false, tlsCertfileClear: false, tlsKeyfileClear: false })
+const tlsClearFlags = ref({ tlsCaCertsClear: false, tlsCertfileClear: false, tlsKeyfileClear: false, commandTokenClear: false })
 const pemFeedback = ref({ tlsCaCerts: null, tlsCertfile: null, tlsKeyfile: null })
 
 const MAX_PEM_BYTES = 8 * 1024
@@ -358,6 +399,12 @@ function clearCert(field, clearFlag, setFlag) {
   pemFeedback.value[field] = null
 }
 
+function clearCommandToken() {
+  mqttConfig.value.commandToken = ''
+  mqttConfig.value.commandTokenSet = false
+  tlsClearFlags.value.commandTokenClear = true
+}
+
 const mtlsInconsistent = computed(() => {
   const hasCert = !!(mqttConfig.value.tlsCertfile || mqttConfig.value.tlsCertfileSet)
   const hasKey  = !!(mqttConfig.value.tlsKeyfile  || mqttConfig.value.tlsKeyfileSet)
@@ -410,14 +457,15 @@ const saveConfig = async () => {
 
   saving.value = true
   try {
-    const { tlsCaCertsSet, tlsCertfileSet, tlsKeyfileSet, ...mqttPayload } = mqttConfig.value
+    const { tlsCaCertsSet, tlsCertfileSet, tlsKeyfileSet, commandTokenSet, ...mqttPayload } = mqttConfig.value
     mqttPayload.tlsCaCertsClear  = tlsClearFlags.value.tlsCaCertsClear
     mqttPayload.tlsCertfileClear = tlsClearFlags.value.tlsCertfileClear
     mqttPayload.tlsKeyfileClear  = tlsClearFlags.value.tlsKeyfileClear
+    mqttPayload.commandTokenClear = tlsClearFlags.value.commandTokenClear
 
     await monitoringStore.save({ checkmk: checkmkConfig.value, mqtt: mqttPayload })
     await monitoringStore.load()
-    tlsClearFlags.value = { tlsCaCertsClear: false, tlsCertfileClear: false, tlsKeyfileClear: false }
+    tlsClearFlags.value = { tlsCaCertsClear: false, tlsCertfileClear: false, tlsKeyfileClear: false, commandTokenClear: false }
 
     uiStore.pushToast({ type: 'success', title: t('common.success'), message: t('monitoring.saveSuccess') })
     hasChanges.value = false
@@ -611,7 +659,12 @@ const runDiagnostic = async (target) => {
   margin-top: 16px;
 }
 
-.tls-section h4 {
+.command-section {
+  margin-top: 16px;
+}
+
+.tls-section h4,
+.command-section h4 {
   font-size: 1rem;
   margin: 0 0 4px;
 }

--- a/webui/src/stores.js
+++ b/webui/src/stores.js
@@ -397,7 +397,11 @@ export const useMonitoringStore = defineStore('monitoring', {
       tlsKeyfile: '',
       tlsCaCertsSet: false,
       tlsCertfileSet: false,
-      tlsKeyfileSet: false
+      tlsKeyfileSet: false,
+      // Phase A: command-topic security
+      commandEnabled: true,
+      commandToken: '',
+      commandTokenSet: false
     },
     diagnostics: {
       checkmk: null,


### PR DESCRIPTION
…ed status topics

Phase A (security + basics):
- Add MQTT Last Will & Testament (status/online -> 'offline' on unclean disconnect) plus matching birth message so HA reliably detects offline state
- Decouple command subscription from HA discovery via new mqtt.command_enabled flag (default true). Plain-MQTT users without HA discovery can now use restart/update/etc. commands.
- Add optional shared-secret command token (mqtt.command_token). When set, every command payload must match the token exactly. Token charset restricted to A-Z a-z 0-9 - _ . (8..63 chars), validated by validateMqttCommandToken() in validation.{h,cpp}.
- Token is published verbatim as HA payload_press/payload_install so HA buttons keep working when a token is configured. Document broker ACL requirement in TROUBLESHOOTING.md + WIKI.md.
- WebUI gains 'Command Topics' section under Monitoring -> MQTT with enable toggle, token field, set/clear semantics, and ACL warning banner.

Phase B (feature parity):
- Replace blocking esp_https_ota() in UpdateCheck::performOnlineUpdate() with the advanced esp_https_ota_begin/perform/finish/abort API and report real download progress (0..100%) via a new OTA state machine: idle / checking / starting / downloading / flashing / success / failed
- Expose UpdateCheck::getOtaState() returning OtaSnapshot {state, progress, error_code, error_text} guarded by the existing _stateMutex.
- MQTT publishes new topics: status/ota_state, status/ota_progress, status/ota_error and transient events under event/* (update_started, update_downloading, update_finished, command_rejected, ...).
- Publish task reacts to OTA state changes within ~1s instead of the 60s default cycle and emits discrete progress events every ~5%.
- Extend status topics with Ethernet (link/speed/duplex/IP/gateway), radio module (type/serial/firmware), reset reason, heap details, and NTP sync state. New providers registered via monitoring_set_providers() in main.cpp.
- Add 'check_update' command (refresh release info without flashing).
- Bump publish task stack 4 KB -> 6 KB for the richer snprintf chain.

API/WebUI:
- GET/POST /api/monitoring expose commandEnabled, commandTokenSet/Clear.
- Token is write-only (never returned by GET) like the existing password field. openapi.yaml + API.md updated accordingly.
- Add validateMqttCommandToken() tests; remove obsolete SNMP tests that referenced a non-existent function.

Note: this is a source-level change only; ESP-IDF is not available on this host so the build has not been compiled locally. WebUI vite build passes.

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
