### PR TITLE
fix: raise check_update client timeout to cover device-side worst case

### DIFF
--- a/webui/src/stores.js
+++ b/webui/src/stores.js
@@ -296,9 +296,13 @@ export const useUpdateStore = defineStore('update', {
       this.checkError = null
 
       try {
+        // Worst case on the device: up to 15 s waiting for g_net_fetch_mutex
+        // (another TLS fetch already running) plus up to 10 s for the GitHub
+        // request itself - give the client enough headroom to not time out
+        // while the device is still legitimately working.
         const config = cached
           ? { params: { t: Date.now() } }
-          : { timeout: 15000 }
+          : { timeout: 30000 }
         const response = cached
           ? await axios.get('/api/check_update', config)
           : await axios.post('/api/check_update', {}, config)


### PR DESCRIPTION
## Summary
- Raises the WebUI's manual "Check for update" axios timeout from 15 s to 30 s in `webui/src/stores.js` (`useUpdateStore.checkForUpdate`).
- Root cause: `POST /api/check_update` on the device (`main/webui.cpp::post_check_update_handler_func` → `_refresh_task` → `UpdateCheck::refresh()` → `UpdateCheck::_doFetch()`) can legitimately take up to ~25 s in the worst case - up to 15 s waiting for `g_net_fetch_mutex` if another TLS fetch (background 24h poll, changelog proxy, log-share) is already holding it, plus up to 10 s for the actual GitHub HTTP request (`config.timeout_ms = 10000` in `updatecheck.cpp::_doFetch`).
- The frontend's old 15 s timeout was shorter than this worst case, so a manual update check could legitimately fail with `timeout of 15000ms exceeded` while the device was still working and about to return a valid result - reproduced from a user-reported log/screenshot showing exactly this failure mode.
- All call sites go through the `updateStore.checkForUpdate()` action (`firmwareupdate.vue`, `header.vue`), so this single change covers every path that triggers a live (non-cached) check.

## Test plan
- [ ] `idf.py build` succeeds (no firmware changes, WebUI-only fix)
- [ ] `cd webui && npm run build` succeeds
- [ ] Manually trigger "Check for update" while another TLS fetch is in progress (e.g. log-share) and confirm it now completes instead of timing out at 15 s


---
_Generated by [Claude Code](https://claude.ai/code/session_01PW63G24kawFndFm3UpzgP6)_