### PR TITLE
Fix flashPause persistence, firmware-archive fallback and monitoring responsive layout

### DIFF
--- a/main/webui.cpp
+++ b/main/webui.cpp
@@ -692,12 +692,12 @@ esp_err_t post_settings_json_handler_func(httpd_req_t *req)
         } else {
             LogManager::stop();
         }
+    }
 
     cJSON *flashPauseItem = cJSON_GetObjectItem(root, "flashPause");
     if (flashPauseItem && cJSON_IsBool(flashPauseItem)) {
         _settings->setFlashPause(cJSON_IsTrue(flashPauseItem));
         set_flash_pause_enabled(cJSON_IsTrue(flashPauseItem));
-    }
     }
 
     _settings->save();

--- a/webui/src/firmwareupdate.vue
+++ b/webui/src/firmwareupdate.vue
@@ -372,6 +372,7 @@ const archiveInstallingVersion = ref('')
 const selectedArchiveVersion = ref('')
 
 const ARCHIVE_MANIFEST_URL = '/api/firmware_archive'
+const ARCHIVE_MANIFEST_FALLBACK_URL = 'https://raw.githubusercontent.com/Xerolux/HB-RF-ETH-ng/main/archive.json'
 
 const archiveFilters = computed(() => [
   { value: 'stable', label: t('firmware.archiveStable') },
@@ -495,13 +496,8 @@ const normalizeArchiveEntry = (entry, index = 0) => {
   }
 }
 
-const loadArchiveManifest = async () => {
-  const response = await axios.get(ARCHIVE_MANIFEST_URL, {
-    headers: { Accept: 'application/json' },
-    silent: true
-  })
-  const data = response.data
-  const entries = Array.isArray(data) ? data : data.releases
+const parseArchiveManifest = (data) => {
+  const entries = Array.isArray(data) ? data : data?.releases
   if (!Array.isArray(entries)) {
     throw new Error(t('firmware.archiveLoadError'))
   }
@@ -509,6 +505,26 @@ const loadArchiveManifest = async () => {
   return entries
     .map(normalizeArchiveEntry)
     .filter((release) => release?.version && release.downloadUrl)
+}
+
+const fetchArchiveManifest = (url) => axios.get(url, {
+  headers: { Accept: 'application/json' },
+  params: { _: Date.now() },
+  timeout: 15000,
+  silent: true
+})
+
+const loadArchiveManifest = async () => {
+  try {
+    const response = await fetchArchiveManifest(ARCHIVE_MANIFEST_URL)
+    return parseArchiveManifest(response.data)
+  } catch (primaryError) {
+    // Some firmware builds run the GitHub proxy with very little free heap.
+    // Fall back to the static raw manifest directly from the browser so the
+    // archive remains usable even when the device-side proxy cannot fetch it.
+    const response = await fetchArchiveManifest(ARCHIVE_MANIFEST_FALLBACK_URL)
+    return parseArchiveManifest(response.data)
+  }
 }
 
 const loadFirmwareArchive = async () => {

--- a/webui/src/monitoring.vue
+++ b/webui/src/monitoring.vue
@@ -820,7 +820,7 @@ const runDiagnostic = async (target) => {
 <style scoped>
 .monitoring-page {
   padding-bottom: 80px;
-  max-width: 800px;
+  width: min(100%, 1120px);
   margin: 0 auto;
 }
 
@@ -1081,9 +1081,23 @@ const runDiagnostic = async (target) => {
     grid-template-columns: 1fr;
   }
 
-  .diagnostic-card {
+  .diagnostic-card,
+  .card-header,
+  .tls-section > .d-flex,
+  .command-section > .d-flex {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .tool-btn {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .card-header .form-check,
+  .tls-section .form-check,
+  .command-section .form-check {
+    align-self: flex-start;
   }
 
   .card-header {
@@ -1097,8 +1111,13 @@ const runDiagnostic = async (target) => {
     font-size: 1rem;
   }
 
+  .header-content {
+    align-items: flex-start;
+  }
+
   .card-header h3 {
     font-size: 1rem;
+    overflow-wrap: anywhere;
   }
 
   .card-body {
@@ -1115,14 +1134,27 @@ const runDiagnostic = async (target) => {
     padding: 0.875rem;
   }
 
-  .cert-status-row {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
+  .cert-status-row,
   .pem-label-row {
     align-items: flex-start;
     flex-direction: column;
+  }
+}
+
+@media (max-width: 480px) {
+  .monitoring-page {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .diagnostic-copy {
+    align-items: flex-start;
+  }
+
+  .diagnostic-copy p,
+  .form-text,
+  .alert-warning-soft {
+    overflow-wrap: anywhere;
   }
 }
 </style>


### PR DESCRIPTION
### Motivation
- Persist the experimental `flashPause` setting reliably so toggling it does not get lost when other optional fields (e.g. system log) are omitted in the payload. 
- Make the firmware archive UI resilient when the device-side proxy or low-heap conditions prevent fetching `archive.json`. 
- Improve the Monitoring page layout so controls, long helper texts and action buttons behave predictably on narrow viewports.

### Description
- Ensure `flashPause` is applied and saved unconditionally in the server settings handler by fixing a misplaced brace in `main/webui.cpp` so the flag is set independently of the optional system-log branch and before `_settings->save()`.
- Harden firmware archive loading in `webui/src/firmwareupdate.vue` by adding `ARCHIVE_MANIFEST_FALLBACK_URL`, a small `fetchArchiveManifest()` wrapper with cache-busting query param and a 15s timeout, a `parseArchiveManifest()` step for validation/normalization, and a fallback to the raw GitHub manifest when the device proxy fails.
- Improve responsive behaviour in `webui/src/monitoring.vue` by widening the desktop content area (`width: min(100%, 1120px)`), stacking header/tools/tls/command rows on small screens, making diagnostic/tool buttons full-width on narrow viewports, and adding overflow/word-wrap fixes for long helper text and labels.

### Testing
- Ran the production WebUI build with `cd webui && npm run build` which completed successfully and produced the `dist/` artifacts. 
- Ran `git diff --check` (no whitespace or diff-check issues) to validate the changeset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b3301cb60832bab9b08a0e266f348)