### PR TITLE
Increase OTA task stack, extend paste upload timeout, and preserve paste Location URL

### DIFF
--- a/main/mqtt_handler.cpp
+++ b/main/mqtt_handler.cpp
@@ -146,6 +146,8 @@ static bool command_token_ok(const char *payload, int payload_len)
     return strncmp(payload, current_mqtt_config.command_token, expected) == 0;
 }
 
+static constexpr uint32_t MQTT_UPDATE_TASK_STACK_BYTES = 12288;
+
 static void handle_mqtt_command(const char* command, const char* payload, int payload_len)
 {
     ESP_LOGI(TAG, "Received MQTT command: %s (payload %d bytes)", command, payload_len);
@@ -186,7 +188,7 @@ static void handle_mqtt_command(const char* command, const char* payload, int pa
             BaseType_t created = xTaskCreate([](void *p) {
                 static_cast<UpdateCheck *>(p)->performOnlineUpdate();
                 vTaskDelete(NULL);
-            }, "mqtt_ota", 8192, updateCheck, 5, NULL);
+            }, "mqtt_ota", MQTT_UPDATE_TASK_STACK_BYTES, updateCheck, 5, NULL);
             if (created != pdPASS) {
                 ESP_LOGE(TAG, "Failed to create OTA update task");
                 mqtt_handler_publish_event("event/update_failed", "task_create_failed");
@@ -205,7 +207,7 @@ static void handle_mqtt_command(const char* command, const char* payload, int pa
             BaseType_t created = xTaskCreate([](void *p) {
                 static_cast<UpdateCheck *>(p)->refresh();
                 vTaskDelete(NULL);
-            }, "mqtt_chkupd", 8192, updateCheck, 4, NULL);
+            }, "mqtt_chkupd", MQTT_UPDATE_TASK_STACK_BYTES, updateCheck, 4, NULL);
             mqtt_handler_publish_event("event/check_update",
                                        created == pdPASS ? "requested" : "task_create_failed");
         } else {

--- a/main/webui.cpp
+++ b/main/webui.cpp
@@ -3024,7 +3024,7 @@ static void _share_log_task(void *arg)
         config.crt_bundle_attach = esp_crt_bundle_attach;
         config.keep_alive_enable = false;
         config.disable_auto_redirect = true;
-        config.timeout_ms = 20000;
+        config.timeout_ms = 45000;
         config.event_handler = [](esp_http_client_event_t *evt) -> esp_err_t {
             PasteCtx *ctx = (PasteCtx *)evt->user_data;
             if (!ctx) return ESP_OK;
@@ -3075,14 +3075,10 @@ static void _share_log_task(void *arg)
             int status = esp_http_client_get_status_code(client);
             if ((status == 303 || status == 302 || status == 301) && pctx.hasLocation)
             {
-                // MicroBin returns Location: https://paste.blueml.eu/upload/<id>
-                // but the paste view URL is https://paste.blueml.eu/p/<id>.
-                char* upload_ptr = strstr(pctx.location, "/upload");
-                if (upload_ptr) {
-                    memmove(upload_ptr + 2, upload_ptr + 7, strlen(upload_ptr + 7) + 1);
-                    upload_ptr[0] = '/';
-                    upload_ptr[1] = 'p';
-                }
+                // MicroBin returns the final share URL in Location (currently
+                // /upload/<id> on paste.blueml.eu). Keep it verbatim instead
+                // of rewriting paths client-side; the service owns the URL
+                // format and may change aliases independently.
                 snprintf(result, sizeof(result),
                          "{\"success\":true,\"url\":\"%s\"}", pctx.location);
             }


### PR DESCRIPTION
### Motivation
- Prevent stack exhaustion and TLS failures during OTA/check-update operations by allocating more stack to the tasks that perform network TLS work.
- Reduce false failures for log/paste uploads by allowing a longer HTTP client timeout for slower uploads.
- Avoid client-side assumptions about paste service URL formats by returning the `Location` header verbatim instead of rewriting paths.

### Description
- Add `MQTT_UPDATE_TASK_STACK_BYTES` constant set to `12288` and use it to increase the stack size for the `mqtt_ota` and `mqtt_chkupd` tasks instead of the previous `8192` value.
- Increase the paste upload HTTP client timeout by changing `config.timeout_ms` from `20000` to `45000` in the web UI paste sharing flow.
- Remove the client-side rewrite of the `Location` header returned by the paste service and return the header value verbatim to callers.

### Testing
- Performed an ESP-IDF build (`idf.py build`) of the firmware which completed successfully.
- Executed the repository's automated test suite in CI and observed all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55c28e7328832ea403b61f55de5042)