### PR TITLE
fix(diag): log reset reason at boot + expose task stack hwm (#371)

### DIFF
--- a/include/mqtt_handler.h
+++ b/include/mqtt_handler.h
@@ -49,6 +49,11 @@ void mqtt_handler_publish_status(void);
 // Used for transient events like OTA started / finished / command rejected.
 void mqtt_handler_publish_event(const char *subtopic, const char *payload);
 
+// Publish the FreeRTOS task stack high-water marks under
+// <prefix>/status/task_stacks (retained). Called periodically by the publish
+// task; safe to call from elsewhere but not on the hot 5 s status cycle.
+void mqtt_handler_publish_task_stacks(void);
+
 // Force a single immediate status publish cycle (e.g. after a setting changed
 // or after OTA state changed). Safe to call from any task; returns immediately
 // and schedules the publish on the periodic task if it is running.

--- a/include/sysinfo.h
+++ b/include/sysinfo.h
@@ -50,4 +50,14 @@ public:
     uint32_t getBoardSenseVoltage();
     uint64_t getUptimeSeconds();
     const char* getResetReason();
+
+    // Compact diagnostic summary of all FreeRTOS tasks: name + stack
+    // high-water mark (bytes remaining) for each, sorted by stack usage
+    // descending. Returned pointer is valid until the next call. Exposed
+    // via /sysinfo.json (taskStacks) and MQTT status/task_stacks so that
+    // over-provisioned task stacks can be spotted from a remote support
+    // request without needing serial access. Cheap to call (transient
+    // ~2 KB scratch for uxTaskGetSystemState), but not free — callers
+    // should not poll it more often than once per second.
+    const char* getTaskStackInfo();
 };

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -30,6 +30,7 @@
 #include "driver/uart.h"
 #include "esp_log.h"
 #include "esp_task_wdt.h"
+#include "esp_heap_caps.h"
 
 #include "pins.h"
 #include "led.h"
@@ -298,6 +299,30 @@ void app_main()
 
     // Initialize reset info system
     ResetInfo::init();
+
+    // Surface the reset reason at boot. getResetDetails() is the canonical
+    // one-shot entry point: it auto-classifies unexplained reboots (panic,
+    // watchdog, brownout) when no subsystem had a chance to tag them, reads
+    // the persisted diagnostic string, and clears NVS so the next normal
+    // reboot does not show stale data. Calling it here makes the boot log
+    // the first consumer — MQTT (status/last_reset_reason) and /sysinfo.json
+    // later read the cached reset_text_buffer and see the same value. Without
+    // this block a user inspecting the serial log after an unexplained
+    // overnight reboot sees "no error" because nothing else logs the reason.
+    {
+        const char *details = sysInfo.getResetReason();
+        const char *esp_reason = ResetInfo::getEspResetReason();
+        const char *diag = ResetInfo::getLastDiag();
+        size_t free_heap = heap_caps_get_free_size(MALLOC_CAP_DEFAULT);
+        size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT);
+        ESP_LOGI(TAG, "Boot reset reason: %s (esp: %s)%s%s",
+                 details ? details : "(unknown)",
+                 esp_reason ? esp_reason : "(unknown)",
+                 (diag && diag[0]) ? " - " : "",
+                 (diag && diag[0]) ? diag : "");
+        ESP_LOGI(TAG, "Boot heap: %u bytes free, %u bytes largest block",
+                 (unsigned)free_heap, (unsigned)largest);
+    }
 
     static UpdateCheck updateCheck(&settings, &sysInfo, &statusLED);
     // NOTE: updateCheck.start() is intentionally deferred until AFTER

--- a/main/mqtt_handler.cpp
+++ b/main/mqtt_handler.cpp
@@ -291,6 +291,13 @@ void mqtt_publish_task(void *pvParameters)
         mqtt_handler_publish_status();
         publish_ota_state();
 
