### PR TITLE
Delay firmware archive fetch, add firmware lookup busy state, and show monitoring resource warning

### DIFF
--- a/webui/src/firmwareupdate.vue
+++ b/webui/src/firmwareupdate.vue
@@ -37,7 +37,7 @@
     </div>
 
     <div class="quick-actions">
-      <button class="chip-btn" type="button" @click="manualCheckForUpdate" :disabled="updateStore.isChecking">
+      <button class="chip-btn" type="button" @click="manualCheckForUpdate" :disabled="firmwareLookupBusy">
         <AppIcon name="refresh" />
         {{ updateStore.isChecking ? t('firmware.checking') : t('firmware.checkNow') }}
       </button>
@@ -146,7 +146,7 @@
               <span class="check-icon"><AppIcon name="alert" /></span>
               <span>{{ t('firmware.checkFailed') }}: {{ updateStore.checkError }}</span>
             </div>
-            <button class="check-btn" @click="manualCheckForUpdate" :disabled="updateStore.isChecking">
+            <button class="check-btn" @click="manualCheckForUpdate" :disabled="firmwareLookupBusy">
               <span v-if="updateStore.isChecking" class="spinner-border spinner-border-sm"></span>
               {{ updateStore.isChecking ? t('firmware.checking') : t('firmware.retry') }}
             </button>
@@ -159,7 +159,7 @@
               <span class="check-icon"><AppIcon name="check" /></span>
               <span>{{ t('firmware.upToDate') }}</span>
             </div>
-            <button class="check-btn" @click="manualCheckForUpdate" :disabled="updateStore.isChecking">
+            <button class="check-btn" @click="manualCheckForUpdate" :disabled="firmwareLookupBusy">
               <span v-if="updateStore.isChecking" class="spinner-border spinner-border-sm"></span>
               {{ updateStore.isChecking ? t('firmware.checking') : t('firmware.checkNow') }}
             </button>
@@ -235,7 +235,7 @@
               {{ filter.label }}
             </button>
           </div>
-          <button class="check-btn archive-refresh" type="button" @click="loadFirmwareArchive" :disabled="archiveLoading">
+          <button class="check-btn archive-refresh" type="button" @click="loadFirmwareArchive" :disabled="firmwareLookupBusy" :title="archiveRefreshTitle">
             <span v-if="archiveLoading" class="spinner-border spinner-border-sm"></span>
             <AppIcon v-else name="refresh" />
             {{ archiveLoading ? t('firmware.archiveLoading') : t('firmware.archiveRefresh') }}
@@ -255,6 +255,11 @@
         <div v-if="archiveLoading && firmwareArchive.length === 0" class="archive-empty">
           <span class="spinner-border spinner-border-sm"></span>
           {{ t('firmware.archiveLoading') }}
+        </div>
+
+        <div v-else-if="!archiveLoaded" class="archive-empty">
+          <AppIcon name="info" />
+          {{ t('firmware.archiveHint') }}
         </div>
 
         <div v-else-if="filteredFirmwareArchive.length === 0" class="archive-empty">
@@ -388,6 +393,7 @@ const showChangelogModal = ref(false)
 const betaToggleSaving = ref(false)
 const archiveFilter = ref('stable')
 const archiveLoading = ref(false)
+const archiveLoaded = ref(false)
 const archiveError = ref('')
 const firmwareArchive = ref([])
 const archiveInstallingVersion = ref('')
@@ -401,6 +407,14 @@ const ARCHIVE_MANIFEST_URL = 'https://raw.githubusercontent.com/Xerolux/HB-RF-ET
 const ARCHIVE_MANIFEST_FALLBACK_URL = '/api/firmware_archive'
 const ARCHIVE_CACHE_KEY = 'hb-rf-eth-ng-firmware-archive-cache-v1'
 const ARCHIVE_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+const firmwareLookupBusy = computed(() => archiveLoading.value || updateStore.isChecking || updateStore.fetchInProgress)
