### PR TITLE
fix(webui): complete i18n translations for 8 locales

### DIFF
--- a/webui/src/locales/cs.js
+++ b/webui/src/locales/cs.js
@@ -129,7 +129,8 @@ export default {
     // System Settings
     systemSettings: 'Nastavení systému',
     ledBrightness: 'Jas LED',
-    updateLedBlink: 'Blikat LED při aktualizacích',
+    ledPrograms: 'Programy LED',
+    ledProgramsHelp: 'Přizpůsobte chování LED pro různé stavy systému.',
     checkUpdates: 'Zkontrolovat aktualizace',
     allowPrerelease: 'Povolit dřívější aktualizace (Beta/Alpha)',
     language: 'Jazyk',
@@ -239,6 +240,12 @@ export default {
     installedVersion: 'Nainstalovaná verze',
     versionInfo: 'Modernizovaný fork v2.2.0-Beta.7 od Xerolux (2025) - Založeno na původní práci Alexandra Reinerta.',
     updateAvailable: 'Je k dispozici aktualizace na verzi {latestVersion}.',
+    upToDate: 'Firmware je aktuální',
+    checkNow: 'Zkontrolovat nyní',
+    checking: 'Kontrola...',
+    checkSuccess: 'Kontrola aktualizace úspěšná',
+    checkFailed: 'Kontrola aktualizace selhala',
+    lastCheck: 'Naposledy zkontrolováno',
     newVersionAvailable: 'Nová verze {version} je k dispozici!',
     viewUpdate: 'Zobrazit',
     onlineUpdate: 'Aktualizovat online',
@@ -306,6 +313,16 @@ export default {
       haDiscoveryEnabled: 'Home Assistant Discovery',
       haDiscoveryPrefix: 'Discovery Prefix',
       haDiscoveryPrefixHelp: 'Výchozí: homeassistant',
+      commands: {
+        title: 'Příkazová témata',
+        enableHelp: 'Umožňuje vzdálené ovládání (restart, tovární nastavení, OTA) přes MQTT. Bez tokenu nebo ACL brokeru může zařízení ovládat jakýkoli klient v síti.',
+        token: 'Příkazový token',
+        tokenPlaceholder: 'volitelné – sdílené tajemství',
+        tokenHelp: 'Pokud je nastaven, musí se obsah příkazu přesně shodovat s tímto tokenem. Povoleno: A-Z a-z 0-9 - _ .',
+        tokenPresent: '✓ Přítomen – zadejte novou hodnotu pro nahrazení',
+        clear: 'Vymazat',
+        aclHint: 'Poznámka: bez ACL brokeru + tokenu může jakýkoli MQTT klient restartovat zařízení nebo spustit OTA. Nastavte prosím na brokeru ACL, která uděluje práva publikování do příkazového tématu pouze tomuto zařízení.',
+      },
       serverRequired: 'Please enter an MQTT server address when MQTT is enabled.',
       tls: {
         title: 'TLS / SSL',
@@ -451,6 +468,12 @@ export default {
     empty: 'Zatím žádné záznamy v protokolu.'
   },
 
+  // Privacy
+  privacy: {
+    title: 'Soukromí',
+    updateCheck: 'Automatické aktualizace a kontroly firmwaru se připojují k serveru xerolux.de. Vaše IP adresa je přenášena za účelem kontroly dostupnosti nových verzí.',
+  },
+
   // Changelog
   changelog: {
     title: 'Seznam změn',
@@ -459,7 +482,6 @@ export default {
     error: 'Nepodařilo se načíst seznam změn',
     fetchError: 'Nepodařilo se načíst seznam změn. Zkontrolujte prosím své připojení k internetu.',
     retry: 'Zkusit znovu',
-    checkFailed: 'Kontrola aktualizace selhala',
     close: 'Zavřít',
     viewOnGithub: 'Zobrazit na GitHubu'
   }

--- a/webui/src/locales/es.js
+++ b/webui/src/locales/es.js
@@ -129,7 +129,8 @@ export default {
     // System Settings
     systemSettings: 'Configuración del sistema',
     ledBrightness: 'Brillo del LED',
-    updateLedBlink: 'Parpadear LED en actualizaciones',
+    ledPrograms: 'Programas LED',
+    ledProgramsHelp: 'Personaliza el comportamiento de los LED para los distintos estados del sistema.',
     checkUpdates: 'Buscar actualizaciones',
     allowPrerelease: 'Permitir actualizaciones tempranas (Beta/Alpha)',
     language: 'Idioma',
@@ -239,6 +240,12 @@ export default {
     installedVersion: 'Versión instalada',
     versionInfo: 'Fork modernizado v2.2.0-Beta.7 por Xerolux (2025) - Basado en el trabajo original de Alexander Reinert.',
     updateAvailable: 'Hay una actualización disponible para la versión {latestVersion}.',
+    upToDate: 'El firmware está actualizado',
+    checkNow: 'Comprobar ahora',
+    checking: 'Comprobando...',
+    checkSuccess: 'Comprobación de actualización correcta',
+    checkFailed: 'Error al comprobar actualización',
+    lastCheck: 'Última comprobación',
     newVersionAvailable: '¡Nueva versión {version} disponible!',
     viewUpdate: 'Ver',
     onlineUpdate: 'Actualizar en línea',
@@ -306,6 +313,16 @@ export default {
       haDiscoveryEnabled: 'Descubrimiento de Home Assistant',
       haDiscoveryPrefix: 'Prefijo de descubrimiento',
       haDiscoveryPrefixHelp: 'Predeterminado: homeassistant',
+      commands: {
+        title: 'Topics de comando',
+        enableHelp: 'Permite el control remoto (reinicio, restablecimiento de fábrica, OTA) a través de MQTT. Sin token ni ACL del broker, cualquier cliente de la red puede controlar el dispositivo.',
+        token: 'Token de comando',
+        tokenPlaceholder: 'opcional – secreto compartido',
+        tokenHelp: 'Si se define, la carga útil del comando debe coincidir exactamente con este token. Permitido: A-Z a-z 0-9 - _ .',
+        tokenPresent: '✓ Presente – introduzca un nuevo valor para reemplazar',
+        clear: 'Borrar',
+        aclHint: 'Nota: sin ACL del broker + token, cualquier cliente MQTT puede reiniciar el dispositivo o iniciar una OTA. Configure en el broker una ACL que conceda permisos de publicación en el topic de comando solo a este dispositivo.',
+      },
       serverRequired: 'Por favor, introduzca una dirección de servidor MQTT cuando MQTT esté habilitado.',
       tls: {
         title: 'TLS / SSL',
@@ -451,6 +468,12 @@ export default {
     empty: 'Aún no hay entradas de registro.'
   },
 
+  // Privacy
+  privacy: {
+    title: 'Privacidad',
+    updateCheck: 'Las actualizaciones automáticas y las comprobaciones de firmware se conectan al servidor xerolux.de. Se transmite su dirección IP para comprobar la disponibilidad de nuevas versiones.',
+  },
+
   // Changelog
   changelog: {
     title: 'Registro de cambios',
@@ -459,7 +482,6 @@ export default {
     error: 'Error al cargar el registro de cambios',
     fetchError: 'No se pudo obtener el registro de cambios. Por favor verifique su conexión a internet.',
     retry: 'Reintentar',
-    checkFailed: 'Error al comprobar actualización',
     close: 'Cerrar',
     viewOnGithub: 'Ver en GitHub'
   }

--- a/webui/src/locales/fr.js
+++ b/webui/src/locales/fr.js
@@ -129,7 +129,8 @@ export default {
     // System Settings
     systemSettings: 'Paramètres système',
     ledBrightness: 'Luminosité LED',
-    updateLedBlink: 'LED clignotante lors des mises à jour',
+    ledPrograms: 'Programmes LED',
+    ledProgramsHelp: 'Personnalisez le comportement des LED pour différents états du système.',
     checkUpdates: 'Vérifier les mises à jour',
     allowPrerelease: 'Autoriser les mises à jour anticipées (Beta/Alpha)',
     language: 'Langue',
@@ -239,6 +240,12 @@ export default {
     installedVersion: 'Version installée',
     versionInfo: 'Fork modernisé v2.2.0-Beta.7 par Xerolux (2025) - Basé sur le travail original d\'Alexander Reinert.',
     updateAvailable: 'Une mise à jour vers la version {latestVersion} est disponible.',
+    upToDate: 'Le firmware est à jour',
+    checkNow: 'Vérifier maintenant',
+    checking: 'Vérification...',
+    checkSuccess: 'Vérification de mise à jour réussie',
+    checkFailed: 'Échec de la vérification de mise à jour',
+    lastCheck: 'Dernière vérification',
     newVersionAvailable: 'Nouvelle version {version} disponible !',
     viewUpdate: 'Voir',
     onlineUpdate: 'Mise à jour en ligne',
@@ -306,6 +313,16 @@ export default {
       haDiscoveryEnabled: 'Découverte Home Assistant',
       haDiscoveryPrefix: 'Préfixe de découverte',
       haDiscoveryPrefixHelp: 'Par défaut : homeassistant',
+      commands: {
+        title: 'Topics de commande',
+        enableHelp: 'Permet le contrôle à distance (redémarrage, réinitialisation, OTA) via MQTT. Sans jeton ni ACL de broker, tout client du réseau peut contrôler l\'appareil.',
+        token: 'Jeton de commande',
+        tokenPlaceholder: 'optionnel – secret partagé',
+        tokenHelp: 'Si défini, la charge utile d\'une commande doit correspondre exactement à ce jeton. Autorisé : A-Z a-z 0-9 - _ .',
+        tokenPresent: '✓ Présent – saisir une nouvelle valeur pour remplacer',
+        clear: 'Effacer',
+        aclHint: 'Remarque : sans ACL de broker + jeton, tout client MQTT peut redémarrer l\'appareil ou déclencher une OTA. Veuillez configurer sur le broker une ACL qui n\'accorde les droits de publication sur le topic de commande qu\'à cet appareil.',
+      },
       serverRequired: 'Veuillez entrer une adresse de serveur MQTT lorsque MQTT est activé.',
       tls: {
         title: 'TLS / SSL',
@@ -451,6 +468,12 @@ export default {
     empty: 'Aucune entrée de journal pour le moment.'
   },
 
+  // Privacy
+  privacy: {
+    title: 'Confidentialité',
+    updateCheck: 'Les mises à jour automatiques et les vérifications du firmware se connectent au serveur xerolux.de. Votre adresse IP est transmise pour vérifier la disponibilité de nouvelles versions.',
+  },
+
   // Changelog
   changelog: {
     title: 'Journal des modifications',
@@ -459,7 +482,6 @@ export default {
     error: 'Échec du chargement du journal des modifications',
     fetchError: 'Impossible de récupérer le journal des modifications. Veuillez vérifier votre connexion Internet.',
     retry: 'Réessayer',
-    checkFailed: 'Échec de la vérification de mise à jour',
     close: 'Fermer',
     viewOnGithub: 'Voir sur GitHub'
   }

--- a/webui/src/locales/it.js
+++ b/webui/src/locales/it.js
@@ -129,7 +129,8 @@ export default {
     // System Settings
     systemSettings: 'Impostazioni di Sistema',
     ledBrightness: 'Luminosità LED',
-    updateLedBlink: 'LED lampeggiante per aggiornamenti',
+    ledPrograms: 'Programmi LED',
+    ledProgramsHelp: 'Personalizza il comportamento dei LED per i diversi stati del sistema.',
     checkUpdates: 'Controlla aggiornamenti',
     allowPrerelease: 'Consenti aggiornamenti anticipati (Beta/Alpha)',
     language: 'Lingua',
@@ -239,6 +240,12 @@ export default {
     installedVersion: 'Versione Installata',
     versionInfo: 'Fork modernizzato v2.2.0-Beta.7 di Xerolux (2025) - Basato sul lavoro originale di Alexander Reinert.',
     updateAvailable: 'È disponibile un aggiornamento alla versione {latestVersion}.',
+    upToDate: 'Il firmware è aggiornato',
+    checkNow: 'Controlla ora',
+    checking: 'Controllo...',
+    checkSuccess: 'Verifica aggiornamento riuscita',
+    checkFailed: 'Verifica aggiornamento non riuscita',
+    lastCheck: 'Ultimo controllo',
     newVersionAvailable: 'Nuova versione {version} disponibile!',
     viewUpdate: 'Vedi',
     onlineUpdate: 'Aggiorna Online',
@@ -306,6 +313,16 @@ export default {
       haDiscoveryEnabled: 'Home Assistant Discovery',
       haDiscoveryPrefix: 'Prefisso Discovery',
       haDiscoveryPrefixHelp: 'Predefinito: homeassistant',
+      commands: {
+        title: 'Topic dei comandi',
+        enableHelp: 'Consente il controllo remoto (riavvio, ripristino di fabbrica, OTA) tramite MQTT. Senza token o ACL del broker, qualsiasi client sulla rete può controllare il dispositivo.',
+        token: 'Token comando',
+        tokenPlaceholder: 'opzionale – segreto condiviso',
+        tokenHelp: 'Se impostato, il payload del comando deve corrispondere esattamente a questo token. Consentiti: A-Z a-z 0-9 - _ .',
+        tokenPresent: '✓ Presente – inserisci un nuovo valore per sostituire',
+        clear: 'Cancella',
+        aclHint: 'Nota: senza ACL del broker + token, qualsiasi client MQTT può riavviare il dispositivo o avviare un OTA. Configurare sul broker una ACL che conceda i diritti di pubblicazione sul topic dei comandi solo a questo dispositivo.',
+      },
       serverRequired: 'Inserire un indirizzo server MQTT quando MQTT è abilitato.',
       tls: {
         title: 'TLS / SSL',
@@ -451,6 +468,12 @@ export default {
     empty: 'Nessuna voce di log ancora.'
   },
 
+  // Privacy
+  privacy: {
+    title: 'Privacy',
+    updateCheck: 'Gli aggiornamenti automatici e i controlli del firmware si connettono al server xerolux.de. Il tuo indirizzo IP viene trasmesso per verificare la disponibilità di nuove versioni.',
+  },
+
   // Changelog
   changelog: {
     title: 'Registro delle Modifiche',
@@ -459,7 +482,6 @@ export default {
     error: 'Impossibile caricare il registro delle modifiche',
     fetchError: 'Impossibile recuperare il registro delle modifiche. Controlla la tua connessione internet.',
     retry: 'Riprova',
-    checkFailed: 'Verifica aggiornamento non riuscita',
     close: 'Chiudi',
     viewOnGithub: 'Vedi su GitHub'
   }

--- a/webui/src/locales/nl.js
+++ b/webui/src/locales/nl.js
@@ -129,7 +129,8 @@ export default {
     // System Settings
     systemSettings: 'Systeeminstellingen',
     ledBrightness: 'LED Helderheid',
-    updateLedBlink: 'LED knipperen bij updates',
+    ledPrograms: 'LED-programma\'s',
+    ledProgramsHelp: 'Pas het LED-gedrag aan voor verschillende systeemstatussen.',
     checkUpdates: 'Controleren op updates',
     allowPrerelease: 'Vroege updates toestaan (Beta/Alpha)',
     language: 'Taal',
@@ -239,6 +240,12 @@ export default {
     installedVersion: 'Geïnstalleerde versie',
     versionInfo: 'Gemoderniseerde fork v2.2.0-Beta.7 door Xerolux (2025) - Gebaseerd op het originele werk van Alexander Reinert.',
     updateAvailable: 'Een update naar versie {latestVersion} is beschikbaar.',
+    upToDate: 'Firmware is up-to-date',
+    checkNow: 'Nu controleren',
+    checking: 'Controleren...',
+    checkSuccess: 'Update-controle geslaagd',
+    checkFailed: 'Update-controle mislukt',
+    lastCheck: 'Laatst gecontroleerd',
     newVersionAvailable: 'Nieuwe versie {version} is beschikbaar!',
     viewUpdate: 'Bekijken',
     onlineUpdate: 'Online Updaten',
@@ -306,6 +313,16 @@ export default {
       haDiscoveryEnabled: 'Home Assistant Discovery',
       haDiscoveryPrefix: 'Discovery Prefix',
       haDiscoveryPrefixHelp: 'Standaard: homeassistant',
+      commands: {
+        title: 'Commando-topics',
+        enableHelp: 'Maakt afstandsbediening (herstart, fabrieksreset, OTA) via MQTT mogelijk. Zonder token of broker-ACL kan elke client in het netwerk het apparaat besturen.',
+        token: 'Commando-token',
+        tokenPlaceholder: 'optioneel – gedeeld geheim',
+        tokenHelp: 'Indien ingesteld moet de payload van een commando exact overeenkomen met dit token. Toegestaan: A-Z a-z 0-9 - _ .',
+        tokenPresent: '✓ Aanwezig – voer een nieuwe waarde in om te vervangen',
+        clear: 'Wissen',
+        aclHint: 'Let op: zonder broker-ACL + token kan elke MQTT-client het apparaat herstarten of een OTA starten. Configureer op de broker een ACL die publicatierechten op het commando-topic alleen aan dit apparaat verleent.',
+      },
       serverRequired: 'Voer een MQTT-serveradres in wanneer MQTT is ingeschakeld.',
       tls: {
         title: 'TLS / SSL',
@@ -451,6 +468,12 @@ export default {
     empty: 'Nog geen logboekvermeldingen.'
   },
 
+  // Privacy
+  privacy: {
+    title: 'Privacy',
+    updateCheck: 'Automatische updates en firmwarecontroles maken verbinding met de server xerolux.de. Daarbij wordt uw IP-adres verzonden om te controleren op nieuwe versies.',
+  },
+
   // Changelog
   changelog: {
     title: 'Wijzigingslogboek',
@@ -459,7 +482,6 @@ export default {
     error: 'Kon wijzigingslogboek niet laden',
     fetchError: 'Kon wijzigingslogboek niet ophalen. Controleer uw internetverbinding.',
     retry: 'Opnieuw proberen',
-    checkFailed: 'Update-controle mislukt',
     close: 'Sluiten',
     viewOnGithub: 'Bekijken op GitHub'
   }

--- a/webui/src/locales/no.js
+++ b/webui/src/locales/no.js
@@ -129,7 +129,8 @@ export default {
     // System Settings
     systemSettings: 'Systeminnstillinger',
     ledBrightness: 'LED-lysstyrke',
-    updateLedBlink: 'Blink LED for oppdateringer',
+    ledPrograms: 'LED-programmer',
+    ledProgramsHelp: 'Tilpass LED-oppførselen for ulike systemtilstander.',
     checkUpdates: 'Se etter oppdateringer',
     allowPrerelease: 'Tillat tidlige oppdateringer (Beta/Alpha)',
     language: 'Språk',
@@ -239,6 +240,12 @@ export default {
     installedVersion: 'Installert versjon',
     versionInfo: 'Modernisert fork v2.2.0-Beta.7 av Xerolux (2025) - Basert på originalarbeidet til Alexander Reinert.',
     updateAvailable: 'En oppdatering til versjon {latestVersion} er tilgjengelig.',
+    upToDate: 'Fastvaren er oppdatert',
+    checkNow: 'Sjekk nå',
+    checking: 'Sjekker...',
+    checkSuccess: 'Oppdateringssjekk vellykket',
+    checkFailed: 'Oppdateringssjekk mislyktes',
+    lastCheck: 'Sist sjekket',
     newVersionAvailable: 'Ny versjon {version} er tilgjengelig!',
     viewUpdate: 'Vis',
     onlineUpdate: 'Oppdater Online',
@@ -306,6 +313,16 @@ export default {
       haDiscoveryEnabled: 'Home Assistant Discovery',
       haDiscoveryPrefix: 'Discovery-prefiks',
       haDiscoveryPrefixHelp: 'Standard: homeassistant',
+      commands: {
+        title: 'Kommando-emner',
+        enableHelp: 'Tillater fjernstyring (omstart, fabrikkinnstilling, OTA) via MQTT. Uten token eller megler-ACL kan enhver klient på nettverket styre enheten.',
+        token: 'Kommandotoken',
+        tokenPlaceholder: 'valgfritt – delt hemmelighet',
+        tokenHelp: 'Når satt, må kommandoens nyttelast samsvare nøyaktig med dette tokenet. Tillatt: A-Z a-z 0-9 - _ .',
+        tokenPresent: '✓ Til stede – skriv inn ny verdi for å erstatte',
+        clear: 'Tøm',
+        aclHint: 'Merk: uten megler-ACL + token kan enhver MQTT-klient starte enheten på nytt eller utløse en OTA. Konfigurer en ACL på megleren som kun gir denne enheten publiseringsrettigheter på kommando-emnet.',
+      },
       serverRequired: 'Vennligst oppgi en MQTT-serveradresse når MQTT er aktivert.',
       tls: {
         title: 'TLS / SSL',
@@ -451,6 +468,12 @@ export default {
     empty: 'Ingen loggoppføringer ennå.'
   },
 
+  // Privacy
+  privacy: {
+    title: 'Personvern',
+    updateCheck: 'Automatiske oppdateringer og fastvaresjekker kobler til serveren xerolux.de. IP-adressen din overføres for å sjekke om nye versjoner er tilgjengelige.',
+  },
+
   // Changelog
   changelog: {
     title: 'Endringslogg',
@@ -459,7 +482,6 @@ export default {
     error: 'Kunne ikke laste endringslogg',
     fetchError: 'Kunne ikke hente endringslogg. Vennligst sjekk internettforbindelsen din.',
     retry: 'Prøv igjen',
-    checkFailed: 'Oppdateringssjekk mislyktes',
     close: 'Lukk',
     viewOnGithub: 'Vis på GitHub'
   }

--- a/webui/src/locales/pl.js
+++ b/webui/src/locales/pl.js
@@ -129,7 +129,8 @@ export default {
     // System Settings
     systemSettings: 'Ustawienia systemu',
     ledBrightness: 'Jasność LED',
-    updateLedBlink: 'Migaj LED podczas aktualizacji',
+    ledPrograms: 'Programy LED',
+    ledProgramsHelp: 'Dostosuj zachowanie diod LED dla różnych stanów systemu.',
     checkUpdates: 'Sprawdź aktualizacje',
     allowPrerelease: 'Zezwalaj na wczesne aktualizacje (Beta/Alpha)',
     language: 'Język',
@@ -239,6 +240,12 @@ export default {
     installedVersion: 'Zainstalowana wersja',
     versionInfo: 'Zmodernizowany fork v2.2.0-Beta.7 autorstwa Xerolux (2025) - Na podstawie oryginalnej pracy Alexandra Reinerta.',
     updateAvailable: 'Dostępna jest aktualizacja do wersji {latestVersion}.',
+    upToDate: 'Oprogramowanie jest aktualne',
+    checkNow: 'Sprawdź teraz',
+    checking: 'Sprawdzanie...',
+    checkSuccess: 'Sprawdzanie aktualizacji powiodło się',
+    checkFailed: 'Sprawdzanie aktualizacji nie powiodło się',
+    lastCheck: 'Ostatnie sprawdzenie',
     newVersionAvailable: 'Nowa wersja {version} jest dostępna!',
     viewUpdate: 'Zobacz',
     onlineUpdate: 'Aktualizuj Online',
@@ -306,6 +313,16 @@ export default {
       haDiscoveryEnabled: 'Wykrywanie Home Assistant',
       haDiscoveryPrefix: 'Prefiks Wykrywania',
       haDiscoveryPrefixHelp: 'Domyślnie: homeassistant',
+      commands: {
+        title: 'Tematy poleceń',
+        enableHelp: 'Umożliwia zdalne sterowanie (restart, przywracanie ustawień fabrycznych, OTA) przez MQTT. Bez tokenu lub ACL brokera dowolny klient w sieci może sterować urządzeniem.',
+        token: 'Token polecenia',
+        tokenPlaceholder: 'opcjonalnie – wspólny sekret',
+        tokenHelp: 'Jeśli ustawiony, ładunek polecenia musi dokładnie odpowiadać temu tokenowi. Dozwolone: A-Z a-z 0-9 - _ .',
+        tokenPresent: '✓ Obecny – wprowadź nową wartość, aby zastąpić',
+        clear: 'Wyczyść',
+        aclHint: 'Uwaga: bez ACL brokera + tokenu dowolny klient MQTT może zrestartować urządzenie lub uruchomić OTA. Skonfiguruj na brokerze ACL, która przyznaje prawa publikowania w temacie poleceń tylko temu urządzeniu.',
+      },
       serverRequired: 'Proszę podać adres serwera MQTT gdy MQTT jest włączone.',
       tls: {
         title: 'TLS / SSL',
@@ -451,6 +468,12 @@ export default {
     empty: 'Brak wpisów w dzienniku.'
   },
 
+  // Privacy
+  privacy: {
+    title: 'Prywatność',
+    updateCheck: 'Automatyczne aktualizacje i sprawdzanie oprogramowania łączą się z serwerem xerolux.de. Twój adres IP jest przesyłany w celu sprawdzenia dostępności nowych wersji.',
+  },
+
   // Changelog
   changelog: {
     title: 'Dziennik Zmian',
@@ -459,7 +482,6 @@ export default {
     error: 'Nie udało się załadować dziennika zmian',
     fetchError: 'Nie udało się pobrać dziennika zmian. Sprawdź połączenie z internetem.',
     retry: 'Ponów',
-    checkFailed: 'Sprawdzanie aktualizacji nie powiodło się',
     close: 'Zamknij',
     viewOnGithub: 'Zobacz na GitHub'
   }

--- a/webui/src/locales/sv.js
+++ b/webui/src/locales/sv.js
@@ -129,7 +129,8 @@ export default {
     // System Settings
     systemSettings: 'Systeminställningar',
     ledBrightness: 'LED Ljusstyrka',
-    updateLedBlink: 'Blinka LED vid uppdateringar',
+    ledPrograms: 'LED-program',
+    ledProgramsHelp: 'Anpassa LED-beteendet för olika systemtillstånd.',
     checkUpdates: 'Sök efter uppdateringar',
     allowPrerelease: 'Tillåt tidiga uppdateringar (Beta/Alpha)',
     language: 'Språk',
@@ -239,6 +240,12 @@ export default {
     installedVersion: 'Installerad version',
     versionInfo: 'Moderniserad fork v2.2.0-Beta.7 av Xerolux (2025) - Baserad på originalarbetet av Alexander Reinert.',
     updateAvailable: 'En uppdatering till version {latestVersion} finns tillgänglig.',
+    upToDate: 'Den fasta programvaran är uppdaterad',
+    checkNow: 'Kontrollera nu',
+    checking: 'Kontrollerar...',
+    checkSuccess: 'Uppdateringskontroll lyckades',
+    checkFailed: 'Uppdateringskontroll misslyckades',
+    lastCheck: 'Senast kontrollerad',
     newVersionAvailable: 'Ny version {version} finns tillgänglig!',
     viewUpdate: 'Visa',
     onlineUpdate: 'Uppdatera Online',
@@ -306,6 +313,16 @@ export default {
       haDiscoveryEnabled: 'Home Assistant Discovery',
       haDiscoveryPrefix: 'Discovery Prefix',
       haDiscoveryPrefixHelp: 'Standard: homeassistant',
+      commands: {
+        title: 'Kommando-ämnen',
+        enableHelp: 'Tillåter fjärrstyrning (omstart, fabriksåterställning, OTA) via MQTT. Utan token eller broker-ACL kan vilken klient som helst i nätverket styra enheten.',
+        token: 'Kommandotoken',
+        tokenPlaceholder: 'valfritt – delad hemlighet',
+        tokenHelp: 'När den är inställd måste kommandots nyttolast exakt matcha denna token. Tillåtet: A-Z a-z 0-9 - _ .',
+        tokenPresent: '✓ Finns – ange ett nytt värde för att ersätta',
+        clear: 'Rensa',
+        aclHint: 'Obs: utan broker-ACL + token kan vilken MQTT-klient som helst starta om enheten eller utlösa en OTA. Konfigurera en ACL på brokern som endast ger den här enheten publiceringsrättigheter på kommando-ämnet.',
+      },
       serverRequired: 'Ange en MQTT-serveradress när MQTT är aktiverat.',
       tls: {
         title: 'TLS / SSL',
@@ -451,6 +468,12 @@ export default {
     empty: 'Inga loggposter ännu.'
   },
 
+  // Privacy
+  privacy: {
+    title: 'Integritet',
+    updateCheck: 'Automatiska uppdateringar och kontroller av fast programvara ansluter till servern xerolux.de. Din IP-adress överförs för att kontrollera om nya versioner finns tillgängliga.',
+  },
+
   // Changelog
   changelog: {
     title: 'Ändringslogg',
@@ -459,7 +482,6 @@ export default {
     error: 'Misslyckades med att ladda ändringslogg',
     fetchError: 'Kunde inte hämta ändringslogg. Kontrollera din internetanslutning.',
     retry: 'Försök igen',
-    checkFailed: 'Uppdateringskontroll misslyckades',
     close: 'Stäng',
     viewOnGithub: 'Visa på GitHub'
   }


### PR DESCRIPTION
## Description
The non-German/English locale files (`fr`, `nl`, `it`, `es`, `pl`, `cs`, `no`, `sv`) were each **missing 18 translation keys** and carried **2 stale keys**. Because `vue-i18n` is configured with `fallbackLocale: 'en'`, all of these strings silently rendered in English for users of those 8 languages.

This PR brings every locale back in sync with the English/German baseline (all 10 locales now expose the same **401 keys**).

Changes per affected locale:
- Add `settings.ledPrograms` / `settings.ledProgramsHelp` (replacing the stale `settings.updateLedBlink`)
- Add firmware update-check keys: `upToDate`, `checkNow`, `checking`, `checkSuccess`, `checkFailed`, `lastCheck`
- Add the `monitoring.mqtt.commands.*` block (command-topic security UI: `title`, `enableHelp`, `token`, `tokenPlaceholder`, `tokenHelp`, `tokenPresent`, `clear`, `aclHint`)
- Add the top-level `privacy.title` / `privacy.updateCheck`
- Remove the stale, unused `changelog.checkFailed`

No source/markup changes — only translation data.

## Motivation and Context
Several UI areas (LED programs in Settings, the firmware update-check banner, the MQTT command-topic security panel, and the privacy notice) displayed English text in 8 of the 10 supported languages. This is a user-visible regression introduced when those keys were added to `en`/`de` but not propagated to the other locales.

## How Has This Been Tested?
- Wrote a key-diff script comparing each locale against `en.js`: after the change every locale reports `missing:0 extra:0` (401/401 keys).
- Validated each modified file parses as a valid ES module.
- Ran `npm run build` in `webui/` — builds successfully (289 modules transformed, no errors), confirming the embedded firmware assets still compile.

## Screenshots (if appropriate):
N/A — translation-data only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAqoqivhqSqJu5n4rJgB3y)_