### PR TITLE
fix: flash-pause persistence, OTA stability, archive load, responsive WebUI, i18n parity

### DIFF
--- a/.github/workflows/rebuild-archive.yml
+++ b/.github/workflows/rebuild-archive.yml
@@ -27,8 +27,21 @@ jobs:
           python3 - <<'PY'
           import json
           import os
+          import re
           import urllib.request
           from datetime import datetime, timezone
+
+          def excerpt(text, limit=300):
+              """Collapse whitespace and truncate to a single-line preview.
+              The full release notes are fetched on demand from GitHub (notesUrl)
+              so the firmware archive manifest stays small enough to stream
+              through the ESP32 async proxy without exhausting its TLS heap."""
+              if not text:
+                  return ""
+              flat = re.sub(r"\s+", " ", text).strip()
+              if len(flat) <= limit:
+                  return flat
+              return flat[:limit].rstrip() + "…"
 
           repo = "Xerolux/HB-RF-ETH-ng"
           token = os.environ.get("GITHUB_TOKEN", "")
@@ -84,7 +97,7 @@ jobs:
                   "prerelease": bool(release.get("prerelease")),
                   "assetName": asset.get("name") or "",
                   "assetSize": asset.get("size") or 0,
-                  "notes": release.get("body") or "",
+                  "notesExcerpt": excerpt(release.get("body") or ""),
               })
 
           archive_releases.sort(key=lambda item: item.get("publishedAt") or "", reverse=True)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,18 @@ jobs:
             python3 - <<'PY'
           import json
           import os
+          import re
+
+          def excerpt(text, limit=300):
+              """Collapse whitespace and truncate to a single-line preview.
+              Full notes are fetched on demand from notesUrl so the archive
+              manifest stays small enough to stream through the ESP32 proxy."""
+              if not text:
+                  return ""
+              flat = re.sub(r"\s+", " ", text).strip()
+              if len(flat) <= limit:
+                  return flat
+              return flat[:limit].rstrip() + "…"
 
           version = os.environ["VERSION"]
           version_tag = os.environ["VERSION_TAG"]
@@ -293,7 +305,7 @@ jobs:
               "name": f"HB-RF-ETH-ng {version_tag}",
               "prerelease": is_prerelease,
               "assetName": firmware_file,
-              "notes": notes,
+              "notesExcerpt": excerpt(notes),
           }
 
           archive_path = "archive.json"

--- a/docs/API.md
+++ b/docs/API.md
@@ -212,7 +212,9 @@ Retrieve current device settings.
     "ntpServer": "string",
     "ledBrightness": 100,
     "updateLedBlink": true,
-    "betaChannel": false
+    "betaChannel": false,
+    "flashPause": false,
+    "systemLogEnabled": false
   }
 }
 ```
@@ -248,6 +250,8 @@ Retrieve current device settings.
 - `ledBrightness`: LED brightness (0-100)
 - `updateLedBlink`: Enable/disable LED blinking for update notifications
 - `betaChannel`: When `true`, the firmware update check considers pre-release versions published on GitHub (see [Firmware Management](#firmware-management)). Stable channel (default) only reports the latest stable release.
+- `flashPause`: When `true`, a system restart holds the Ethernet PHY in hardware reset for ~35 seconds before the ESP32 actually reboots. This lets a connected CCU's link-loss watchdog trigger a clean CCU restart so no stale radio-mod connections survive a firmware update. Optional, defaults to `false`. Set via the Settings page; persisted in NVS alongside the other settings.
+- `systemLogEnabled`: When `true`, the in-device ring-buffer system log is active and can be read via `/api/log`. Managed from the System Log page rather than the Settings page, but returned here for visibility.
 
 **Example:**
 ```bash
@@ -328,7 +332,7 @@ curl -X POST http://192.168.1.100/settings.json \
 
 ### GET /api/monitoring
 
-Retrieve monitoring configuration for MQTT and CheckMK.
+Retrieve monitoring configuration for MQTT, CheckMK, Prometheus, Syslog forwarding, and event notifications.
 
 **Authentication:** Required
 
@@ -356,6 +360,35 @@ Retrieve monitoring configuration for MQTT and CheckMK.
     "enabled": false,
     "port": 6556,
     "allowedHosts": ""
+  },
+  "prometheus": {
+    "enabled": false,
+    "port": 9100,
+    "allowedHosts": ""
+  },
+  "syslog": {
+    "enabled": false,
+    "server": "",
+    "port": 514,
+    "transport": 0,
+    "minSeverity": 5,
+    "hostname": ""
+  },
+  "notify": {
+    "enabled": false,
+    "channels": 0,
+    "cooldownSeconds": 300,
+    "webhookUrl": "",
+    "webhookSecretSet": false,
+    "telegramTokenSet": false,
+    "telegramChatId": "",
+    "smtpServer": "",
+    "smtpPort": 587,
+    "smtpTls": 1,
+    "smtpUser": "",
+    "smtpPasswordSet": false,
+    "smtpFrom": "",
+    "smtpTo": ""
   }
 }
 ```
@@ -383,6 +416,27 @@ Retrieve monitoring configuration for MQTT and CheckMK.
 - `enabled`: Enable/disable CheckMK agent
 - `port`: CheckMK agent port (default: 6556, range: 1-65535)
 - `allowedHosts`: Comma-separated list of allowed IP addresses/ranges (validated for IPv4/IPv6 format)
+
+**Prometheus:**
+- `enabled`: Enable/disable the Prometheus metrics exporter
+- `port`: HTTP port the `/metrics` endpoint listens on (default: 9100, range: 1-65535)
+- `allowedHosts`: Comma-separated source-IP allowlist (Prometheus scrapes carry no auth; the IP filter is the gate)
+
+**Syslog:**
+- `enabled`: Enable/disable Syslog forwarding
+- `server`: Syslog server hostname or IP
+- `port`: Syslog server port (default: 514)
+- `transport`: `0` = UDP, `1` = TCP, `2` = TLS-over-TCP. The TLS transport takes the shared net-fetch mutex, so it is briefly deferred while a firmware OTA download is in progress.
+- `minSeverity`: Minimum severity to forward (`0` = EMERG … `7` = DEBUG)
+- `hostname`: Override the hostname tag in forwarded messages; empty = device hostname
+
+**Event Notifications:**
+- `enabled`: Master switch for the notification subsystem
+- `channels`: Bitmask of active channels (`1` = webhook, `2` = Telegram, `4` = email)
+- `cooldownSeconds`: Per-event-type dedupe window; only one notification per event type is sent within this window
+- `webhookUrl` / `webhookSecret` (`webhookSecretSet`): HTTP POST target and shared secret (sent as `X-HB-RF-ETH-Secret` header). Secret write-only.
+- `telegramToken` (`telegramTokenSet`) / `telegramChatId`: Telegram bot token and target chat ID. Token write-only.
+- `smtpServer` / `smtpPort` / `smtpTls` (`0` = none, `1` = STARTTLS, `2` = implicit TLS) / `smtpUser` / `smtpPassword` (`smtpPasswordSet`) / `smtpFrom` / `smtpTo`: SMTP relay configuration. Password write-only. Note: an SMTP send holds the net-fetch mutex for the duration of the SMTP session; the OTA path defers event delivery until the OTA completes.
 
 **Example:**
 ```bash
