### PR TITLE
fix: make clipboard copy fallback reliable on mobile browsers

### DIFF
--- a/webui/src/systemlog.vue
+++ b/webui/src/systemlog.vue
@@ -166,10 +166,10 @@ const copyToClipboard = async (text) => {
   textarea.style.left = '0'
   textarea.style.opacity = '0'
   document.body.appendChild(textarea)
-  textarea.focus()
+  textarea.focus({ preventScroll: true })
   textarea.select()
   // .select() alone is unreliable on some mobile browsers; pin the range explicitly.
-  textarea.setSelectionRange(0, text.length)
+  textarea.setSelectionRange(0, textarea.value.length)
   let ok = false
   try {
     ok = document.execCommand('copy')

--- a/webui/src/systemlog.vue
+++ b/webui/src/systemlog.vue
@@ -158,10 +158,18 @@ const copyToClipboard = async (text) => {
   // consume that activation before falling back, breaking copy on HTTP pages.
   const textarea = document.createElement('textarea')
   textarea.value = text
+  // readonly avoids popping the virtual keyboard on mobile, which can steal
+  // focus/selection before execCommand('copy') runs.
+  textarea.setAttribute('readonly', '')
   textarea.style.position = 'fixed'
+  textarea.style.top = '0'
+  textarea.style.left = '0'
   textarea.style.opacity = '0'
   document.body.appendChild(textarea)
+  textarea.focus()
   textarea.select()
+  // .select() alone is unreliable on some mobile browsers; pin the range explicitly.
+  textarea.setSelectionRange(0, text.length)
   let ok = false
   try {
     ok = document.execCommand('copy')


### PR DESCRIPTION
## Summary
- The system log share modal's "Link kopieren" button copies via `document.execCommand('copy')` on a hidden textarea when `navigator.clipboard` is unavailable — which is the case on plain-HTTP device origins (e.g. `192.168.178.56`), since the Clipboard API requires a secure context.
- The hidden textarea was missing `readonly` and an explicit `setSelectionRange`, both needed on mobile browsers for `select()`-based copy to actually populate the clipboard. This left the clipboard empty after clicking the button, as reported.
- Added `readonly` (avoids the virtual keyboard popping up and stealing focus/selection) and `textarea.setSelectionRange(0, text.length)` (pins the selection explicitly, since `.select()` alone is unreliable on some mobile browsers) to `copyToClipboard()` in `webui/src/systemlog.vue`.

## Test plan
- [ ] Manually verify "Link kopieren" populates the clipboard on a mobile browser over plain HTTP
- [ ] Manually verify copy still works on desktop / HTTPS (Clipboard API path)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PW63G24kawFndFm3UpzgP6)_