### PR TITLE
fix: use MicroBin multipart upload API for log sharing

### DIFF
--- a/main/webui.cpp
+++ b/main/webui.cpp
@@ -1955,7 +1955,7 @@ static void _share_log_task(void *arg)
         // the classic application/x-www-form-urlencoded POST to "/".
         static const char boundary[] = "----HBRFETHngBoundary7331";
 
-        auto appendField = [&](std::string &body, const char *name, const std::string &value) {
+        auto appendField = [&](std::string &body, const char *name, const char *value) {
             body += "--"; body += boundary; body += "\r\n";
             body += "Content-Disposition: form-data; name=\""; body += name; body += "\"\r\n\r\n";
             body += value;
@@ -1964,7 +1964,7 @@ static void _share_log_task(void *arg)
 
         std::string body;
         body.reserve(report.length() + 512);
-        appendField(body, "content", report);
+        appendField(body, "content", report.c_str());
         appendField(body, "expiration", "24hour");
         appendField(body, "burn_after", "0");
         appendField(body, "syntax_highlight", "none");

--- a/main/webui.cpp
+++ b/main/webui.cpp
@@ -1744,32 +1744,6 @@ httpd_uri_t get_log_download_handler = {
 
 // ---- Share log to paste.blueml.eu ----
 
-static void _url_encode(const char *src, size_t src_len, std::string &out)
-{
-    out.clear();
-    out.reserve(src_len * 3);
-    for (size_t i = 0; i < src_len; i++)
-    {
-        char c = src[i];
-        if (('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') ||
-            ('0' <= c && c <= '9') ||
-            c == '-' || c == '_' || c == '.' || c == '~')
-        {
-            out += c;
-        }
-        else if (c == ' ')
-        {
-            out += '+';
-        }
-        else
-        {
-            char hex[4];
-            snprintf(hex, sizeof(hex), "%%%02X", (unsigned char)c);
-            out += hex;
-        }
-    }
-}
-
 struct ShareLogJob
 {
     httpd_req_t *req;
@@ -1976,16 +1950,28 @@ static void _share_log_task(void *arg)
     }
 
     {
-        std::string encoded;
-        _url_encode(report.c_str(), report.length(), encoded);
+        // MicroBin (the software behind paste.blueml.eu) only accepts
+        // multipart/form-data uploads on /upload — it does not implement
+        // the classic application/x-www-form-urlencoded POST to "/".
+        static const char boundary[] = "----HBRFETHngBoundary7331";
+
+        auto appendField = [&](std::string &body, const char *name, const std::string &value) {
+            body += "--"; body += boundary; body += "\r\n";
+            body += "Content-Disposition: form-data; name=\""; body += name; body += "\"\r\n\r\n";
+            body += value;
+            body += "\r\n";
+        };
 
         std::string body;
-        body.reserve(encoded.length() + 32);
-        body = "content=";
-        body += encoded;
-        body += "&syntax=text";
+        body.reserve(report.length() + 512);
+        appendField(body, "content", report);
+        appendField(body, "expiration", "24hour");
+        appendField(body, "burn_after", "0");
+        appendField(body, "syntax_highlight", "none");
+        appendField(body, "privacy", "unlisted");
+        body += "--"; body += boundary; body += "--\r\n";
 
-        // Event handler captures the Location response header from the 303
+        // Event handler captures the Location response header from the 302
         // redirect. ESP-IDF's esp_http_client_get_header() reads REQUEST
         // headers, not response headers — so we MUST use the event callback.
         struct PasteCtx {
@@ -1996,7 +1982,7 @@ static void _share_log_task(void *arg)
         pctx.hasLocation = false;
 
         esp_http_client_config_t config = {};
-        config.url = "https://paste.blueml.eu/";
+        config.url = "https://paste.blueml.eu/upload";
         config.method = HTTP_METHOD_POST;
         config.crt_bundle_attach = esp_crt_bundle_attach;
         config.keep_alive_enable = false;
@@ -2024,7 +2010,10 @@ static void _share_log_task(void *arg)
             goto respond;
         }
 
+        std::string contentType = "multipart/form-data; boundary=";
+        contentType += boundary;
         esp_http_client_set_header(client, "User-Agent", "HB-RF-ETH-ng");
+        esp_http_client_set_header(client, "Content-Type", contentType.c_str());
         esp_http_client_set_post_field(client, body.c_str(), body.length());
 
         esp_err_t err = esp_http_client_perform(client);


### PR DESCRIPTION
## Description
The "Share log" feature (`POST /api/log/share`) sent an `application/x-www-form-urlencoded` POST to `https://paste.blueml.eu/` and expected a 301/302/303 redirect with a `Location` header containing the paste URL.

`paste.blueml.eu` actually runs [MicroBin](https://github.com/szabodanika/microbin), which:
- serves the upload form at `/`, but the actual upload endpoint is `/upload`
- only accepts `multipart/form-data` submissions (fields: `content`, `expiration`, `burn_after`, `syntax_highlight`, `privacy`)

Because of this mismatch, the server returned `200 OK` with an HTML 404 page instead of a redirect, so the firmware always reported `{"success":false,"error":"Paste service returned HTTP 200"}` and no URL was ever shown.

## Motivation and Context
Fixes the broken "share log" / paste upload feature reported by the user — uploads silently failed and no shareable URL was displayed.

## How Has This Been Tested?
- Verified the real behavior of `paste.blueml.eu` with `curl`: confirmed the old `POST /` form-encoded request returns `200` with a 404 HTML body, and that `POST /upload` with `multipart/form-data` (fields `content`, `expiration`, `burn_after`, `syntax_highlight`, `privacy`) correctly returns a `302` redirect with a `Location` header pointing to the new paste.
- Updated `main/webui.cpp` to build a proper multipart/form-data body and POST it to `/upload`, keeping the existing `Location`-header-capture logic (now also matching the `302` MicroBin actually returns).
- Removed the now-unused `_url_encode` helper.

## Screenshots (if appropriate):
N/A (backend-only change)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XSp8QjWXGmQb9jsCY4CHu6)_