+        // Task-stack diagnostics move slowly; publishing every cycle (5 s)
+        // wastes broker storage for no insight. ~60 s cadence is enough to
+        // spot slow leaks or post-OTA drift when the user files a bug.
+        if (publish_cycle % 12 == 0) {
+            mqtt_handler_publish_task_stacks();
+        }
+
         // Re-publish the moment the OTA state changes - users get instant
         // feedback when an update starts, finishes or fails.
         OtaSnapshot ota = monitoring_get_updatecheck()
@@ -356,6 +363,27 @@ void mqtt_handler_publish_event(const char *subtopic, const char *payload)
     snprintf(topic, sizeof(topic), "%s/%s", current_mqtt_config.topic_prefix, subtopic);
     // Non-retained, QoS 0: events are transient by definition.
     esp_mqtt_client_publish(client, topic, payload, 0, 0, 0);
+}
+
+// Publish the FreeRTOS task stack high-water marks as a single retained string.
+// Called infrequently (every 60 s) because the values move slowly and the
+// payload can be several hundred bytes — publishing it on the 5 s status cycle
+// would waste bandwidth and MQTT broker storage for no diagnostic gain.
+void mqtt_handler_publish_task_stacks(void)
+{
+    if (!mqtt_running.load() || client == NULL) {
+        return;
+    }
+    SysInfo *sysInfo = monitoring_get_sysinfo();
+    if (!sysInfo) return;
+
+    const char *stacks = sysInfo->getTaskStackInfo();
+    if (!stacks || !stacks[0]) return;
+
+    char topic[160];
+    snprintf(topic, sizeof(topic), "%s/status/task_stacks",
+             current_mqtt_config.topic_prefix);
+    esp_mqtt_client_publish(client, topic, stacks, 0, 0, 1);
 }
 
 // Publish one value under <prefix>/<subtopic> with retain=1, QoS=0.

--- a/main/sysinfo.cpp
+++ b/main/sysinfo.cpp
@@ -37,6 +37,8 @@
 #include "pins.h"
 #include <atomic>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <inttypes.h>
 
 #define DEFAULT_VREF 1100
@@ -318,4 +320,75 @@ const char* SysInfo::getResetReason()
 {
     // Use ResetInfo for detailed reset reasons
     return ResetInfo::getResetDetails();
+}
+
+const char* SysInfo::getTaskStackInfo()
+{
+    // Build a compact "name=hwm_bytes" list sorted by stack usage descending.
+    // The high-water mark (uxTaskGetStackHighWaterMark) is the minimum free
+    // stack ever observed for a task — small values flag tasks close to
+    // overflow, large values flag over-provisioned stacks that waste heap.
+    // Returned pointer is a static buffer so callers must copy if they need
+    // to keep the value across another call.
+    static char out[512];
+
+    // uxTaskGetSystemState needs CONFIG_FREERTOS_USE_TRACE_FACILITY (set in
+    // sdkconfig.defaults). Estimate an upper bound on the task count so the
+    // transient scratch allocation is right-sized without a second pass.
+    const size_t MAX_TASKS = 32;
+    TaskStatus_t *tasks = (TaskStatus_t *)malloc(sizeof(TaskStatus_t) * MAX_TASKS);
+    if (!tasks) {
+        snprintf(out, sizeof(out), "alloc-failed");
+        return out;
+    }
+
+    UBaseType_t n = uxTaskGetSystemState(tasks, MAX_TASKS, NULL);
+    if (n == 0) {
+        free(tasks);
+        snprintf(out, sizeof(out), "no-tasks");
+        return out;
+    }
+
+    // Sort descending by usStackHighWaterMark (bytes). The smaller this value,
+    // the closer the task got to overflow — so the most interesting entries
+    // (largest hwm = biggest waste) go to the end; we sort biggest-first so
+    // a truncated buffer still surfaces the worst waste.
+    for (UBaseType_t i = 1; i < n; i++) {
+        TaskStatus_t key = tasks[i];
+        UBaseType_t j = i;
+        while (j > 0 && tasks[j - 1].usStackHighWaterMark < key.usStackHighWaterMark) {
+            tasks[j] = tasks[j - 1];
+            j--;
+        }
+        tasks[j] = key;
+    }
+
+    size_t pos = 0;
+    out[0] = 0;
+    for (UBaseType_t i = 0; i < n; i++) {
+        // Skip the idle tasks — their hwm is not actionable and would just
+        // waste the limited buffer budget.
+        if (strcmp(tasks[i].pcTaskName, "IDLE0") == 0 ||
+            strcmp(tasks[i].pcTaskName, "IDLE1") == 0) {
+            continue;
+        }
+        // High-water mark is in stack words; multiply by sizeof(StackType_t)
+        // (= 4 bytes on the ESP32) to report bytes, matching the task-creation
+        // stack sizes passed to xTaskCreate.
+        unsigned hwm_bytes = (unsigned)tasks[i].usStackHighWaterMark * sizeof(StackType_t);
+        int written = snprintf(out + pos, sizeof(out) - pos,
+                               "%s%s=%u",
+                               pos > 0 ? " " : "",
+                               tasks[i].pcTaskName,
+                               hwm_bytes);
+        if (written <= 0 || (size_t)written >= sizeof(out) - pos) {
+            // Truncated — append a marker and stop so the JSON is well-formed.
+            snprintf(out + pos, sizeof(out) - pos, "...");
+            break;
+        }
+        pos += (size_t)written;
+    }
+
+    free(tasks);
+    return out;
 }

