### PR TITLE
fix: prevent firmware update banner from overlapping header nav

### DIFF
--- a/webui/src/header.vue
+++ b/webui/src/header.vue
@@ -238,13 +238,13 @@ onUnmounted(() => {
   position: relative;
   z-index: 1000;
   margin-bottom: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
 }
 
 .update-banner {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
+  position: relative;
   z-index: 1001;
   padding: 14px 18px;
   border-radius: 24px;
@@ -580,11 +580,8 @@ onUnmounted(() => {
   }
 
   .update-banner {
-    position: relative;
-    top: auto;
     flex-direction: column;
     align-items: flex-start;
-    margin-bottom: var(--spacing-md);
   }
 
   .update-banner-actions {


### PR DESCRIPTION
## Problem

The "Update verfügbar" banner rendered **on top of** the navigation bar, so the nav links (Firmware, Monitoring, System-Log, Über …) and the banner text overlapped into an unreadable mess. This affected every page, since the banner lives in the shared `header.vue` component — both the Dashboard and the Firmware page showed the same broken layout.

## Cause

`.update-banner` used `position: absolute; top: 0; left: 0; right: 0`, removing it from the document flow and stacking it directly over `.header-nav`. The mobile breakpoint (`max-width: 991px`) already overrode this to `position: relative`, which is why only the desktop layout was broken.

## Fix

- Make `.header-shell` a `flex-direction: column` container with a gap.
- Return `.update-banner` to normal flow (`position: relative`), so it sits **above** the nav and pushes it down instead of covering it.
- Drop the now-redundant `position`/`top`/`margin-bottom` overrides in the mobile media query (spacing is handled by the flex gap).

The slide-down enter/leave transition is preserved.

## Verification

- `npm run build` in `webui/` completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfrkuWZn8MSK28eYEvTUd6)_