+
+const archiveRefreshTitle = computed(() => (
+  updateStore.isChecking || updateStore.fetchInProgress
+    ? t('firmware.checking')
+    : ''
+))
 
 const archiveFilters = computed(() => [
   { value: 'stable', label: t('firmware.archiveStable') },
@@ -644,12 +658,15 @@ const loadArchiveManifest = async () => {
 }
 
 const loadFirmwareArchive = async () => {
+  if (archiveLoading.value || updateStore.isChecking || updateStore.fetchInProgress) return
+
   archiveLoading.value = true
   archiveError.value = ''
 
   try {
     const archiveResult = await loadArchiveManifest()
     firmwareArchive.value = archiveResult.releases
+    archiveLoaded.value = true
     selectDefaultArchiveRelease()
     if (archiveResult.fromCache) {
       const savedAt = new Date(archiveResult.savedAt).toLocaleString()
@@ -661,6 +678,7 @@ const loadFirmwareArchive = async () => {
     archiveError.value = details
       ? `${t('firmware.archiveLoadError')} (${details})`
       : t('firmware.archiveLoadError')
+    archiveLoaded.value = firmwareArchive.value.length > 0
     uiStore.pushToast({ type: 'error', title: t('common.error'), message: archiveError.value })
   } finally {
     archiveLoading.value = false
@@ -890,6 +908,8 @@ const factoryResetClick = async () => {
 }
 
 const manualCheckForUpdate = async () => {
+  if (archiveLoading.value) return
+
   if (!sysInfoStore.currentVersion) {
     await sysInfoStore.update()
   }
@@ -939,7 +959,11 @@ onMounted(async () => {
     console.warn('Initial cached update read failed:', e.response?.status || e.message)
   }
   syncArchiveFilterWithUpdateChannel()
-  loadFirmwareArchive()
+  // Do not load the archive automatically when opening the Firmware page.
+  // The archive may need an external HTTPS request (browser direct, then ESP32
+  // proxy fallback) and users reported UI freezes / high device CPU load when
+  // this work was started just by visiting the page. Keep normal update status
+  // cheap and only fetch the archive after the explicit "Refresh list" action.
   // Periodically re-read the cache while the page is open so the
   // "last check" indicator and download URL stay fresh (cached read only,
   // no GitHub call).

--- a/webui/src/locales/cs.js
+++ b/webui/src/locales/cs.js
@@ -371,6 +371,8 @@ export default {
     chipLabelNotify: 'Oznámení',
     title: 'Monitorování',
     description: 'Nakonfigurujte monitorování a oznámení pro bránu HB-RF-ETH.',
+    resourceWarningTitle: 'Keep resources in mind',
+    resourceWarningText: '{count} monitoring services are enabled. The ESP32 can usually handle this, but concurrent TLS connections, firmware checks/archive fetches, and OTA share heap and CPU; if problems occur, disable individual services or stagger tests.',
     save: 'Uložit',
     saving: 'Ukládání...',
     saveSuccess: 'Konfigurace úspěšně uložena!',

--- a/webui/src/locales/de.js
+++ b/webui/src/locales/de.js
@@ -384,6 +384,8 @@ export default {
     chipLabelNotify: 'Benachrichtigungen',
     title: 'Monitoring',
     description: 'Monitoring und Benachrichtigungen für das HB-RF-ETH Gateway konfigurieren.',
+    resourceWarningTitle: 'Ressourcen im Blick behalten',
+    resourceWarningText: 'Es sind {count} Monitoring-Dienste aktiv. Der ESP32 kann das normalerweise bedienen, aber gleichzeitige TLS-Verbindungen, Firmware-Suche/Archiv und OTA konkurrieren um Heap und CPU; bei Problemen bitte einzelne Dienste deaktivieren oder Tests zeitlich versetzen.',
     save: 'Speichern',
     saving: 'Speichern...',
     saveSuccess: 'Konfiguration erfolgreich gespeichert!',

--- a/webui/src/locales/en.js
+++ b/webui/src/locales/en.js
@@ -384,6 +384,8 @@ export default {
     chipLabelNotify: 'Notifications',
     title: 'Monitoring',
     description: 'Configure monitoring and notifications for the HB-RF-ETH gateway.',
+    resourceWarningTitle: 'Keep resources in mind',
+    resourceWarningText: '{count} monitoring services are enabled. The ESP32 can usually handle this, but concurrent TLS connections, firmware checks/archive fetches, and OTA share heap and CPU; if problems occur, disable individual services or stagger tests.',
     save: 'Save',
     saving: 'Saving...',
     saveSuccess: 'Configuration saved successfully!',

--- a/webui/src/locales/es.js
+++ b/webui/src/locales/es.js
@@ -371,6 +371,8 @@ export default {
     chipLabelNotify: 'Notificaciones',
     title: 'Monitoreo',
     description: 'Configure el monitoreo y las notificaciones para la puerta de enlace HB-RF-ETH.',
+    resourceWarningTitle: 'Keep resources in mind',
+    resourceWarningText: '{count} monitoring services are enabled. The ESP32 can usually handle this, but concurrent TLS connections, firmware checks/archive fetches, and OTA share heap and CPU; if problems occur, disable individual services or stagger tests.',
     save: 'Guardar',
     saving: 'Guardando...',
     saveSuccess: '¡Configuración guardada correctamente!',

--- a/webui/src/locales/fr.js
+++ b/webui/src/locales/fr.js
@@ -371,6 +371,8 @@ export default {
     chipLabelNotify: 'Notifications',
     title: 'Surveillance',
     description: 'Configurez la surveillance et les notifications pour la passerelle HB-RF-ETH.',
+    resourceWarningTitle: 'Keep resources in mind',
+    resourceWarningText: '{count} monitoring services are enabled. The ESP32 can usually handle this, but concurrent TLS connections, firmware checks/archive fetches, and OTA share heap and CPU; if problems occur, disable individual services or stagger tests.',
     save: 'Enregistrer',
     saving: 'Enregistrement...',
     saveSuccess: 'Configuration enregistrée avec succès !',

--- a/webui/src/locales/it.js
+++ b/webui/src/locales/it.js
@@ -371,6 +371,8 @@ export default {
     chipLabelNotify: 'Notifiche',
     title: 'Monitoraggio',
     description: 'Configura monitoraggio e notifiche per il gateway HB-RF-ETH.',
+    resourceWarningTitle: 'Keep resources in mind',
+    resourceWarningText: '{count} monitoring services are enabled. The ESP32 can usually handle this, but concurrent TLS connections, firmware checks/archive fetches, and OTA share heap and CPU; if problems occur, disable individual services or stagger tests.',
     save: 'Salva',
     saving: 'Salvataggio...',
     saveSuccess: 'Configurazione salvata con successo!',

--- a/webui/src/locales/nl.js
+++ b/webui/src/locales/nl.js
@@ -371,6 +371,8 @@ export default {
     chipLabelNotify: 'Notificaties',
     title: 'Monitoring',
     description: 'Configureer monitoring en meldingen voor de HB-RF-ETH gateway.',
+    resourceWarningTitle: 'Keep resources in mind',
+    resourceWarningText: '{count} monitoring services are enabled. The ESP32 can usually handle this, but concurrent TLS connections, firmware checks/archive fetches, and OTA share heap and CPU; if problems occur, disable individual services or stagger tests.',
     save: 'Opslaan',
     saving: 'Opslaan...',
     saveSuccess: 'Configuratie succesvol opgeslagen!',

--- a/webui/src/locales/no.js
+++ b/webui/src/locales/no.js
@@ -371,6 +371,8 @@ export default {
     chipLabelNotify: 'Varsler',
     title: 'Overvåking',
     description: 'Konfigurer overvåking og varsler for HB-RF-ETH-gatewayen.',
+    resourceWarningTitle: 'Keep resources in mind',
+    resourceWarningText: '{count} monitoring services are enabled. The ESP32 can usually handle this, but concurrent TLS connections, firmware checks/archive fetches, and OTA share heap and CPU; if problems occur, disable individual services or stagger tests.',
     save: 'Lagre',
     saving: 'Lagrer...',
     saveSuccess: 'Konfigurasjon lagret!',

--- a/webui/src/locales/pl.js
+++ b/webui/src/locales/pl.js
@@ -371,6 +371,8 @@ export default {
     chipLabelNotify: 'Powiadomienia',
     title: 'Monitoring',
     description: 'Skonfiguruj monitoring i powiadomienia dla bramki HB-RF-ETH.',
+    resourceWarningTitle: 'Keep resources in mind',
+    resourceWarningText: '{count} monitoring services are enabled. The ESP32 can usually handle this, but concurrent TLS connections, firmware checks/archive fetches, and OTA share heap and CPU; if problems occur, disable individual services or stagger tests.',
     save: 'Zapisz',
     saving: 'Zapisywanie...',
     saveSuccess: 'Konfiguracja zapisana pomyślnie!',

--- a/webui/src/locales/sv.js
+++ b/webui/src/locales/sv.js
@@ -371,6 +371,8 @@ export default {
     chipLabelNotify: 'Aviseringar',
     title: 'Övervakning',
     description: 'Konfigurera övervakning och aviseringar för HB-RF-ETH-gatewayen.',
+    resourceWarningTitle: 'Keep resources in mind',
+    resourceWarningText: '{count} monitoring services are enabled. The ESP32 can usually handle this, but concurrent TLS connections, firmware checks/archive fetches, and OTA share heap and CPU; if problems occur, disable individual services or stagger tests.',
     save: 'Spara',
     saving: 'Sparar...',
     saveSuccess: 'Konfiguration sparad framgångsrikt!',

--- a/webui/src/monitoring.vue
+++ b/webui/src/monitoring.vue
@@ -15,6 +15,14 @@
       </div>
     </section>
 
+    <div v-if="showResourceWarning" class="monitoring-resource-warning">
+      <AppIcon name="alert" />
+      <div>
+        <strong>{{ t('monitoring.resourceWarningTitle') }}</strong>
+        <p>{{ t('monitoring.resourceWarningText', { count: activeMonitoringServiceCount }) }}</p>
+      </div>
+    </div>
+
     <section class="diagnostics-panel settings-card card-glass">
       <div class="card-header">
         <div class="header-content">
@@ -640,6 +648,16 @@ const mtlsInconsistent = computed(() => {
   return (hasCert || hasKey) && !(hasCert && hasKey)
 })
 
+const activeMonitoringServiceCount = computed(() => [
+  checkmkConfig.value.enabled,
+  mqttConfig.value.enabled,
+  prometheusConfig.value.enabled,
+  syslogConfig.value.enabled,
+  notifyConfig.value.enabled && Number(notifyConfig.value.channels || 0) !== 0
+].filter(Boolean).length)
+
+const showResourceWarning = computed(() => activeMonitoringServiceCount.value >= 4)
+
 const diagnosticCards = computed(() => [
   { key: 'checkmk', title: t('monitoring.chipLabelCheckmk'), icon: 'logs', tone: 'warning' },
   { key: 'mqtt', title: t('monitoring.chipLabelMqtt'), icon: 'activity', tone: 'success' },
@@ -847,6 +865,22 @@ const runDiagnostic = async (target) => {
 
 .diagnostics-panel {
   margin-bottom: var(--spacing-lg);
+}
+
+.monitoring-resource-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
+  padding: var(--spacing-md);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  border-radius: var(--radius-lg);
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--warning-dark, #92400e);
+}
+
+.monitoring-resource-warning p {
+  margin: 0.25rem 0 0;
 }
 
 .diagnostics-subtitle {


### PR DESCRIPTION
### Motivation
- Prevent heavy network/TLS work and device CPU/heap spikes when visiting the Firmware page by avoiding an automatic archive fetch. 
- Avoid conflicting UI actions while a firmware lookup or archive load is in progress by centralizing busy state.
- Warn users when many monitoring services are enabled because concurrent TLS/OTA/archive activity can strain ESP32 resources.

### Description
- Stop auto-loading the remote firmware archive on mount and require an explicit `Refresh list` action by removing the initial `loadFirmwareArchive()` call in `webui/src/firmwareupdate.vue`.
- Add `archiveLoaded` state and a computed `firmwareLookupBusy` that combines `archiveLoading`, `updateStore.isChecking`, and `updateStore.fetchInProgress`, and use it to disable relevant buttons and show a contextual title via `archiveRefreshTitle` in `webui/src/firmwareupdate.vue`.
- Prevent duplicate archive/update requests by returning early in `loadFirmwareArchive()` and `manualCheckForUpdate()` if a lookup is already running, and show an inline hint when the archive has not yet been loaded.
- Add a monitoring resource warning UI in `webui/src/monitoring.vue` with computed `activeMonitoringServiceCount` and `showResourceWarning`, styles for the warning box, and translations keys plus entries added to multiple locale files under `webui/src/locales/*`.

### Testing
- Built the frontend locally with `npm run build` to ensure compilation after template and script changes, and the build completed successfully.
- Ran linting with `npm run lint` to validate code style, and linting passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e23cdeaa0832b803a6130642d444b)