### PR TITLE
fix: copy-to-clipboard button not working on HTTP WebUI

### DIFF
--- a/webui/src/sysinfo.vue
+++ b/webui/src/sysinfo.vue
@@ -268,19 +268,28 @@ const safePercent = (value) => Math.max(0, Math.min(100, Number(value || 0).toFi
 
 const copyValue = async (value, label) => {
   if (!value) return
+  // execCommand runs synchronously within the click handler, so it still has
+  // the user-gesture activation. Awaiting the async Clipboard API first can
+  // consume that activation before falling back, breaking copy on HTTP pages.
+  const textarea = document.createElement('textarea')
+  textarea.value = value
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+  let ok = false
   try {
-    await navigator.clipboard.writeText(value)
+    ok = document.execCommand('copy')
   } catch {
-    // execCommand fallback for non-HTTPS contexts
-    const textarea = document.createElement('textarea')
-    textarea.value = value
-    textarea.style.position = 'fixed'
-    textarea.style.opacity = '0'
-    document.body.appendChild(textarea)
-    textarea.select()
-    const ok = document.execCommand('copy')
-    document.body.removeChild(textarea)
-    if (!ok) throw new Error('copy failed')
+    ok = false
+  }
+  document.body.removeChild(textarea)
+  if (!ok) {
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(value)
+    } else {
+      throw new Error('copy failed')
+    }
   }
   uiStore.pushToast({
     type: 'success',

--- a/webui/src/systemlog.vue
+++ b/webui/src/systemlog.vue
@@ -153,23 +153,29 @@ const MAX_LOG_LINES = 2500
 const MAX_COPY_LINES = 500
 
 const copyToClipboard = async (text) => {
-  try {
-    await navigator.clipboard.writeText(text)
-    return
-  } catch {
-    // fall through to fallback
-  }
+  // execCommand runs synchronously within the click handler, so it still has
+  // the user-gesture activation. Awaiting the async Clipboard API first can
+  // consume that activation before falling back, breaking copy on HTTP pages.
   const textarea = document.createElement('textarea')
   textarea.value = text
   textarea.style.position = 'fixed'
   textarea.style.opacity = '0'
   document.body.appendChild(textarea)
   textarea.select()
-  const ok = document.execCommand('copy')
-  document.body.removeChild(textarea)
-  if (!ok) {
-    throw new Error('execCommand copy failed')
+  let ok = false
+  try {
+    ok = document.execCommand('copy')
+  } catch {
+    ok = false
   }
+  document.body.removeChild(textarea)
+  if (ok) return
+
+  if (navigator.clipboard) {
+    await navigator.clipboard.writeText(text)
+    return
+  }
+  throw new Error('execCommand copy failed')
 }
 
 const getEntryLevel = (line) => {


### PR DESCRIPTION
## Description
The copy-to-clipboard buttons in the "Log teilen" (share log) dialog and on the sysinfo page didn't reliably copy text when the WebUI is served over plain HTTP (a non-secure context).

## Motivation and Context
`copyToClipboard`/`copyValue` awaited `navigator.clipboard.writeText()` first and only fell back to `document.execCommand('copy')` on failure. On a non-secure (HTTP) origin, `navigator.clipboard.writeText()` rejects asynchronously, and awaiting that rejection can consume the click's transient user-gesture activation before the `execCommand` fallback runs — so the fallback silently fails too, leaving the copy button non-functional, matching the reported bug ("der kopieren button funktioniert nicht").

Fix: run `execCommand('copy')` synchronously first (still within the click's user-gesture activation), and only fall back to the async Clipboard API if that fails or is unavailable.

## How Has This Been Tested?
Verified with a local Vite dev server and a scripted Playwright check that:
- simulated a non-secure context (`navigator.clipboard` unavailable / `isSecureContext = false`)
- opened the "Share log" dialog and clicked the "Copy Link" button
- confirmed the success toast appeared after the fix (it did not reliably appear before, depending on Clipboard API behavior order)

Also ran `npm run build` in `webui/` to confirm the WebUI still builds.

## Screenshots (if appropriate):
N/A (logic-only fix)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D2jsy86wp3SroE2RABWjWH)_