### PR TITLE
fix: restore OTA/update check on ESP32 by disabling TLS cert verification (PSA OOM -141)

### DIFF
--- a/main/ota_config.cpp
+++ b/main/ota_config.cpp
@@ -26,8 +26,11 @@ void configure_ota_http_client(esp_http_client_config_t& config, const char* url
     // This was a deliberate choice to restore update functionality on
     // memory-constrained hardware. MQTT TLS and the log-share upload keep full
     // certificate verification (they do not use this helper).
+    // Leave skip_cert_common_name_check at its default (false): with no CA
+    // attached the connection already skips all verification, and keeping the
+    // hostname check enabled means that if a CA bundle is ever re-attached here
+    // later, hostname verification is not silently left off.
     config.crt_bundle_attach = nullptr;
-    config.skip_cert_common_name_check = true;
 
     // Fix for Bug #235: GitHub redirects fail with keep-alive
     config.keep_alive_enable = false;

--- a/main/ota_config.cpp
+++ b/main/ota_config.cpp
@@ -1,15 +1,33 @@
 #include "ota_config.h"
-#include "esp_crt_bundle.h"
 
 void configure_ota_http_client(esp_http_client_config_t& config, const char* url) {
     config.url = url;
 
-    // Verify the server certificate chain against the bundled Mozilla root CAs.
-    // The full bundle (CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL) is used so
-    // that the ECDSA roots GitHub's CDN can present (e.g. ISRG Root X2) are
-    // covered. Keeping verification on protects the OTA path against
-    // man-in-the-middle delivery of arbitrary firmware.
-    config.crt_bundle_attach = esp_crt_bundle_attach;
+    // NOTE: server certificate verification is intentionally DISABLED on the
+    // GitHub fetch / OTA download path.
+    //
+    // On the ESP32 (WROOM-32, internal RAM only, no PSRAM) the PSA-crypto
+    // certificate-chain verification under ESP-IDF 6.x runs out of heap during
+    // the TLS handshake and aborts with:
+    //     esp-x509-crt-bundle: PSA signature verification failed with error
+    //         0xffffff73 (decimal: -141)   // PSA_ERROR_INSUFFICIENT_MEMORY
+    //     esp-x509-crt-bundle: Certificate matched but signature verification failed
+    // i.e. GitHub's certificate is trusted ("matched") but there is not enough
+    // memory to run the signature math, so BOTH the update check and the OTA
+    // download fail with ESP_ERR_HTTP_CONNECT.
+    //
+    // Because no CA bundle is attached here, esp-tls falls back to
+    // MBEDTLS_SSL_VERIFY_NONE (enabled via CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY
+    // in sdkconfig), so the handshake completes without the memory-hungry
+    // verification step.
+    //
+    // TRADE-OFF: the OTA path no longer authenticates the server, so a
+    // man-in-the-middle on the network path could serve arbitrary firmware.
+    // This was a deliberate choice to restore update functionality on
+    // memory-constrained hardware. MQTT TLS and the log-share upload keep full
+    // certificate verification (they do not use this helper).
+    config.crt_bundle_attach = nullptr;
+    config.skip_cert_common_name_check = true;
 
     // Fix for Bug #235: GitHub redirects fail with keep-alive
     config.keep_alive_enable = false;

--- a/test/test_ota_config/test_ota_config.cpp
+++ b/test/test_ota_config/test_ota_config.cpp
@@ -30,9 +30,10 @@ void test_ota_config_defaults(void) {
 
     // Cert verification is intentionally disabled on the OTA/fetch path to work
     // around PSA insufficient-memory (-141) handshake failures on the ESP32, so
-    // no CA bundle must be attached and the CN check is skipped.
+    // no CA bundle must be attached. The CN check stays at its default (false)
+    // so it is not silently left off if a CA bundle is re-attached later.
     TEST_ASSERT_NULL(config.crt_bundle_attach);
-    TEST_ASSERT_TRUE(config.skip_cert_common_name_check);
+    TEST_ASSERT_FALSE(config.skip_cert_common_name_check);
 }
 
 // GitHub Releases API URL: stable channel hits /releases/latest, beta

--- a/test/test_ota_config/test_ota_config.cpp
+++ b/test/test_ota_config/test_ota_config.cpp
@@ -28,8 +28,11 @@ void test_ota_config_defaults(void) {
     // Verify Fix 3: Max redirection count set
     TEST_ASSERT_EQUAL(5, config.max_redirection_count);
 
-    // Verify CRT bundle is attached
-    TEST_ASSERT_NOT_NULL(config.crt_bundle_attach);
+    // Cert verification is intentionally disabled on the OTA/fetch path to work
+    // around PSA insufficient-memory (-141) handshake failures on the ESP32, so
+    // no CA bundle must be attached and the CN check is skipped.
+    TEST_ASSERT_NULL(config.crt_bundle_attach);
+    TEST_ASSERT_TRUE(config.skip_cert_common_name_check);
 }
 
 // GitHub Releases API URL: stable channel hits /releases/latest, beta


### PR DESCRIPTION
## Description

On real hardware the GitHub **update check** and **OTA download** both fail at the
TLS handshake. Device log:

```
E esp-x509-crt-bundle: PSA signature verification failed with error 0xffffff73 (decimal: -141)
E esp-x509-crt-bundle: Certificate matched but signature verification failed
E esp-tls-mbedtls: mbedtls_ssl_handshake returned -0x3000
E UpdateCheck: GitHub fetch failed: HTTP 0 (ESP_ERR_HTTP_CONNECT)
```

`0xffffff73 = -141 = PSA_ERROR_INSUFFICIENT_MEMORY`. GitHub's certificate is
*trusted* ("Certificate matched"), but on the ESP32 (WROOM-32, internal RAM only,
no PSRAM) the PSA-crypto signature verification under ESP-IDF 6.x cannot allocate
enough heap during the handshake, so verification aborts and the connection fails.
This breaks both the update search and the OTA download (they share the same TLS
path).

This PR stops attaching the CA bundle in the shared `configure_ota_http_client()`
helper. With no CA configured, esp-tls falls back to `MBEDTLS_SSL_VERIFY_NONE`
(`CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY` is already enabled in sdkconfig), so the
handshake completes without the memory-hungry verification step.

Scope: only the paths that use `configure_ota_http_client()` — the GitHub release
fetch, the OTA download (online update + `/api/ota_url`), and the changelog proxy.
**MQTT TLS and the log-share upload keep full certificate verification.**

## Motivation and Context

The certificate verification was previously toggled off and back on (commits
`02e5c43` → `a33116e`) around exactly this ESP-IDF 6.x PSA-crypto issue. On this
memory-constrained board it makes the entire online-update feature non-functional.
Disabling verification on this path was chosen deliberately to restore that
functionality.

## How Has This Been Tested?

The trigger was reproduced on real hardware (see device log above). The fix itself
needs an on-device verification build (recommended: cut a Beta and confirm the
update check resolves and an OTA Beta.14 → next completes). The legacy
`test_ota_config` unit test was updated to assert the new no-bundle behaviour.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) — OTA path no longer authenticates the server (MITM trade-off, see below)

## Security trade-off

The OTA path no longer authenticates GitHub's server, so a man-in-the-middle on
the network could serve arbitrary firmware. This was an explicit, informed choice
to make updates work on hardware where certificate verification runs out of memory.
A future alternative that keeps verification would be to reduce TLS memory use
(`CONFIG_MBEDTLS_DYNAMIC_BUFFER`, smaller `CONFIG_MBEDTLS_SSL_IN_CONTENT_LEN`).

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJLc6LR6JK64u4HFYHt2zQ)_