--- a/main/syslog.cpp
+++ b/main/syslog.cpp
@@ -61,7 +61,14 @@ struct syslog_entry {
     size_t len;
 };
 
-static constexpr int QUEUE_DEPTH = 32;
+// Queue depth: 16 entries × ~516 bytes ≈ 8.3 KB heap. Halved from the
+// original 32 (16.5 KB) to ease heap pressure on the WROOM-32 (no PSRAM)
+// when syslog is enabled. Syslog forwarding is best-effort UDP; a full
+// queue already drops new lines via xQueueSend(..., 0) in enqueue(), so
+// the lower depth trades burst capacity for ~8 KB of freed heap that is
+// better spent on the TLS handshake during the periodic update check /
+// OTA path. 16 still covers the typical smart-home log volume.
+static constexpr int QUEUE_DEPTH = 16;
 
 // ---------------------------------------------------------------------------
 // ESP-IDF log line parsing.

--- a/main/webui.cpp
+++ b/main/webui.cpp
@@ -635,6 +635,28 @@ esp_err_t get_sysinfo_json_handler_func(httpd_req_t *req)
              hmIPMAC, _radioModuleDetector->getSGTIN());
     httpd_resp_send_chunk(req, buf, strlen(buf));
 
+    // Task stack high-water marks. The summary string can exceed the 256-byte
+    // buf above, so emit it as its own chunk with a dedicated buffer. Spaces
+    // are legal in JSON strings; only escape quotes and backslashes (defensive
+    // — task names are bounded ASCII).
+    {
+        const char *stacks = _sysInfo->getTaskStackInfo();
+        char stack_buf[640];
+        size_t pos = 0;
+        stack_buf[0] = 0;
+        pos += snprintf(stack_buf + pos, sizeof(stack_buf) - pos,
+                        ",\"taskStacks\":\"");
+        for (const char *p = stacks; *p && pos + 4 < sizeof(stack_buf); p++) {
+            if (*p == '"' || *p == '\\') {
+                stack_buf[pos++] = '\\';
+            }
+            stack_buf[pos++] = *p;
+        }
+        stack_buf[pos++] = '"';
+        stack_buf[pos] = 0;
+        httpd_resp_send_chunk(req, stack_buf, pos);
+    }
+
     // Supporter key logic
     if (_settings->getSupporterKey() && strlen(_settings->getSupporterKey()) > 0) {
         SupporterKeyStatus sk;


### PR DESCRIPTION
Closes #371.

## Problem

Issue #371 reports overnight reboots + radio module loss, but the user sees 'no error in the log'. Root cause analysis:

- **Reset-reason is never logged at boot.** The full diagnostic infrastructure exists in `reset_info.cpp` (auto-classifies panic/watchdog/brownout, persists diag string in NVS), but only MQTT (`status/last_reset_reason`) and `/sysinfo.json` consume it. The serial boot log stays silent, so users inspecting the log after an unexplained reboot see nothing.
- **55 KB free heap 37s after boot** is critically low for an ESP32 without PSRAM. After hours of runtime, individual allocations (UART frame parser, TLS buffer) start failing → radio module loss + reboots via heap-watchdog or deeper panic.
- The heap-watchdog (20 KB threshold, 8 min sustained) does NOT trip at 55 KB — so the reboots come from a different path that the current logs don't surface.

## Fix (three layers)

### 1. Boot-time reset-reason log (`main/main.cpp`)

Right after `ResetInfo::init()`, log:
- Reset reason text via `SysInfo::getResetReason()` (the canonical one-shot entry point through `ResetInfo::getResetDetails()` — auto-classifies unexplained reboots)
- ESP hardware reason via `ResetInfo::getEspResetReason()`
- Persisted diag string via `ResetInfo::getLastDiag()` (contains e.g. `low heap: free=X largest=Y min_ever=Z uptime=Ns` from the heap watchdog)
- Free heap + largest block at boot

**Placement rationale:** Must run before `monitoring_init()` so the boot log is the first caller of the one-shot `getResetDetails()` — otherwise MQTT connect or the first `/sysinfo.json` request consumes the NVS reason. The cached `reset_text_buffer` then serves all later consumers (MQTT, WebUI) with the same value.

### 2. Syslog queue halved (`main/syslog.cpp`)

`QUEUE_DEPTH` 32 → 16 entries. Each `syslog_entry` is ~516 bytes, so this frees ~8 KB heap when syslog is enabled. Syslog is best-effort UDP and already drops on a full queue (`xQueueSend(..., 0)` non-blocking), so burst capacity is the only trade-off. No effect when syslog is disabled.

### 3. Task stack high-water marks

New method `SysInfo::getTaskStackInfo()` builds a compact `name=hwm_bytes` list sorted by stack usage descending, idle tasks skipped, JSON-safe. Exposed via:
- `/sysinfo.json` → new `taskStacks` field (own 640-byte chunk buffer because the summary can exceed the 256-byte shared buf)
- MQTT → `status/task_stacks` published every ~60 s (every 12th cycle of the 5 s publish task)

This gives users (and future bug reports) the data to identify over-provisioned task stacks — the basis for targeted heap optimization in a separate PR.

## What is NOT changed

- Heap-watchdog threshold (20 KB / 8 min) — already well-calibrated; not the source of the symptom
- TLS / mbedTLS config (`sdkconfig.defaults`) — already optimal (dynamic buffer, asymmetric content len, CA cert free)
- `g_net_fetch_mutex` serialization and OTA pause logic — already mature
- HTTPD socket pool (`lru_purge_enable = true` is already on)
- Direct task stack reductions — too risky for stable tasks, belongs in a separate PR after evaluating the new high-water-mark data

## Build status

⚠️ **Code has not been built yet.** This PR triggers `build.yml` + `pr-check.yml` on the PR — that's the verification step.

## Test plan

- [ ] CI build.yml passes
- [ ] CI pr-check.yml passes (semantic PR title, version-bump check)
- [ ] (Hardware) After flash, the serial log shows the reset-reason line at boot
- [ ] (Hardware) `/sysinfo.json` contains a `taskStacks` field
- [ ] (Hardware) MQTT subscriber sees `status/task_stacks` once per ~60 s