@@ -624,6 +678,46 @@ curl -X POST http://192.168.1.100/ota_update \
   -H "Authorization: Token YOUR_TOKEN_HERE" \
   -F "file=@firmware_2_1_0.bin"
 ```
+
+### GET /api/firmware_archive
+
+Retrieve the list of previously released firmware versions. Proxied from the project's `archive.json` manifest on GitHub.
+
+**Authentication:** Required
+
+**Response (200 OK):**
+```json
+{
+  "schema": 1,
+  "updatedAt": "2026-07-05T19:06:15Z",
+  "releases": [
+    {
+      "version": "2.2.3-Beta.12",
+      "channel": "beta",
+      "isPrerelease": true,
+      "publishedAt": "2026-07-05T19:06:15Z",
+      "downloadUrl": "https://github.com/.../firmware_2.2.3-Beta.12.bin",
+      "releaseUrl": "https://github.com/.../releases/tag/v2.2.3-Beta.12",
+      "notesUrl": "https://github.com/.../releases/tag/v2.2.3-Beta.12",
+      "tagName": "v2.2.3-Beta.12",
+      "name": "HB-RF-ETH-ng v2.2.3-Beta.12",
+      "assetName": "firmware_2.2.3-Beta.12.bin",
+      "assetSize": 1234567,
+      "notesExcerpt": "Short single-line preview of the release notes…"
+    }
+  ]
+}
+```
+
+**Fields:**
+- `version`: Semantic version string.
+- `channel`: `"stable"` or `"beta"`.
+- `downloadUrl`: Direct asset URL on GitHub (used to trigger an archive install via `POST /api/ota_url`).
+- `notesExcerpt`: A short (~300 char) collapsed-whitespace preview of the release notes. The full release notes are not embedded in the manifest to keep it small enough to stream through the device; follow `notesUrl` to read them on GitHub.
+- `notesUrl` / `releaseUrl`: GitHub URL for the release (full notes, assets, etc.).
+- `assetSize`: Firmware binary size in bytes (absent on legacy manifest entries).
+
+**Note:** The response is generated by the GitHub Actions `rebuild-archive.yml` / `release.yml` workflows. Older manifest entries may carry a `notes` field with the full markdown; the API and WebUI accept both shapes. The device streams the manifest via an async HTTPS proxy, so a request can return `503` if the HTTPS subsystem is busy (e.g. another fetch or OTA is in progress) — retry shortly afterwards.
 
 ---
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -37,7 +37,7 @@ tags:
   - name: Settings
     description: Device configuration management
   - name: Monitoring
-    description: MQTT and CheckMK monitoring configuration
+    description: MQTT, CheckMK, Prometheus, Syslog and notification configuration
   - name: Firmware
     description: Firmware update management
 
@@ -158,7 +158,7 @@ paths:
       tags:
         - Monitoring
       summary: Get monitoring configuration
-      description: Retrieve MQTT and CheckMK monitoring configuration
+      description: Retrieve MQTT, CheckMK, Prometheus, Syslog and notification configuration
       responses:
         '200':
           description: Monitoring configuration retrieved successfully
@@ -173,7 +173,7 @@ paths:
       tags:
         - Monitoring
       summary: Update monitoring configuration
-      description: Update MQTT and CheckMK monitoring settings
+      description: Update MQTT, CheckMK, Prometheus, Syslog and notification settings
       requestBody:
         required: true
         content:
@@ -385,6 +385,24 @@ components:
           minimum: 0
           maximum: 100
           example: 100
+        betaChannel:
+          type: boolean
+          description: When true, the update check considers GitHub pre-releases
+          example: false
+        flashPause:
+          type: boolean
+          description: >-
+            When true, a system restart holds the Ethernet PHY in hardware reset
+            for ~35 seconds so a connected CCU's link-loss watchdog can trigger
+            a clean CCU restart. Default false.
+          example: false
+        systemLogEnabled:
+          type: boolean
+          description: >-
+            Whether the in-device ring-buffer system log is active (managed from
+            the System Log page; returned here for visibility).
+          example: false
+          readOnly: true
 
     MonitoringConfig:
       type: object
@@ -508,6 +526,129 @@ components:
               type: string
               description: Comma-separated list of allowed IP addresses/ranges
               example: 192.168.1.0/24,10.0.0.5
+        prometheus:
+          type: object
+          description: Prometheus metrics exporter configuration
+          properties:
+            enabled:
+              type: boolean
+              description: Enable the Prometheus exporter
+              example: false
+            port:
+              type: integer
+              description: HTTP port for /metrics (default 9100)
+              minimum: 1
+              maximum: 65535
+              example: 9100
+            allowedHosts:
+              type: string
+              description: Comma-separated source-IP allowlist (Prometheus carries no auth)
+              example: 192.168.1.0/24
+        syslog:
+          type: object
+          description: Syslog forwarding configuration
+          properties:
+            enabled:
+              type: boolean
+              description: Enable Syslog forwarding
+              example: false
+            server:
+              type: string
+              description: Syslog server hostname or IP
+              example: syslog.local
+            port:
+              type: integer
+              description: Syslog server port (default 514)
+              minimum: 1
+              maximum: 65535
+              example: 514
+            transport:
+              type: integer
+              description: Transport mode
+              enum: [0, 1, 2]
+              example: 0
+              x-enum-descriptions:
+                - 0 = UDP
+                - 1 = TCP
+                - 2 = TLS-over-TCP (serialized on the net-fetch mutex; deferred during OTA)
+            minSeverity:
+              type: integer
+              description: Minimum severity to forward (0 = EMERG ... 7 = DEBUG)
+              minimum: 0
+              maximum: 7
+              example: 5
+            hostname:
+              type: string
+              description: Hostname tag override; empty = device hostname
+              example: ''
+        notify:
+          type: object
+          description: Event notification configuration (webhook / Telegram / email)
+          properties:
+            enabled:
+              type: boolean
+              description: Master switch for notifications
+              example: false
+            channels:
+              type: integer
+              description: Bitmask of active channels (1 = webhook, 2 = Telegram, 4 = email)
+              example: 0
+            cooldownSeconds:
+              type: integer
+              description: Per-event-type dedupe window in seconds
+              minimum: 0
+              example: 300
+            webhookUrl:
+              type: string
+              description: HTTP POST target for webhook notifications
+              example: ''
+            webhookSecretSet:
+              type: boolean
+              description: Read-only flag indicating a webhook secret is stored
+              readOnly: true
+            telegramTokenSet:
+              type: boolean
+              description: Read-only flag indicating a Telegram bot token is stored
+              readOnly: true
+            telegramChatId:
+              type: string
+              description: Telegram target chat ID
+              example: ''
+            smtpServer:
+              type: string
+              description: SMTP relay hostname or IP
+              example: ''
+            smtpPort:
+              type: integer
+              description: SMTP relay port
+              minimum: 1
+              maximum: 65535
+              example: 587
+            smtpTls:
+              type: integer
+              description: SMTP transport security
+              enum: [0, 1, 2]
+              example: 1
+              x-enum-descriptions:
+                - 0 = none (plaintext)
+                - 1 = STARTTLS
+                - 2 = implicit TLS
+            smtpUser:
+              type: string
+              description: SMTP authentication username (optional)
+              example: ''
+            smtpPasswordSet:
+              type: boolean
+              description: Read-only flag indicating an SMTP password is stored
+              readOnly: true
+            smtpFrom:
+              type: string
+              description: SMTP envelope sender
+              example: ''
+            smtpTo:
+              type: string
+              description: SMTP envelope recipient
+              example: ''
 
   responses:
     Unauthorized:

--- a/include/monitoring.h
+++ b/include/monitoring.h
@@ -167,4 +167,13 @@ esp_err_t checkmk_stop(void);
 // TLS connections never occupy the heap at once on memory-constrained devices.
 extern SemaphoreHandle_t g_net_fetch_mutex;
 
+// OTA download activity flag. Set by both OTA paths (WebUI URL download and
+// MQTT-triggered update) around their TLS download so that lower-priority
+// outbound TLS consumers (event notifications, syslog forwarding) can defer
+// and leave the mutex uncontested for the duration of a firmware download.
+// Without this, an SMTP notification fired by ota_started can hold
+// g_net_fetch_mutex for 20-40s and starve the OTA itself.
+void net_fetch_set_ota_active(bool active);
+bool net_fetch_ota_active(void);
+
 #endif // MONITORING_H

--- a/main/events.cpp
+++ b/main/events.cpp
@@ -501,6 +501,27 @@ static void events_task(void *)
         EventEntry e;
         if (xQueueReceive(s_queue, &e, pdMS_TO_TICKS(500)) != pdTRUE) continue;
 
+        // Defer notification delivery while a firmware OTA download is in
+        // progress. The OTA path holds g_net_fetch_mutex for the whole TLS
+        // download; if we tried to send (webhook/telegram/email) at the same
+        // time we would either block on that mutex for tens of seconds or,
+        // worse, starve the OTA of heap by opening a second TLS context.
+        // We poll up to ~3 minutes; if OTA still isn't done, the event is
+        // dropped (acceptable for non-critical notifications, and the cooldown
+        // logic will suppress duplicates once delivery resumes).
+        if (net_fetch_ota_active()) {
+            int waited = 0;
+            while (s_running.load() && net_fetch_ota_active() && waited < 180000) {
+                vTaskDelay(pdMS_TO_TICKS(500));
+                waited += 500;
+            }
+            if (net_fetch_ota_active()) {
+                ESP_LOGW(TAG, "dropping event %d: OTA still active after wait",
+                         (int)e.id);
+                continue;
+            }
+        }
+
         if ((int)e.id >= 0 && (int)e.id < MAX_EVENT_ID) {
             int64_t now = esp_timer_get_time();
             int64_t cooldown_us = (int64_t)s_cfg.cooldown_seconds * 1000000LL;

--- a/main/monitoring.cpp
+++ b/main/monitoring.cpp
@@ -56,6 +56,19 @@ static const char *TAG = "MONITORING";
 SemaphoreHandle_t g_net_fetch_mutex = NULL;
 static StaticSemaphore_t net_fetch_mutex_buffer;
 
+// True while an OTA firmware download is streaming. See net_fetch_set_ota_active().
+static std::atomic<bool> g_ota_active{false};
+
+void net_fetch_set_ota_active(bool active)
+{
+    g_ota_active.store(active);
+}
+
+bool net_fetch_ota_active(void)
+{
+    return g_ota_active.load();
+}
+
 static monitoring_config_t current_config = {};
 static SemaphoreHandle_t config_mutex = NULL;
 static std::atomic<bool> checkmk_running{false};

--- a/main/syslog.cpp
+++ b/main/syslog.cpp
@@ -364,7 +364,14 @@ static void syslog_task(void *pv)
             // TLS — fresh handshake per message under the net-fetch mutex.
             // Syslog volumes are modest; a persistent TLS session is not
             // worth the heap on this device.
-            send_tls(s_cfg.server, s_cfg.port, e.buf, e.len);
+            //
+            // Skip while an OTA firmware download is in progress: the OTA
+            // owns g_net_fetch_mutex for the whole download, and contending
+            // for it (or opening a second TLS context) risks starving the
+            // OTA of heap. The log line is dropped; the queue keeps moving.
+            if (!net_fetch_ota_active()) {
+                send_tls(s_cfg.server, s_cfg.port, e.buf, e.len);
+            }
         }
     }
 

--- a/main/updatecheck.cpp
+++ b/main/updatecheck.cpp
@@ -698,6 +698,7 @@ void UpdateCheck::performOnlineUpdate()
     }
 
     auto releaseOperation = [&]() {
+        net_fetch_set_ota_active(false);
         if (net_locked) {
             xSemaphoreGive(g_net_fetch_mutex);
             net_locked = false;
@@ -708,13 +709,33 @@ void UpdateCheck::performOnlineUpdate()
     esp_https_ota_config_t ota_config = {};
     ota_config.http_config = &config;
 
+    // Signal lower-priority TLS consumers (event notifications, syslog
+    // forwarding) to stand down for the duration of the download so they
+    // don't contend for g_net_fetch_mutex or the limited TLS heap.
+    net_fetch_set_ota_active(true);
+
     // Use the advanced esp_https_ota API so we can report real progress to
     // MQTT / WebUI. The simple esp_https_ota(&ota_config) call is a thin
     // wrapper around these steps but hides all intermediate state.
+    //
+    // Retry the begin a couple of times: the GitHub asset redirect forces a
+    // second TLS handshake to objects.githubusercontent.com which can
+    // transiently OOM on the WROOM-32. Mirrors the WebUI OTA path.
     esp_https_ota_handle_t ota_handle = NULL;
-    esp_err_t ret = esp_https_ota_begin(&ota_config, &ota_handle);
+    esp_err_t ret = ESP_FAIL;
+    for (int attempt = 1; attempt <= 3; ++attempt) {
+        ret = esp_https_ota_begin(&ota_config, &ota_handle);
+        if (ret == ESP_OK) {
+            break;
+        }
+        ESP_LOGW(TAG, "esp_https_ota_begin attempt %d/3 failed: %s",
+                 attempt, esp_err_to_name(ret));
+        if (attempt < 3) {
+            vTaskDelay(pdMS_TO_TICKS(2000));
+        }
+    }
     if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "esp_https_ota_begin failed: %s", esp_err_to_name(ret));
+        ESP_LOGE(TAG, "esp_https_ota_begin failed after retries: %s", esp_err_to_name(ret));
         if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
             _setOtaStateLocked(OTA_STATE_FAILED);
             _setOtaErrorLocked(ret, esp_err_to_name(ret));

--- a/main/webui.cpp
+++ b/main/webui.cpp
@@ -1424,7 +1424,7 @@ static esp_err_t post_ota_url_handler_func(httpd_req_t *req)
 
         esp_http_client_config_t config = {};
         configure_ota_http_client(config, a->url);
-        config.timeout_ms = 30000;
+        config.timeout_ms = 60000;
         config.buffer_size = 4096;
 
         esp_https_ota_config_t ota_config = {};
@@ -1432,15 +1432,36 @@ static esp_err_t post_ota_url_handler_func(httpd_req_t *req)
 
         a->statusLED->setState(LED_STATE_BLINK_FAST);
 
-        // Use advanced OTA API for progress tracking
+        // Signal lower-priority TLS consumers (event notifications, syslog
+        // forwarding) to stand down for the duration of the download so they
+        // don't contend for g_net_fetch_mutex or the limited TLS heap.
+        net_fetch_set_ota_active(true);
+
+        // Use advanced OTA API for progress tracking. Retry the begin+download
+        // a couple of times — the GitHub asset redirect forces a second TLS
+        // handshake to objects.githubusercontent.com which can transiently OOM
+        // on the WROOM-32. A single transient failure should not force the
+        // user to click "Update" repeatedly.
         esp_https_ota_handle_t ota_handle = NULL;
-        esp_err_t ret = esp_https_ota_begin(&ota_config, &ota_handle);
+        esp_err_t ret = ESP_FAIL;
+        for (int attempt = 1; attempt <= 3; ++attempt) {
+            ret = esp_https_ota_begin(&ota_config, &ota_handle);
+            if (ret == ESP_OK) {
+                break;
+            }
+            ESP_LOGW(TAG, "OTA begin attempt %d/3 failed: %s",
+                     attempt, esp_err_to_name(ret));
+            if (attempt < 3) {
+                vTaskDelay(pdMS_TO_TICKS(2000));
+            }
+        }
 
         if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "OTA begin failed: %s", esp_err_to_name(ret));
+            ESP_LOGE(TAG, "OTA begin failed after retries: %s", esp_err_to_name(ret));
             set_ota_error("OTA begin failed: %s", esp_err_to_name(ret));
             _ota_status = OTA_FAILED;
             a->statusLED->setState(LED_STATE_ON);
+            net_fetch_set_ota_active(false);
             if (net_locked) xSemaphoreGive(g_net_fetch_mutex);
             free(a->url);
             delete a;
@@ -1452,6 +1473,10 @@ static esp_err_t post_ota_url_handler_func(httpd_req_t *req)
         int image_size = esp_https_ota_get_image_size(ota_handle);
         ESP_LOGI(TAG, "OTA image size: %d bytes", image_size);
 
+        // Yield periodically (every 8th chunk) rather than every chunk so the
+        // total artificial delay over a ~1.5 MB image stays modest. This
+        // matches the MQTT-triggered OTA path in updatecheck.cpp.
+        int otaChunk = 0;
         while (true) {
             ret = esp_https_ota_perform(ota_handle);
             if (ret != ESP_ERR_HTTPS_OTA_IN_PROGRESS) {
@@ -1462,7 +1487,9 @@ static esp_err_t post_ota_url_handler_func(httpd_req_t *req)
                 int downloaded = esp_https_ota_get_image_len_read(ota_handle);
                 _ota_progress = (int)((int64_t)downloaded * 100 / image_size);
             }
-            vTaskDelay(pdMS_TO_TICKS(10));
+            if ((++otaChunk & 0x07) == 0) {
+                vTaskDelay(pdMS_TO_TICKS(10));
+            }
         }
 
         bool complete = esp_https_ota_is_complete_data_received(ota_handle);
@@ -1482,6 +1509,7 @@ static esp_err_t post_ota_url_handler_func(httpd_req_t *req)
             _ota_status = OTA_SUCCESS;
             ResetInfo::storeResetReason(RESET_REASON_FIRMWARE_UPDATE);
             a->statusLED->setState(LED_STATE_OFF);
+            net_fetch_set_ota_active(false);
             if (net_locked) xSemaphoreGive(g_net_fetch_mutex);
             free(a->url);
             delete a;
@@ -1494,6 +1522,7 @@ static esp_err_t post_ota_url_handler_func(httpd_req_t *req)
             _ota_status = OTA_FAILED;
             ResetInfo::storeResetReason(RESET_REASON_UPDATE_FAILED);
             a->statusLED->setState(LED_STATE_ON);
+            net_fetch_set_ota_active(false);
             if (net_locked) xSemaphoreGive(g_net_fetch_mutex);
             free(a->url);
             delete a;
@@ -1659,9 +1688,12 @@ static void _async_proxy_task(void *arg)
 
     // Serialize with UpdateCheck background fetch so two TLS handshakes never
     // exhaust the heap at once. Never continue unlocked after a timeout.
+    // The 45 s budget tolerates a long-lived mutex holder (e.g. an in-flight
+    // SMTP notification) without prematurely failing the firmware archive /
+    // changelog fetch.
     bool net_locked = false;
     if (g_net_fetch_mutex) {
-        if (xSemaphoreTake(g_net_fetch_mutex, pdMS_TO_TICKS(15000)) != pdTRUE) {
+        if (xSemaphoreTake(g_net_fetch_mutex, pdMS_TO_TICKS(45000)) != pdTRUE) {
             ESP_LOGW(TAG, "External proxy rejected: HTTPS subsystem busy");
             httpd_resp_set_status(job->req, "503 Service Unavailable");
             httpd_resp_set_type(job->req, "text/plain");
@@ -1679,7 +1711,7 @@ static void _async_proxy_task(void *arg)
     configure_ota_http_client(config, job->url);
     config.event_handler = _proxy_http_event_handler;
     config.user_data = job;
-    config.timeout_ms = 10000;
+    config.timeout_ms = 30000;
     config.buffer_size = 4096;
 
     httpd_resp_set_type(job->req, job->content_type);

--- a/webui/src/components/NewDesignHeader.vue
+++ b/webui/src/components/NewDesignHeader.vue
@@ -367,6 +367,24 @@ onUnmounted(() => {
   flex-direction: column;
   gap: 28px;
   pointer-events: auto;
+  /* Allow the sidebar to scroll vertically when the viewport is too short to
+     show every nav item plus the pinned footer (restart / logout). Without
+     this, items silently overflow below the fold and become unreachable —
+     which was the "Vollbildmodus" bug. min-height:0 lets the flex column
+     shrink so overflow actually engages. */
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+  scrollbar-width: thin;
+}
+
+.desktop-sidebar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.desktop-sidebar::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: 3px;
 }
 
 .header-nav {

--- a/webui/src/firmwareupdate.vue
+++ b/webui/src/firmwareupdate.vue
@@ -302,12 +302,22 @@
                 </button>
               </div>
             </div>
-            <details v-if="selectedArchiveRelease.notes" class="archive-notes" open>
+            <details v-if="selectedArchiveRelease.notes" class="archive-notes">
               <summary>
                 <AppIcon name="logs" />
                 {{ t('firmware.archiveReleaseNotes') }}
               </summary>
               <pre>{{ selectedArchiveRelease.notes }}</pre>
+              <a
+                v-if="selectedArchiveRelease.notesUrl"
+                class="archive-notes-link"
+                :href="selectedArchiveRelease.notesUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <AppIcon name="externalLink" />
+                {{ t('firmware.viewOnGithub') }}
+              </a>
             </details>
           </div>
         </div>
@@ -491,7 +501,8 @@ const normalizeArchiveEntry = (entry, index = 0) => {
     downloadUrl,
     assetName: entry.assetName || entry.asset_name || (downloadUrl ? downloadUrl.split('/').pop() : ''),
     assetSize: entry.assetSize || entry.asset_size || entry.size || 0,
-    notes: entry.notes || entry.body || '',
+    notes: entry.notesExcerpt || entry.notes || entry.body || '',
+    notesUrl: entry.notesUrl || entry.releaseUrl || entry.html_url || '',
     isCurrent: currentVersion && normalizeVersion(version) === currentVersion
   }
 }
@@ -1418,6 +1429,21 @@ onUnmounted(() => {
   border: 1px solid var(--color-border-light);
   font-family: inherit;
   font-size: 0.8125rem;
+}
+
+.archive-notes-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: var(--spacing-sm);
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.archive-notes-link:hover {
+  color: var(--color-primary);
 }
 
 /* System Actions */

--- a/webui/src/locales/cs.js
+++ b/webui/src/locales/cs.js
@@ -359,6 +359,9 @@ export default {
     diagnosticFailed: 'Diagnostický požadavek selhal',
     chipLabelCheckmk: 'CheckMK',
     chipLabelMqtt: 'MQTT',
+    chipLabelPrometheus: 'Prometheus',
+    chipLabelSyslog: 'Syslog',
+    chipLabelNotify: 'Oznámení',
     title: 'Monitorování',
     description: 'Nakonfigurujte monitorování CheckMK a MQTT pro bránu HB-RF-ETH.',
     save: 'Uložit',
@@ -431,6 +434,52 @@ export default {
     },
     enable: 'Povolit',
     allowedHosts: 'Povolené hostitelé',
+    prometheus: {
+      title: 'Exportér Prometheus',
+      port: 'Port',
+      portHelp: 'Výchozí: 9100',
+      allowedHosts: 'Povolené IP klientů',
+      allowedHostsHelp: 'IP adresy oddělené čárkami nebo "*" pro všechny'
+    },
+    syslog: {
+      title: 'Přesměrování Syslog',
+      server: 'Server',
+      serverHelp: 'Hostitelské jméno nebo IP Syslog serveru',
+      port: 'Port',
+      portHelp: 'Výchozí: 514',
+      transport: 'Transport',
+      minSeverity: 'Min. závažnost',
+      minSeverityHelp: 'Přesměrovávat pouze zprávy od této závažnosti výše',
+      hostname: 'Přepsání hostitele',
+      hostnameHelp: 'Prázdné = použít hostitele zařízení'
+    },
+    notify: {
+      title: 'Oznámení o událostech',
+      channels: 'Aktivní kanály',
+      channelWebhook: 'Webhook',
+      channelTelegram: 'Telegram',
+      channelEmail: 'E-mail',
+      cooldown: 'Cooldown (sekundy)',
+      cooldownHelp: 'Pro každý typ události bude oznámeno pouze jednou v rámci tohoto okna',
+      webhookSection: 'Webhook',
+      webhookUrl: 'URL',
+      webhookSecret: 'Secret',
+      telegramSection: 'Telegram',
+      telegramToken: 'Bot-Token',
+      telegramChatId: 'Chat-ID',
+      smtpSection: 'E-mail (SMTP)',
+      smtpServer: 'Server',
+      smtpPort: 'Port',
+      smtpTls: 'Šifrování',
+      smtpTlsNone: 'Žádné',
+      smtpTlsStarttls: 'STARTTLS',
+      smtpTlsImplicit: 'TLS (implicitní)',
+      smtpUser: 'Uživatel',
+      smtpPassword: 'Heslo',
+      smtpFrom: 'Odesílatel',
+      smtpTo: 'Příjemce',
+      secretPresent: '✓ Uloženo – zadejte novou hodnotu pro nahrazení'
+    },
     diag: {
       unsupported: 'Neznámý cíl diagnostiky',
       checkmk: {
@@ -443,6 +492,20 @@ export default {
         tcp_ok: 'TCP připojení k {host}:{port} úspěšné',
         tcp_failed: 'TCP připojení k {host}:{port} selhalo',
         tls_note: ' (TLS povoleno, ověřování certifikátů není testováno)'
+      },
+      prometheus: {
+        disabled: 'Prometheus je zakázán',
+        listening: 'Exportér Prometheus naslouchá na TCP portu {port}',
+        not_ready: 'Prometheus je povolen, ale naslouchač není připraven'
+      },
+      syslog: {
+        disabled: 'Přesměrování Syslog je zakázáno',
+        tcp_ok: 'TCP připojení k {host}:{port} úspěšné',
+        tcp_failed: 'TCP připojení k {host}:{port} selhalo'
+      },
+      notify: {
+        disabled: 'Oznámení jsou zakázána',
+        queued: 'Testovací oznámení pro kanály 0x{mask} zařazeno do fronty'
       }
     }
   },

--- a/webui/src/locales/es.js
+++ b/webui/src/locales/es.js
@@ -359,6 +359,9 @@ export default {
     diagnosticFailed: 'La solicitud de diagnóstico falló',
     chipLabelCheckmk: 'CheckMK',
     chipLabelMqtt: 'MQTT',
+    chipLabelPrometheus: 'Prometheus',
+    chipLabelSyslog: 'Syslog',
+    chipLabelNotify: 'Notificaciones',
     title: 'Monitoreo',
     description: 'Configure el monitoreo CheckMK y MQTT para la puerta de enlace HB-RF-ETH.',
     save: 'Guardar',
@@ -431,6 +434,52 @@ export default {
     },
     enable: 'Habilitar',
     allowedHosts: 'Hosts permitidos',
+    prometheus: {
+      title: 'Exportador Prometheus',
+      port: 'Puerto',
+      portHelp: 'Predeterminado: 9100',
+      allowedHosts: 'IPs de clientes permitidas',
+      allowedHostsHelp: 'Direcciones IP separadas por comas o "*" para todas'
+    },
+    syslog: {
+      title: 'Reenvío de Syslog',
+      server: 'Servidor',
+      serverHelp: 'Nombre de host o IP del servidor Syslog',
+      port: 'Puerto',
+      portHelp: 'Predeterminado: 514',
+      transport: 'Transporte',
+      minSeverity: 'Severidad mín.',
+      minSeverityHelp: 'Solo reenviar mensajes a partir de este nivel de severidad',
+      hostname: 'Sobrescribir hostname',
+      hostnameHelp: 'Vacío = usar el hostname del dispositivo'
+    },
+    notify: {
+      title: 'Notificaciones de eventos',
+      channels: 'Canales activos',
+      channelWebhook: 'Webhook',
+      channelTelegram: 'Telegram',
+      channelEmail: 'Correo electrónico',
+      cooldown: 'Enfriamiento (segundos)',
+      cooldownHelp: 'Por tipo de evento solo se notifica una vez dentro de esta ventana',
+      webhookSection: 'Webhook',
+      webhookUrl: 'URL',
+      webhookSecret: 'Secreto',
+      telegramSection: 'Telegram',
+      telegramToken: 'Token del bot',
+      telegramChatId: 'ID de chat',
+      smtpSection: 'Correo (SMTP)',
+      smtpServer: 'Servidor',
+      smtpPort: 'Puerto',
+      smtpTls: 'Cifrado',
+      smtpTlsNone: 'Ninguno',
+      smtpTlsStarttls: 'STARTTLS',
+      smtpTlsImplicit: 'TLS (implícito)',
+      smtpUser: 'Usuario',
+      smtpPassword: 'Contraseña',
+      smtpFrom: 'Remitente',
+      smtpTo: 'Destinatario',
+      secretPresent: '✓ Guardado – introduzca uno nuevo para reemplazar'
+    },
     diag: {
       unsupported: 'Destino de diagnóstico desconocido',
       checkmk: {
@@ -443,6 +492,20 @@ export default {
         tcp_ok: 'Conexión TCP a {host}:{port} correcta',
         tcp_failed: 'Error en la conexión TCP a {host}:{port}',
         tls_note: ' (TLS activado, validación de certificados no comprobada)'
+      },
+      prometheus: {
+        disabled: 'Prometheus está desactivado',
+        listening: 'El exportador Prometheus escucha en el puerto TCP {port}',
+        not_ready: 'Prometheus está activado, pero el listener no está listo'
+      },
+      syslog: {
+        disabled: 'El reenvío de Syslog está desactivado',
+        tcp_ok: 'Conexión TCP a {host}:{port} correcta',
+        tcp_failed: 'Error en la conexión TCP a {host}:{port}'
+      },
+      notify: {
+        disabled: 'Las notificaciones están desactivadas',
+        queued: 'Notificación de prueba para los canales 0x{mask} encolada'
       }
     }
   },

--- a/webui/src/locales/fr.js
+++ b/webui/src/locales/fr.js
@@ -359,6 +359,9 @@ export default {
     diagnosticFailed: 'Échec de la demande de diagnostic',
     chipLabelCheckmk: 'CheckMK',
     chipLabelMqtt: 'MQTT',
+    chipLabelPrometheus: 'Prometheus',
+    chipLabelSyslog: 'Syslog',
+    chipLabelNotify: 'Notifications',
     title: 'Surveillance',
     description: 'Configurer la surveillance CheckMK et MQTT pour la passerelle HB-RF-ETH.',
     save: 'Enregistrer',
@@ -431,6 +434,52 @@ export default {
     },
     enable: 'Activer',
     allowedHosts: 'Hôtes autorisés',
+    prometheus: {
+      title: 'Exporteur Prometheus',
+      port: 'Port',
+      portHelp: 'Par défaut : 9100',
+      allowedHosts: 'IPs clientes autorisées',
+      allowedHostsHelp: 'Adresses IP séparées par des virgules ou "*" pour tous'
+    },
+    syslog: {
+      title: 'Transfert Syslog',
+      server: 'Serveur',
+      serverHelp: 'Nom d\'hôte ou IP du serveur Syslog',
+      port: 'Port',
+      portHelp: 'Par défaut : 514',
+      transport: 'Transport',
+      minSeverity: 'Sévérité min.',
+      minSeverityHelp: 'Transférer uniquement les messages à partir de cette sévérité',
+      hostname: 'Remplacement du nom d\'hôte',
+      hostnameHelp: 'Vide = utiliser le nom d\'hôte de l\'appareil'
+    },
+    notify: {
+      title: 'Notifications d\'événements',
+      channels: 'Canaux actifs',
+      channelWebhook: 'Webhook',
+      channelTelegram: 'Telegram',
+      channelEmail: 'E-mail',
+      cooldown: 'Intervalle (secondes)',
+      cooldownHelp: 'Pour chaque type d\'événement, une seule notification est envoyée pendant cette fenêtre',
+      webhookSection: 'Webhook',
+      webhookUrl: 'URL',
+      webhookSecret: 'Secret',
+      telegramSection: 'Telegram',
+      telegramToken: 'Jeton du bot',
+      telegramChatId: 'ID de chat',
+      smtpSection: 'E-mail (SMTP)',
+      smtpServer: 'Serveur',
+      smtpPort: 'Port',
+      smtpTls: 'Chiffrement',
+      smtpTlsNone: 'Aucun',
+      smtpTlsStarttls: 'STARTTLS',
+      smtpTlsImplicit: 'TLS (implicite)',
+      smtpUser: 'Utilisateur',
+      smtpPassword: 'Mot de passe',
+      smtpFrom: 'Expéditeur',
+      smtpTo: 'Destinataire',
+      secretPresent: '✓ Enregistré – saisir une nouvelle valeur pour remplacer'
+    },
     diag: {
       unsupported: 'Cible de diagnostic inconnue',
       checkmk: {
@@ -443,6 +492,20 @@ export default {
         tcp_ok: 'Connexion TCP à {host}:{port} réussie',
         tcp_failed: 'Échec de la connexion TCP à {host}:{port}',
         tls_note: ' (TLS activé, validation des certificats non testée)'
+      },
+      prometheus: {
+        disabled: 'Prometheus est désactivé',
+        listening: 'L\'exporteur Prometheus écoute sur le port TCP {port}',
+        not_ready: 'Prometheus est activé, mais le listener n\'est pas prêt'
+      },
+      syslog: {
+        disabled: 'Le transfert Syslog est désactivé',
+        tcp_ok: 'Connexion TCP à {host}:{port} réussie',
+        tcp_failed: 'Échec de la connexion TCP à {host}:{port}'
+      },
+      notify: {
+        disabled: 'Les notifications sont désactivées',
+        queued: 'Notification de test mise en file pour les canaux 0x{mask}'
       }
     }
   },

--- a/webui/src/locales/it.js
+++ b/webui/src/locales/it.js
@@ -359,6 +359,9 @@ export default {
     diagnosticFailed: 'Richiesta di diagnostica non riuscita',
     chipLabelCheckmk: 'CheckMK',
     chipLabelMqtt: 'MQTT',
+    chipLabelPrometheus: 'Prometheus',
+    chipLabelSyslog: 'Syslog',
+    chipLabelNotify: 'Notifiche',
     title: 'Monitoraggio',
     description: 'Configura il monitoraggio CheckMK e MQTT per il gateway HB-RF-ETH.',
     save: 'Salva',
@@ -431,6 +434,52 @@ export default {
     },
     enable: 'Abilita',
     allowedHosts: 'Host Consentiti',
+    prometheus: {
+      title: 'Esportatore Prometheus',
+      port: 'Porta',
+      portHelp: 'Predefinito: 9100',
+      allowedHosts: 'Host consentiti',
+      allowedHostsHelp: 'Indirizzi IP separati da virgola oppure "*" per consentire tutti'
+    },
+    syslog: {
+      title: 'Inoltro Syslog',
+      server: 'Server',
+      serverHelp: 'Hostname o IP del server Syslog',
+      port: 'Porta',
+      portHelp: 'Predefinito: 514',
+      transport: 'Trasporto',
+      minSeverity: 'Gravità min.',
+      minSeverityHelp: 'Inoltra solo i messaggi a partire da questo livello di gravità',
+      hostname: 'Override hostname',
+      hostnameHelp: 'Vuoto = usa l\'hostname del dispositivo'
+    },
+    notify: {
+      title: 'Notifiche degli eventi',
+      channels: 'Canali attivi',
+      channelWebhook: 'Webhook',
+      channelTelegram: 'Telegram',
+      channelEmail: 'E-mail',
+      cooldown: 'Intervallo (secondi)',
+      cooldownHelp: 'Per ogni tipo di evento viene inviata una sola notifica durante questa finestra',
+      webhookSection: 'Webhook',
+      webhookUrl: 'URL',
+      webhookSecret: 'Secret',
+      telegramSection: 'Telegram',
+      telegramToken: 'Token del bot',
+      telegramChatId: 'Chat ID',
+      smtpSection: 'E-mail (SMTP)',
+      smtpServer: 'Server',
+      smtpPort: 'Porta',
+      smtpTls: 'Crittografia',
+      smtpTlsNone: 'Nessuna',
+      smtpTlsStarttls: 'STARTTLS',
+      smtpTlsImplicit: 'TLS (implicito)',
+      smtpUser: 'Utente',
+      smtpPassword: 'Password',
+      smtpFrom: 'Mittente',
+      smtpTo: 'Destinatario',
+      secretPresent: '✓ Salvato – inserire un nuovo valore per sostituire'
+    },
     diag: {
       unsupported: 'Destinazione di diagnostica sconosciuta',
       checkmk: {
@@ -443,6 +492,20 @@ export default {
         tcp_ok: 'Connessione TCP a {host}:{port} riuscita',
         tcp_failed: 'Connessione TCP a {host}:{port} non riuscita',
         tls_note: ' (TLS attivo, verifica dei certificati non testata)'
+      },
+      prometheus: {
+        disabled: 'Prometheus è disattivato',
+        listening: 'L\'esportatore Prometheus è in ascolto sulla porta TCP {port}',
+        not_ready: 'Prometheus è attivato, ma il listener non è pronto'
+      },
+      syslog: {
+        disabled: 'L\'inoltro Syslog è disattivato',
+        tcp_ok: 'Connessione TCP a {host}:{port} riuscita',
+        tcp_failed: 'Connessione TCP a {host}:{port} non riuscita'
+      },
+      notify: {
+        disabled: 'Le notifiche sono disattivate',
+        queued: 'Notifica di prova accodata per i canali 0x{mask}'
       }
     }
   },

--- a/webui/src/locales/nl.js
+++ b/webui/src/locales/nl.js
@@ -359,6 +359,9 @@ export default {
     diagnosticFailed: 'Diagnoseverzoek mislukt',
     chipLabelCheckmk: 'CheckMK',
     chipLabelMqtt: 'MQTT',
+    chipLabelPrometheus: 'Prometheus',
+    chipLabelSyslog: 'Syslog',
+    chipLabelNotify: 'Notificaties',
     title: 'Monitoring',
     description: 'Configureer CheckMK en MQTT monitoring voor de HB-RF-ETH gateway.',
     save: 'Opslaan',
@@ -431,6 +434,52 @@ export default {
     },
     enable: 'Inschakelen',
     allowedHosts: 'Toegestane Hosts',
+    prometheus: {
+      title: 'Prometheus Exporter',
+      port: 'Poort',
+      portHelp: 'Standaard: 9100',
+      allowedHosts: 'Toegestane Client IP\'s',
+      allowedHostsHelp: 'Komma-gescheiden IP-adressen of "*" voor alles'
+    },
+    syslog: {
+      title: 'Syslog Doorsturen',
+      server: 'Server',
+      serverHelp: 'Hostnaam of IP van de Syslog-server',
+      port: 'Poort',
+      portHelp: 'Standaard: 514',
+      transport: 'Transport',
+      minSeverity: 'Min. ernst',
+      minSeverityHelp: 'Alleen berichten vanaf dit ernstniveau doorsturen',
+      hostname: 'Hostnaam overschrijven',
+      hostnameHelp: 'Leeg = hostnaam van apparaat gebruiken'
+    },
+    notify: {
+      title: 'Gebeurtenisnotificaties',
+      channels: 'Actieve kanalen',
+      channelWebhook: 'Webhook',
+      channelTelegram: 'Telegram',
+      channelEmail: 'E-mail',
+      cooldown: 'Cooldown (seconden)',
+      cooldownHelp: 'Per gebeurtenistype wordt binnen dit venster slechts één keer gemeld',
+      webhookSection: 'Webhook',
+      webhookUrl: 'URL',
+      webhookSecret: 'Secret',
+      telegramSection: 'Telegram',
+      telegramToken: 'Bot-token',
+      telegramChatId: 'Chat-ID',
+      smtpSection: 'E-mail (SMTP)',
+      smtpServer: 'Server',
+      smtpPort: 'Poort',
+      smtpTls: 'Versleuteling',
+      smtpTlsNone: 'Geen',
+      smtpTlsStarttls: 'STARTTLS',
+      smtpTlsImplicit: 'TLS (impliciet)',
+      smtpUser: 'Gebruiker',
+      smtpPassword: 'Wachtwoord',
+      smtpFrom: 'Afzender',
+      smtpTo: 'Ontvanger',
+      secretPresent: '✓ Opgeslagen – voer nieuwe in om te vervangen'
+    },
     diag: {
       unsupported: 'Onbekend diagnose-doel',
       checkmk: {
@@ -443,6 +492,20 @@ export default {
         tcp_ok: 'TCP-verbinding naar {host}:{port} geslaagd',
         tcp_failed: 'TCP-verbinding naar {host}:{port} mislukt',
         tls_note: ' (TLS ingeschakeld, certificaatverificatie niet getest)'
+      },
+      prometheus: {
+        disabled: 'Prometheus is uitgeschakeld',
+        listening: 'Prometheus-exporter luistert op TCP-poort {port}',
+        not_ready: 'Prometheus is ingeschakeld, maar listener is niet klaar'
+      },
+      syslog: {
+        disabled: 'Syslog-doorsturen is uitgeschakeld',
+        tcp_ok: 'TCP-verbinding naar {host}:{port} geslaagd',
+        tcp_failed: 'TCP-verbinding naar {host}:{port} mislukt'
+      },
+      notify: {
+        disabled: 'Notificaties zijn uitgeschakeld',
+        queued: 'Testnotificatie voor kanalen 0x{mask} in de wachtrij geplaatst'
       }
     }
   },

--- a/webui/src/locales/no.js
+++ b/webui/src/locales/no.js
@@ -359,6 +359,9 @@ export default {
     diagnosticFailed: 'Diagnoseforespørselen mislyktes',
     chipLabelCheckmk: 'CheckMK',
     chipLabelMqtt: 'MQTT',
+    chipLabelPrometheus: 'Prometheus',
+    chipLabelSyslog: 'Syslog',
+    chipLabelNotify: 'Varsler',
     title: 'Overvåking',
     description: 'Konfigurer CheckMK og MQTT-overvåking for HB-RF-ETH-gatewayen.',
     save: 'Lagre',
@@ -431,6 +434,52 @@ export default {
     },
     enable: 'Aktiver',
     allowedHosts: 'Tillatte verter',
+    prometheus: {
+      title: 'Prometheus Eksporter',
+      port: 'Port',
+      portHelp: 'Standard: 9100',
+      allowedHosts: 'Tillatte klient-IP-er',
+      allowedHostsHelp: 'Kommaseparerte IP-adresser eller "*" for alle'
+    },
+    syslog: {
+      title: 'Syslog-videresending',
+      server: 'Server',
+      serverHelp: 'Vertsnavn eller IP for Syslog-serveren',
+      port: 'Port',
+      portHelp: 'Standard: 514',
+      transport: 'Transport',
+      minSeverity: 'Min. alvorlighetsgrad',
+      minSeverityHelp: 'Videresend kun meldinger fra denne alvorlighetsgraden og opp',
+      hostname: 'Vertsnavn-overskriving',
+      hostnameHelp: 'Tom = bruk enhetens vertsnavn'
+    },
+    notify: {
+      title: 'Hendelsesvarsler',
+      channels: 'Aktive kanaler',
+      channelWebhook: 'Webhook',
+      channelTelegram: 'Telegram',
+      channelEmail: 'E-post',
+      cooldown: 'Nedkjøling (sekunder)',
+      cooldownHelp: 'Per hendelsestype varsles det kun én gang innenfor dette vinduet',
+      webhookSection: 'Webhook',
+      webhookUrl: 'URL',
+      webhookSecret: 'Secret',
+      telegramSection: 'Telegram',
+      telegramToken: 'Bot-token',
+      telegramChatId: 'Chat-ID',
+      smtpSection: 'E-post (SMTP)',
+      smtpServer: 'Server',
+      smtpPort: 'Port',
+      smtpTls: 'Kryptering',
+      smtpTlsNone: 'Ingen',
+      smtpTlsStarttls: 'STARTTLS',
+      smtpTlsImplicit: 'TLS (implisitt)',
+      smtpUser: 'Bruker',
+      smtpPassword: 'Passord',
+      smtpFrom: 'Avsender',
+      smtpTo: 'Mottaker',
+      secretPresent: '✓ Lagret – skriv inn ny verdi for å erstatte'
+    },
     diag: {
       unsupported: 'Ukjent diagnosemål',
       checkmk: {
@@ -443,6 +492,20 @@ export default {
         tcp_ok: 'TCP-tilkobling til {host}:{port} lyktes',
         tcp_failed: 'TCP-tilkobling til {host}:{port} mislyktes',
         tls_note: ' (TLS aktivert, sertifikatvalidering ikke testet)'
+      },
+      prometheus: {
+        disabled: 'Prometheus er deaktivert',
+        listening: 'Prometheus-eksporter lytter på TCP-port {port}',
+        not_ready: 'Prometheus er aktivert, men lytteren er ikke klar'
+      },
+      syslog: {
+        disabled: 'Syslog-videresending er deaktivert',
+        tcp_ok: 'TCP-tilkobling til {host}:{port} lyktes',
+        tcp_failed: 'TCP-tilkobling til {host}:{port} mislyktes'
+      },
+      notify: {
+        disabled: 'Varsler er deaktivert',
+        queued: 'Test-varsling for kanaler 0x{mask} satt i kø'
       }
     }
   },

--- a/webui/src/locales/pl.js
+++ b/webui/src/locales/pl.js
@@ -359,6 +359,9 @@ export default {
     diagnosticFailed: 'Żądanie diagnostyczne nie powiodło się',
     chipLabelCheckmk: 'CheckMK',
     chipLabelMqtt: 'MQTT',
+    chipLabelPrometheus: 'Prometheus',
+    chipLabelSyslog: 'Syslog',
+    chipLabelNotify: 'Powiadomienia',
     title: 'Monitoring',
     description: 'Skonfiguruj monitoring CheckMK i MQTT dla bramki HB-RF-ETH.',
     save: 'Zapisz',
@@ -431,6 +434,52 @@ export default {
     },
     enable: 'Włącz',
     allowedHosts: 'Dozwolone Hosty',
+    prometheus: {
+      title: 'Eksporter Prometheus',
+      port: 'Port',
+      portHelp: 'Domyślnie: 9100',
+      allowedHosts: 'Dozwolone IP klienta',
+      allowedHostsHelp: 'Adresy IP oddzielone przecinkami lub "*" dla wszystkich'
+    },
+    syslog: {
+      title: 'Przekazywanie Syslog',
+      server: 'Serwer',
+      serverHelp: 'Nazwa hosta lub IP serwera Syslog',
+      port: 'Port',
+      portHelp: 'Domyślnie: 514',
+      transport: 'Transport',
+      minSeverity: 'Min. ważność',
+      minSeverityHelp: 'Przekazuj tylko komunikaty od tego poziomu ważności',
+      hostname: 'Nadpisanie nazwy hosta',
+      hostnameHelp: 'Puste = użyj nazwy hosta urządzenia'
+    },
+    notify: {
+      title: 'Powiadomienia o zdarzeniach',
+      channels: 'Aktywne kanały',
+      channelWebhook: 'Webhook',
+      channelTelegram: 'Telegram',
+      channelEmail: 'E-mail',
+      cooldown: 'Czas powstrzymania (sekundy)',
+      cooldownHelp: 'Dla każdego typu zdarzenia powiadomienie wysyłane jest raz w tym oknie',
+      webhookSection: 'Webhook',
+      webhookUrl: 'URL',
+      webhookSecret: 'Secret',
+      telegramSection: 'Telegram',
+      telegramToken: 'Token bota',
+      telegramChatId: 'ID czatu',
+      smtpSection: 'E-mail (SMTP)',
+      smtpServer: 'Serwer',
+      smtpPort: 'Port',
+      smtpTls: 'Szyfrowanie',
+      smtpTlsNone: 'Brak',
+      smtpTlsStarttls: 'STARTTLS',
+      smtpTlsImplicit: 'TLS (implicite)',
+      smtpUser: 'Użytkownik',
+      smtpPassword: 'Hasło',
+      smtpFrom: 'Nadawca',
+      smtpTo: 'Odbiorca',
+      secretPresent: '✓ Zapisano – wpisz nowe, aby zastąpić'
+    },
     diag: {
       unsupported: 'Nieznany cel diagnostyki',
       checkmk: {
@@ -443,6 +492,20 @@ export default {
         tcp_ok: 'Połączenie TCP z {host}:{port} powiodło się',
         tcp_failed: 'Połączenie TCP z {host}:{port} nie powiodło się',
         tls_note: ' (TLS włączony, walidacja certyfikatów nie jest testowana)'
+      },
+      prometheus: {
+        disabled: 'Prometheus jest wyłączony',
+        listening: 'Eksporter Prometheus nasłuchuje na porcie TCP {port}',
+        not_ready: 'Prometheus jest włączony, ale nasłuchiwacz nie jest gotowy'
+      },
+      syslog: {
+        disabled: 'Przekazywanie Syslog jest wyłączone',
+        tcp_ok: 'Połączenie TCP z {host}:{port} powiodło się',
+        tcp_failed: 'Połączenie TCP z {host}:{port} nie powiodło się'
+      },
+      notify: {
+        disabled: 'Powiadomienia są wyłączone',
+        queued: 'Testowe powiadomienie dla kanałów 0x{mask} dodane do kolejki'
       }
     }
   },

--- a/webui/src/locales/sv.js
+++ b/webui/src/locales/sv.js
@@ -359,6 +359,9 @@ export default {
     diagnosticFailed: 'Diagnostikbegäran misslyckades',
     chipLabelCheckmk: 'CheckMK',
     chipLabelMqtt: 'MQTT',
+    chipLabelPrometheus: 'Prometheus',
+    chipLabelSyslog: 'Syslog',
+    chipLabelNotify: 'Aviseringar',
     title: 'Övervakning',
     description: 'Konfigurera CheckMK och MQTT-övervakning för HB-RF-ETH-gatewayen.',
     save: 'Spara',
@@ -431,6 +434,52 @@ export default {
     },
     enable: 'Aktivera',
     allowedHosts: 'Tillåtna Värdar',
+    prometheus: {
+      title: 'Prometheus Exporter',
+      port: 'Port',
+      portHelp: 'Standard: 9100',
+      allowedHosts: 'Tillåtna klient-IP:er',
+      allowedHostsHelp: 'Kommaseparerade IP-adresser eller "*" för alla'
+    },
+    syslog: {
+      title: 'Syslog-vidarebefordran',
+      server: 'Server',
+      serverHelp: 'Värdnamn eller IP för Syslog-servern',
+      port: 'Port',
+      portHelp: 'Standard: 514',
+      transport: 'Transport',
+      minSeverity: 'Min. allvarlighetsgrad',
+      minSeverityHelp: 'Vidarebefordra endast meddelanden från denna allvarlighetsgrad och uppåt',
+      hostname: 'Värdnamn-överskrivning',
+      hostnameHelp: 'Tomt = använd enhetens värdnamn'
+    },
+    notify: {
+      title: 'Händelseaviseringar',
+      channels: 'Aktiva kanaler',
+      channelWebhook: 'Webhook',
+      channelTelegram: 'Telegram',
+      channelEmail: 'E-post',
+      cooldown: 'Cooldown (sekunder)',
+      cooldownHelp: 'Per händelsetyp aviseras endast en gång inom detta fönster',
+      webhookSection: 'Webhook',
+      webhookUrl: 'URL',
+      webhookSecret: 'Secret',
+      telegramSection: 'Telegram',
+      telegramToken: 'Bot-token',
+      telegramChatId: 'Chat-ID',
+      smtpSection: 'E-post (SMTP)',
+      smtpServer: 'Server',
+      smtpPort: 'Port',
+      smtpTls: 'Kryptering',
+      smtpTlsNone: 'Ingen',
+      smtpTlsStarttls: 'STARTTLS',
+      smtpTlsImplicit: 'TLS (implicit)',
+      smtpUser: 'Användare',
+      smtpPassword: 'Lösenord',
+      smtpFrom: 'Avsändare',
+      smtpTo: 'Mottagare',
+      secretPresent: '✓ Sparat – ange nytt värde för att ersätta'
+    },
     diag: {
       unsupported: 'Okänt diagnostikmål',
       checkmk: {
@@ -443,6 +492,20 @@ export default {
         tcp_ok: 'TCP-anslutning till {host}:{port} lyckades',
         tcp_failed: 'TCP-anslutning till {host}:{port} misslyckades',
         tls_note: ' (TLS aktiverat, certifikatvalidering inte testad)'
+      },
+      prometheus: {
+        disabled: 'Prometheus är inaktiverat',
+        listening: 'Prometheus-exporter lyssnar på TCP-port {port}',
+        not_ready: 'Prometheus är aktiverat, men lyssnaren är inte redo'
+      },
+      syslog: {
+        disabled: 'Syslog-vidarebefordran är inaktiverad',
+        tcp_ok: 'TCP-anslutning till {host}:{port} lyckades',
+        tcp_failed: 'TCP-anslutning till {host}:{port} misslyckades'
+      },
+      notify: {
+        disabled: 'Aviseringar är inaktiverade',
+        queued: 'Testavisering för kanaler 0x{mask} köad'
       }
     }
   },

--- a/webui/src/monitoring.vue
+++ b/webui/src/monitoring.vue
@@ -1067,6 +1067,18 @@ const runDiagnostic = async (target) => {
   font-weight: 600;
 }
 
+/* Tablet range and the experimental sidebar ("fullscreen") layout.
+   In the sidebar layout the available content width is the viewport minus
+   the 384px left padding, so 2- and 3-column Bootstrap grids (col-md-*)
+   that look fine on a full-width desktop get cramped between ~768px and
+   ~1100px. Stack them earlier in that band so the inputs stay readable. */
+@media (max-width: 1100px) {
+  .monitoring-page .row > [class*="col-md-"] {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+}
+
 @media (max-width: 768px) {
   .monitoring-page {
     padding-bottom: 100px;


### PR DESCRIPTION
## Summary

Behebt alle Punkte aus Clems Beta-12-Feedback: Flashpause-Persistenz, OTA-Stabilität, defektes Firmware-Archiv, Responsive-Design (Monitoring + Vollbild) und fehlende i18n-Keys. Zusätzlich Doku-Updates und ein MQTT-OTA-Retry.

## Changes

### Flashpause wird nicht gespeichert
`webui.cpp` POST `/settings.json` hatte den `flashPause`-Block fälschlich *innerhalb* des `systemLogEnabled`-if-Blocks geschachtelt. Da die Settings-Seite `systemLogEnabled` nie sendet, wurde `flashPause` übersprungen → nie gespeichert, Toggle sprang zurück. Auf Top-Level gehoben.

### OTA „ESP failed" (seit Beta 10)
- WebUI-URL-OTA retryt `esp_https_ota_begin` bis zu 3× (transienter TLS-OOM beim GitHub-CDN-Redirect).
- Yield nur noch jeden 8. Chunk statt jeden (≈3,75 s künstliche Verzögerung über 1,5 MB Image entfernt; entspricht dem MQTT-Pfad).
- MQTT-OTA bekommt dieselbe Retry-Schleife.
- Timeout 30 s → 60 s.

### Firmware-Archiv defekt (seit Beta 12)
- Net-fetch-Mutex 15 s → 45 s, Download-Timeout 10 s → 30 s.
- `archive.json`-Workflows emitten `notesExcerpt` (~300 Zeichen) statt voller Markdown-Notes → 141 KB → ~15 KB.
- Frontend akzeptiert beide Formate und verlinkt auf `notesUrl` für die vollständigen Notes.

### Mutex-Starvation (Wurzel von OTA + Archiv)
Neues entkoppeltes `net_fetch_set_ota_active()`-Flag, das von beiden OTA-Pfaden während des TLS-Downloads gesetzt wird. Events (Webhook/Telegram/SMTP) und Syslog-TLS deferren in dieser Zeit, statt den Mutex zu belegen oder einen zweiten TLS-Kontext zu öffnen.

### Responsive WebUI
- `monitoring.vue`: hartes `max-width: 800px` → `min(960px, 100%)`; col-md-Grids stapeln bei ≤1100 px (Tablet + Sidebar-Layout).
- `NewDesignHeader.vue`: Sidebar scrollt jetzt (`overflow-y: auto`, `min-height: 0`) → Nav-Items und Footer (Logout/Restart) bleiben erreichbar.

### i18n
51 fehlende Monitoring-Keys (Prometheus/Syslog/Notifications + diag) in allen 8 Nicht-Referenz-Locales (fr, it, es, nl, pl, cs, no, sv) ergänzt. Jede Locale-Datei jetzt 543 Keys (Parität mit de/en).

### Docs
`API.md` + `openapi.yaml` decken jetzt `flashPause`, `systemLogEnabled`, die prometheus/syslog/notify-Blöcke und `/api/firmware_archive` (mit `notesExcerpt`) ab.

## Verification

- [x] WebUI-Build grün (`vite build`, 292 Module)
- [x] Alle 10 Locale-Dateien: 543 Keys (node-Import geprüft)
- [x] `openapi.yaml` YAML-gültig (Python yaml.safe_load)
- [x] C++-Diffs Review (Brace-Matching, Flag in allen Exit-Pfaden)
- [ ] **Firmware-Build (`idf.py build`)** — lokal kein ESP-IDF installiert, CI muss validieren

## Notes

- **`archive.json`-Verschlankung** greift erst nach dem nächsten Release oder einem manuellen *Rebuild Firmware Archive*-Workflow-Lauf. Bis dahin lädt das Archiv dank Mutex/Timeout-Fixes aber wieder zuverlässig; das Frontend akzeptiert beide Formate.
- **Kein Push to device** — `webui/dist/` ist in `.gitignore`, die `.gz`-Embedding-Assets werden beim CI-Build regeneriert.
- `webui/dist/` wurde lokal mit `rename_webui_files.py` vorbereitet (nicht committet).