### PR TITLE
feat: add lightweight system recovery themes and log diagnostics

### DIFF
--- a/docs/SYSTEM_OVERVIEW_THEME_LOGS.md
+++ b/docs/SYSTEM_OVERVIEW_THEME_LOGS.md
@@ -1,0 +1,78 @@
+# System overview, device themes, recovery, and log streaming
+
+This feature set extends the New Design after the separate WebUI update
+foundation described in `WEBUI_UPDATES.md`.
+
+## System overview
+
+The authenticated endpoint `GET /api/system/overview` returns diagnostics that
+are useful when investigating memory pressure and update failures on the
+ESP32-WROOM-32:
+
+- ESP-IDF version and build target
+- chip model, revision, features, and CPU-core count
+- total, used, and free internal heap
+- internal heap usage percentage
+- minimum free heap observed since boot
+- largest currently allocatable contiguous heap block
+- PSRAM presence plus total/free PSRAM when available
+- reset reason as a readable string
+- detected flash size
+- running and next OTA partition labels and sizes
+- active WebUI source, version, mount state, and SPIFFS usage
+- log capture state, ring capacity, currently available bytes, total stream
+  offset, active subscriber count, and crash-tail availability
+
+Values are calculated only when requested. No permanent diagnostic task,
+statistics buffer, history recorder, or additional polling loop is created in
+firmware. The New Design requests the data once when the page is opened and only
+again when the user presses **Refresh**.
+
+## Minimal recovery page
+
+`GET /recovery` serves a small standalone HTML page embedded in the firmware. It
+does not depend on Vue, Bootstrap, the SPIFFS WebUI image, external assets, or a
+background task. It adds one route to the existing HTTP server and does not
+create a second server instance.
+
+The page uses the normal `/login.json` authentication flow and existing
+`Authorization: Token ...` contract. After login it can:
+
+- display on-demand RAM, reset, WebUI, and crash-tail status
+- upload a raw WebUI image through `POST /api/webui/update`
+- upload a raw firmware image through `POST /ota_update`
+- download the current log through `GET /api/log/download`
+- retrieve the one-shot crash tail through `GET /api/crash_log`
+- restart the device through `POST /api/restart`
+
+No privileged recovery-only API is introduced. All modifying actions remain
+protected by the existing admin token.
+
+## Device-wide theme configuration
+
+`GET /api/theme` is public so the login page can adopt the device appearance.
+`POST /api/theme` requires the existing admin token.
+
+Stored values:
+
+- `colorScheme`: `system`, `light`, or `dark`
+- `primaryColor`: hexadecimal `#RRGGBB`
+
+The browser applies its cached values before the request completes to avoid a
+flash of the default theme. The device response then becomes authoritative and
+is mirrored back to local storage. Theme settings are stored in the NVS
+namespace `ui_theme` and therefore survive firmware and separate WebUI updates.
+
+## Allocation-free log download
+
+`GET /api/log/download` no longer constructs a complete `std::string` snapshot.
+It reads the existing in-memory ring buffer in 1 KiB chunks and sends them using
+HTTP chunked transfer encoding.
+
+A reader whose absolute offset points to overwritten data is advanced to the
+oldest byte still present. This keeps download memory constant while preserving
+existing WebSocket live-log and syslog subscriber behavior.
+
+The System Overview displays the same ring-buffer state without allocating a
+log snapshot. Crash-tail presence is checked through the NVS blob length only;
+the crash tail is not loaded or erased until the user explicitly requests it.

--- a/docs/SYSTEM_OVERVIEW_THEME_LOGS.md
+++ b/docs/SYSTEM_OVERVIEW_THEME_LOGS.md
@@ -63,11 +63,12 @@ flash of the default theme. The device response then becomes authoritative and
 is mirrored back to local storage. Theme settings are stored in the NVS
 namespace `ui_theme` and therefore survive firmware and separate WebUI updates.
 
-## Allocation-free log download
+## Bounded log download
 
 `GET /api/log/download` no longer constructs a complete `std::string` snapshot.
-It reads the existing in-memory ring buffer in 1 KiB chunks and sends them using
-HTTP chunked transfer encoding.
+It records the absolute end offset at request start, allocates one bounded 1 KiB
+heap buffer, and streams only the data that existed at that moment. New log lines
+written during the transfer cannot keep the response open indefinitely.
 
 A reader whose absolute offset points to overwritten data is advanced to the
 oldest byte still present. This keeps download memory constant while preserving

--- a/docs/SYSTEM_OVERVIEW_THEME_LOGS.md
+++ b/docs/SYSTEM_OVERVIEW_THEME_LOGS.md
@@ -76,3 +76,9 @@ existing WebSocket live-log and syslog subscriber behavior.
 The System Overview displays the same ring-buffer state without allocating a
 log snapshot. Crash-tail presence is checked through the NVS blob length only;
 the crash tail is not loaded or erased until the user explicitly requests it.
+
+## Validation
+
+Automated firmware, WebUI, size, security, and documentation checks are required
+before merge. Physical 4 MiB ESP32-WROOM-32 validation is deferred to the first
+beta test cycle and must be completed before promoting the feature to stable.

--- a/include/log_manager.h
+++ b/include/log_manager.h
@@ -9,16 +9,6 @@
  *
  *  The HB-RF-ETH firmware is licensed under a
  *  Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
- *
- *  You should have received a copy of the license along with this
- *  work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/4.0/>.
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
  */
 
 #pragma once
@@ -29,66 +19,60 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 
-// Subscriber hook signature. Called for every formatted log line that passes
-// through LogManager::write(). `line` is NUL-terminated, `len` excludes the
-// terminator, and `end_offset` is the absolute ring-stream offset immediately
-// after this line (zero while the ring buffer is disabled). Subscribers must
-// not block — they should enqueue and defer I/O to a worker task.
 typedef void (*log_line_subscriber_t)(const char *line, size_t len, uint64_t end_offset);
 
 class LogManager {
 public:
     static LogManager& instance();
 
-    // Default ring-buffer size. Reduced from 8 KB to 4 KB because the ESP32
-    // has no PSRAM and TLS handshakes (OTA, update check, MQTT) need the heap.
-    // The fallback logic in begin() still tries smaller sizes if 4 KB does not fit.
     static constexpr size_t DEFAULT_BUFFER_SIZE = 4096;
 
-    // Static wrappers for initialization (called from main.cpp / WebUI)
-    static void init();  // install the capture hook at boot (idempotent)
+    static void init();
     static void begin(size_t size = DEFAULT_BUFFER_SIZE);
-    // Frees the ring buffer and restores the default log sink. The buffer is
-    // NOT allocated at boot (saves ~8 KB heap needed for the TLS handshake
-    // during firmware update checks); the WebUI enables it on demand.
     static void stop();
     static void clear();
 
-    // True while the in-memory ring buffer is active (i.e. begin() was called
-    // and stop() has not freed it since). Read by the WebUI to show whether
-    // log capture is running.
     bool isEnabled() const;
 
-    // Subscriber registry. add/remove are idempotent and safe to call from
-    // any task. At most LOG_MAX_SUBSCRIBERS may be registered concurrently.
     static constexpr int LOG_MAX_SUBSCRIBERS = 4;
     void addSubscriber(log_line_subscriber_t sub);
     void removeSubscriber(log_line_subscriber_t sub);
     int subscriberCount() const;
 
-    // Instance methods
     std::string getLogContent(uint64_t offset = 0);
-    // Return a body and its absolute end offset from the same locked snapshot.
-    // This keeps HTTP/WebSocket clients from advancing past data that was not
-    // actually included in the returned body.
     std::string getLogSnapshot(uint64_t offset, uint64_t *total_written);
+
+    /**
+     * Copy one stable snapshot chunk directly from the ring buffer.
+     *
+     * `absolute_offset` is both input and output. Lagging readers are clamped to
+     * the oldest byte still present in the ring. No heap allocation is used,
+     * which makes this the preferred path for HTTP downloads on the WROOM-32.
+     */
+    size_t readChunk(uint64_t *absolute_offset, char *destination,
+                     size_t maximum_length);
+
     uint64_t getTotalWritten() const;
 
-    // Persist a tail of the in-memory ring buffer to NVS so it survives the
-    // reboot that follows a watchdog/panic. `tag` is a small label stored
-    // alongside (e.g. "heap_watchdog"). Safe to call from a low-heap context:
-    // it caps the copy by the current largest free block and never allocates
-    // more than CRASH_TAIL_MAX bytes. Returns true on success.
+    /** Current allocated ring-buffer capacity in bytes. */
+    size_t getBufferSize() const { return log_buffer_size; }
+
+    /** Bytes currently available to a new reader after ring-buffer overwrite. */
+    size_t getBufferedBytes() const
+    {
+        const uint64_t written = getTotalWritten();
+        return written < log_buffer_size
+            ? static_cast<size_t>(written)
+            : log_buffer_size;
+    }
+
     static constexpr size_t CRASH_TAIL_MAX = 1024;
     bool saveCrashTailNvs(const char *tag);
-    // Read back the persisted crash tail (one-shot: cleared after read).
-    // Returns an empty string if nothing was stored.
     static std::string loadCrashTailNvs();
 
 private:
     LogManager();
 
-    // Internal implementation
     void _begin(size_t size);
     void _stop();
     void _clear();
@@ -99,16 +83,11 @@ private:
     uint64_t total_written = 0;
     mutable SemaphoreHandle_t _mutex = nullptr;
 
-    // Subscriber list. Iterated under _mutex on every write(); keep it small.
     log_line_subscriber_t _subscribers[LOG_MAX_SUBSCRIBERS] = {};
     int _subscriber_count = 0;
     bool _hook_installed = false;
 
-    // Original esp_log vprintf handler saved by begin() and restored by
-    // stop(); typed as a plain function pointer to avoid pulling esp_log.h
-    // into this header.
     int (*_orig_vprintf)(const char *, va_list) = nullptr;
 
-    // Allow the C-style callback to access private members
     friend int log_vprintf(const char *fmt, va_list args);
 };

--- a/include/system_overview_api.h
+++ b/include/system_overview_api.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "esp_err.h"
+#include "esp_http_server.h"
+
+/** Register the authenticated system-diagnostics endpoint. */
+esp_err_t system_overview_api_register(httpd_handle_t server);

--- a/include/theme_api.h
+++ b/include/theme_api.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "esp_err.h"
+#include "esp_http_server.h"
+
+/** Register public theme read and authenticated theme write endpoints. */
+esp_err_t theme_api_register(httpd_handle_t server);

--- a/main/log_manager.cpp
+++ b/main/log_manager.cpp
@@ -361,6 +361,50 @@ std::string LogManager::getLogSnapshot(uint64_t offset, uint64_t *snapshot_total
     return result;
 }
 
+size_t LogManager::readChunk(uint64_t *absolute_offset, char *destination,
+                             size_t maximum_length) {
+    if (!absolute_offset || !destination || maximum_length == 0 ||
+        !_mutex || !log_buffer || log_buffer_size == 0) {
+        return 0;
+    }
+
+    if (xSemaphoreTake(_mutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+        return 0;
+    }
+
+    const uint64_t local_total = total_written;
+    uint64_t requested = *absolute_offset;
+    if (requested > local_total) requested = local_total;
+
+    const uint64_t oldest = local_total > log_buffer_size
+        ? local_total - log_buffer_size
+        : 0;
+    if (requested < oldest) requested = oldest;
+
+    const uint64_t available64 = local_total - requested;
+    const size_t available = available64 > SIZE_MAX
+        ? SIZE_MAX
+        : static_cast<size_t>(available64);
+    const size_t count = available < maximum_length
+        ? available
+        : maximum_length;
+
+    if (count > 0) {
+        const size_t start = static_cast<size_t>(requested % log_buffer_size);
+        const size_t first = (count < log_buffer_size - start)
+            ? count
+            : log_buffer_size - start;
+        memcpy(destination, log_buffer + start, first);
+        if (count > first) {
+            memcpy(destination + first, log_buffer, count - first);
+        }
+    }
+
+    *absolute_offset = requested + count;
+    xSemaphoreGive(_mutex);
+    return count;
+}
+
 uint64_t LogManager::getTotalWritten() const {
     uint64_t result = 0;
     if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {

--- a/main/system_overview_api.cpp
+++ b/main/system_overview_api.cpp
@@ -1,0 +1,246 @@
+#include "system_overview_api.h"
+
+#include <stdlib.h>
+
+#include "cJSON.h"
+#include "esp_chip_info.h"
+#include "esp_flash.h"
+#include "esp_heap_caps.h"
+#include "esp_idf_version.h"
+#include "esp_log.h"
+#include "esp_ota_ops.h"
+#include "esp_system.h"
+#include "nvs.h"
+
+#include "log_manager.h"
+#include "reset_info.h"
+#include "security_headers.h"
+#include "webui_storage.h"
+
+extern esp_err_t validate_auth(httpd_req_t *req);
+
+namespace
+{
+constexpr const char *TAG = "SystemOverview";
+constexpr const char *CRASH_TAIL_NVS_NAMESPACE = "reset_info";
+constexpr const char *CRASH_TAIL_NVS_KEY = "clog";
+
+bool crash_tail_available()
+{
+    nvs_handle_t handle = 0;
+    if (nvs_open(CRASH_TAIL_NVS_NAMESPACE, NVS_READONLY, &handle) != ESP_OK)
+    {
+        return false;
+    }
+
+    size_t length = 0;
+    const esp_err_t result = nvs_get_blob(handle, CRASH_TAIL_NVS_KEY, nullptr,
+                                          &length);
+    nvs_close(handle);
+    return result == ESP_OK && length > 0;
+}
+
+// Deliberately self-contained: no Vue, no external files, no timer and no
+// automatic polling. The page allocates no firmware resources until requested.
+constexpr char RECOVERY_PAGE[] = R"HTML(<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>HB-RF-ETH-ng Recovery</title>
+<style>
+:root{color-scheme:dark;font-family:system-ui,-apple-system,"Segoe UI",sans-serif}*{box-sizing:border-box}body{margin:0;background:#0f131a;color:#f4f7fb}main{max-width:820px;margin:auto;padding:24px}.hero,.card{background:#171d26;border:1px solid #303846;border-radius:18px;padding:20px;margin-bottom:16px}.hero h1{margin:0 0 6px}.muted,small{color:#a9b0be}.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:16px}label{display:block;margin:10px 0 5px}input,button{width:100%;min-height:44px;border-radius:10px;border:1px solid #3c4657;padding:10px 12px;background:#10161f;color:#f4f7fb}button{background:#f26a3d;border:0;font-weight:700;cursor:pointer;margin-top:10px}button.secondary{background:#303846}button.danger{background:#b83f38}button:disabled{opacity:.55;cursor:not-allowed}.status{white-space:pre-wrap;overflow-wrap:anywhere;background:#0c1118;border-radius:10px;padding:12px;min-height:48px}.facts{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}.fact{background:#10161f;border-radius:10px;padding:10px}.fact span{display:block;color:#a9b0be;font-size:.78rem}.fact strong{display:block;margin-top:3px}progress{width:100%;height:14px;margin-top:10px}@media(max-width:640px){.grid,.facts{grid-template-columns:1fr}main{padding:14px}}
+</style>
+</head>
+<body><main>
+<section class="hero"><h1>HB-RF-ETH-ng Recovery</h1><p class="muted">Minimale Notfalloberfläche ohne New-Design-Bundle. Alle Aktionen verwenden die normale Geräteanmeldung.</p></section>
+<section class="card" id="loginCard"><h2>Anmelden</h2><label>Benutzer</label><input id="user" value="admin" autocomplete="username"><label>Passwort</label><input id="pass" type="password" autocomplete="current-password"><button id="login">Anmelden</button></section>
+<section id="tools" hidden>
+<div class="grid">
+<section class="card"><h2>Systemstatus</h2><div class="facts" id="facts"></div><button class="secondary" id="refresh">Status aktualisieren</button></section>
+<section class="card"><h2>Diagnose</h2><button class="secondary" id="crash">Crash-Tail laden</button><button class="secondary" id="logs">Aktuelles Log herunterladen</button><div class="status" id="diag">Noch keine Diagnose geladen.</div></section>
+<section class="card"><h2>WebUI wiederherstellen</h2><p class="muted">Nur ein passendes <code>webui_*.bin</code> beziehungsweise <code>spiffs.bin</code> verwenden.</p><input id="wwwFile" type="file" accept=".bin,application/octet-stream"><button id="wwwUpload">WebUI hochladen</button><progress id="wwwProgress" max="100" value="0"></progress></section>
+<section class="card"><h2>Firmware wiederherstellen</h2><p class="muted">Das Gerät startet nach erfolgreichem Firmware-Upload automatisch neu.</p><input id="fwFile" type="file" accept=".bin,application/octet-stream"><button id="fwUpload">Firmware hochladen</button><progress id="fwProgress" max="100" value="0"></progress></section>
+</div>
+<section class="card"><h2>Gerätesteuerung</h2><button class="danger" id="restart">Gerät neu starten</button><div class="status" id="status">Bereit.</div></section>
+</section>
+<script>
+let token='',busy=false;const $=id=>document.getElementById(id);const status=m=>$('status').textContent=m;
+const headers=(extra={})=>Object.assign({'Authorization':'Token '+token},extra);
+const bytes=n=>{n=Number(n)||0;if(n<1024)return n+' B';if(n<1048576)return(n/1024).toFixed(1)+' KB';return(n/1048576).toFixed(2)+' MB'};
+const esc=s=>String(s??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+async function api(url,opt={}){opt.headers=headers(opt.headers||{});const r=await fetch(url,opt);const text=await r.text();if(!r.ok)throw new Error(text||('HTTP '+r.status));try{return JSON.parse(text)}catch{return text}}
+async function login(){status('Anmeldung läuft …');const r=await fetch('/login.json',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({username:$('user').value,password:$('pass').value})});const d=await r.json();if(!r.ok||!d.isAuthenticated||!d.token)throw new Error('Anmeldung fehlgeschlagen');token=d.token;$('loginCard').hidden=true;$('tools').hidden=false;status('Angemeldet.');await refresh()}
+async function refresh(){const [s,o]=await Promise.all([api('/sysinfo.json?t='+Date.now()),api('/api/system/overview')]);const i=s.sysInfo||{};const used=Number(o.usedInternalHeap)||0,total=Number(o.totalInternalHeap)||0;const rows=[['Firmware',i.currentVersion||'—'],['Laufzeit',Math.floor((i.uptimeSeconds||0)/60)+' min'],['Resetgrund',o.resetReasonText||i.resetReason||'—'],['RAM gesamt',bytes(total)],['RAM belegt',bytes(used)+' ('+(Number(o.internalHeapUsagePercent)||0).toFixed(1)+' %)'],['RAM frei',bytes(o.freeInternalHeap)],['RAM-Minimum',bytes(o.minimumFreeHeap)],['Größter Block',bytes(o.largestFreeBlock)],['PSRAM',o.psramAvailable?bytes(o.totalPsram):'nicht vorhanden'],['WebUI',o.webui?.version||'embedded'],['Crash-Tail',o.logs?.crashTailAvailable?'vorhanden':'nicht vorhanden'],['Logpuffer',o.logs?.enabled?bytes(o.logs.bufferBytes):'inaktiv']];$('facts').innerHTML=rows.map(x=>'<div class="fact"><span>'+esc(x[0])+'</span><strong>'+esc(x[1])+'</strong></div>').join('');status('Status aktualisiert.')}
+function upload(fileId,url,progressId,label){if(busy)return status('Ein Update läuft bereits.');const f=$(fileId).files[0];if(!f)return status('Bitte zuerst eine BIN-Datei auswählen.');if(!confirm(label+' wirklich starten?'))return;busy=true;const x=new XMLHttpRequest();x.open('POST',url);x.setRequestHeader('Authorization','Token '+token);x.setRequestHeader('Content-Type','application/octet-stream');x.upload.onprogress=e=>{if(e.lengthComputable)$(progressId).value=Math.round(e.loaded*100/e.total)};x.onload=()=>{busy=false;status(x.status>=200&&x.status<300?label+' erfolgreich.':label+' fehlgeschlagen: '+x.responseText);$(progressId).value=x.status>=200&&x.status<300?100:0};x.onerror=()=>{busy=false;status(label+' fehlgeschlagen: Netzwerkfehler')};status(label+' läuft …');x.send(f)}
+$('login').onclick=()=>login().catch(e=>status(e.message));$('refresh').onclick=()=>refresh().catch(e=>status(e.message));$('wwwUpload').onclick=()=>upload('wwwFile','/api/webui/update','wwwProgress','WebUI-Upload');$('fwUpload').onclick=()=>upload('fwFile','/ota_update','fwProgress','Firmware-Upload');
+$('crash').onclick=async()=>{try{const d=await api('/api/crash_log');$('diag').textContent=d.available?(d.tail||'Crash-Tail leer'):'Kein Crash-Tail vorhanden.';await refresh()}catch(e){$('diag').textContent=e.message}};
+$('logs').onclick=async()=>{try{const r=await fetch('/api/log/download',{headers:headers()});if(!r.ok)throw new Error(await r.text());const a=document.createElement('a');a.href=URL.createObjectURL(await r.blob());a.download='hb-rf-eth-log.txt';a.click();setTimeout(()=>URL.revokeObjectURL(a.href),1000)}catch(e){status(e.message)}};
+$('restart').onclick=async()=>{if(busy)return status('Ein Update läuft bereits.');if(!confirm('Gerät wirklich neu starten?'))return;try{await api('/api/restart',{method:'POST'});status('Neustart wurde ausgelöst.')}catch(e){status('Neustart ausgelöst; Verbindung wird getrennt.')}};
+</script></main></body></html>)HTML";
+
+esp_err_t get_recovery_page(httpd_req_t *req)
+{
+    add_security_headers(req);
+    httpd_resp_set_type(req, "text/html; charset=utf-8");
+    httpd_resp_set_hdr(req, "Cache-Control", "no-store");
+    return httpd_resp_send(req, RECOVERY_PAGE, HTTPD_RESP_USE_STRLEN);
+}
+
+esp_err_t get_system_overview(httpd_req_t *req)
+{
+    add_security_headers(req);
+    if (validate_auth(req) != ESP_OK)
+    {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, nullptr);
+    }
+
+    esp_chip_info_t chip = {};
+    esp_chip_info(&chip);
+
+    uint32_t flash_size = 0;
+    const esp_err_t flash_result = esp_flash_get_size(nullptr, &flash_size);
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    const esp_partition_t *next_update = esp_ota_get_next_update_partition(nullptr);
+    const WebUIStorageStatus webui = webui_storage_get_status();
+    LogManager &logs = LogManager::instance();
+
+    const size_t total_internal = heap_caps_get_total_size(MALLOC_CAP_INTERNAL);
+    const size_t free_internal = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+    const size_t used_internal = total_internal > free_internal
+        ? total_internal - free_internal
+        : 0;
+    const double internal_usage = total_internal > 0
+        ? static_cast<double>(used_internal) * 100.0 /
+              static_cast<double>(total_internal)
+        : 0.0;
+
+    const size_t total_psram = heap_caps_get_total_size(MALLOC_CAP_SPIRAM);
+    const size_t free_psram = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+    const size_t used_psram = total_psram > free_psram
+        ? total_psram - free_psram
+        : 0;
+
+    cJSON *root = cJSON_CreateObject();
+    if (!root)
+    {
+        return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
+                                   "Out of memory");
+    }
+
+    cJSON_AddStringToObject(root, "idfVersion", esp_get_idf_version());
+    cJSON_AddStringToObject(root, "target", CONFIG_IDF_TARGET);
+    cJSON_AddNumberToObject(root, "chipModel", static_cast<int>(chip.model));
+    cJSON_AddNumberToObject(root, "chipRevision", chip.revision);
+    cJSON_AddNumberToObject(root, "chipCores", chip.cores);
+    cJSON_AddNumberToObject(root, "chipFeatures", chip.features);
+    cJSON_AddNumberToObject(root, "resetReason", static_cast<int>(esp_reset_reason()));
+    cJSON_AddStringToObject(root, "resetReasonText", ResetInfo::getResetDetails());
+
+    cJSON_AddNumberToObject(root, "flashBytes",
+                            flash_result == ESP_OK ? flash_size : 0);
+    cJSON_AddNumberToObject(root, "freeHeap", esp_get_free_heap_size());
+    cJSON_AddNumberToObject(root, "minimumFreeHeap",
+                            esp_get_minimum_free_heap_size());
+    cJSON_AddNumberToObject(root, "largestFreeBlock",
+                            heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT));
+    cJSON_AddNumberToObject(root, "totalInternalHeap", total_internal);
+    cJSON_AddNumberToObject(root, "freeInternalHeap", free_internal);
+    cJSON_AddNumberToObject(root, "usedInternalHeap", used_internal);
+    cJSON_AddNumberToObject(root, "internalHeapUsagePercent", internal_usage);
+    cJSON_AddBoolToObject(root, "psramAvailable", total_psram > 0);
+    cJSON_AddNumberToObject(root, "totalPsram", total_psram);
+    cJSON_AddNumberToObject(root, "freePsram", free_psram);
+    cJSON_AddNumberToObject(root, "usedPsram", used_psram);
+
+    cJSON_AddStringToObject(root, "runningPartition",
+                            running ? running->label : "unknown");
+    cJSON_AddNumberToObject(root, "runningPartitionAddress",
+                            running ? running->address : 0);
+    cJSON_AddNumberToObject(root, "runningPartitionSize",
+                            running ? running->size : 0);
+    cJSON_AddStringToObject(root, "nextUpdatePartition",
+                            next_update ? next_update->label : "unknown");
+    cJSON_AddNumberToObject(root, "nextUpdatePartitionSize",
+                            next_update ? next_update->size : 0);
+
+    cJSON *webui_object = cJSON_AddObjectToObject(root, "webui");
+    if (webui_object)
+    {
+        cJSON_AddStringToObject(webui_object, "source",
+                                webui.valid ? "spiffs" : "embedded");
+        cJSON_AddStringToObject(webui_object, "version",
+                                webui.version[0] ? webui.version : "embedded");
+        cJSON_AddBoolToObject(webui_object, "valid", webui.valid);
+        cJSON_AddBoolToObject(webui_object, "mounted", webui.mounted);
+        cJSON_AddNumberToObject(webui_object, "partitionBytes",
+                                webui.partitionSize);
+        cJSON_AddNumberToObject(webui_object, "usedBytes", webui.usedBytes);
+    }
+
+    cJSON *log_object = cJSON_AddObjectToObject(root, "logs");
+    if (log_object)
+    {
+        cJSON_AddBoolToObject(log_object, "enabled", logs.isEnabled());
+        cJSON_AddNumberToObject(log_object, "bufferBytes",
+                                logs.getBufferSize());
+        cJSON_AddNumberToObject(log_object, "availableBytes",
+                                logs.getBufferedBytes());
+        cJSON_AddNumberToObject(log_object, "totalWritten",
+                                static_cast<double>(logs.getTotalWritten()));
+        cJSON_AddNumberToObject(log_object, "subscribers",
+                                logs.subscriberCount());
+        cJSON_AddBoolToObject(log_object, "crashTailAvailable",
+                              crash_tail_available());
+    }
+
+    char *json = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (!json)
+    {
+        return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
+                                   "JSON allocation failed");
+    }
+
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_set_hdr(req, "Cache-Control",
+                       "no-store, no-cache, must-revalidate, max-age=0");
+    const esp_err_t result = httpd_resp_send(req, json, HTTPD_RESP_USE_STRLEN);
+    free(json);
+    return result;
+}
+
+httpd_uri_t system_overview_uri = {
+    .uri = "/api/system/overview",
+    .method = HTTP_GET,
+    .handler = get_system_overview,
+    .user_ctx = nullptr,
+};
+
+httpd_uri_t recovery_page_uri = {
+    .uri = "/recovery",
+    .method = HTTP_GET,
+    .handler = get_recovery_page,
+    .user_ctx = nullptr,
+};
+} // namespace
+
+esp_err_t system_overview_api_register(httpd_handle_t server)
+{
+    if (!server) return ESP_ERR_INVALID_ARG;
+
+    esp_err_t result = httpd_register_uri_handler(server, &system_overview_uri);
+    if (result != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Could not register system overview API: %s",
+                 esp_err_to_name(result));
+        return result;
+    }
+
+    result = httpd_register_uri_handler(server, &recovery_page_uri);
+    if (result != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Could not register recovery page: %s",
+                 esp_err_to_name(result));
+    }
+    return result;
+}

--- a/main/theme_api.cpp
+++ b/main/theme_api.cpp
@@ -1,0 +1,187 @@
+#include "theme_api.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cJSON.h"
+#include "esp_log.h"
+#include "nvs.h"
+
+#include "security_headers.h"
+
+extern esp_err_t validate_auth(httpd_req_t *req);
+
+namespace
+{
+constexpr const char *TAG = "ThemeAPI";
+constexpr const char *NVS_NAMESPACE = "ui_theme";
+constexpr const char *NVS_SCHEME_KEY = "scheme";
+constexpr const char *NVS_COLOR_KEY = "primary";
+constexpr const char *DEFAULT_SCHEME = "system";
+constexpr const char *DEFAULT_COLOR = "#f26a3d";
+
+bool valid_scheme(const char *value)
+{
+    return value &&
+           (strcmp(value, "system") == 0 ||
+            strcmp(value, "light") == 0 ||
+            strcmp(value, "dark") == 0);
+}
+
+bool valid_color(const char *value)
+{
+    if (!value || strlen(value) != 7 || value[0] != '#') return false;
+    for (size_t index = 1; index < 7; ++index)
+    {
+        if (!isxdigit(static_cast<unsigned char>(value[index]))) return false;
+    }
+    return true;
+}
+
+void load_theme(char scheme[8], char color[8])
+{
+    snprintf(scheme, 8, "%s", DEFAULT_SCHEME);
+    snprintf(color, 8, "%s", DEFAULT_COLOR);
+
+    nvs_handle_t handle = 0;
+    if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle) != ESP_OK) return;
+
+    size_t scheme_size = 8;
+    if (nvs_get_str(handle, NVS_SCHEME_KEY, scheme, &scheme_size) != ESP_OK ||
+        !valid_scheme(scheme))
+    {
+        snprintf(scheme, 8, "%s", DEFAULT_SCHEME);
+    }
+
+    size_t color_size = 8;
+    if (nvs_get_str(handle, NVS_COLOR_KEY, color, &color_size) != ESP_OK ||
+        !valid_color(color))
+    {
+        snprintf(color, 8, "%s", DEFAULT_COLOR);
+    }
+    nvs_close(handle);
+}
+
+esp_err_t send_theme(httpd_req_t *req)
+{
+    char scheme[8] = {};
+    char color[8] = {};
+    load_theme(scheme, color);
+
+    char response[96];
+    snprintf(response, sizeof(response),
+             "{\"colorScheme\":\"%s\",\"primaryColor\":\"%s\"}",
+             scheme, color);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_set_hdr(req, "Cache-Control",
+                       "no-store, no-cache, must-revalidate, max-age=0");
+    return httpd_resp_send(req, response, HTTPD_RESP_USE_STRLEN);
+}
+
+esp_err_t get_theme(httpd_req_t *req)
+{
+    add_security_headers(req);
+    return send_theme(req);
+}
+
+esp_err_t post_theme(httpd_req_t *req)
+{
+    add_security_headers(req);
+    if (validate_auth(req) != ESP_OK)
+    {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, nullptr);
+    }
+    if (req->content_len <= 0 || req->content_len >= 256)
+    {
+        return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
+                                   "Invalid theme payload size");
+    }
+
+    char body[256] = {};
+    size_t received = 0;
+    while (received < static_cast<size_t>(req->content_len))
+    {
+        const int count = httpd_req_recv(req, body + received,
+                                         req->content_len - received);
+        if (count <= 0)
+        {
+            return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
+                                       "Could not read theme payload");
+        }
+        received += static_cast<size_t>(count);
+    }
+    body[received] = '\0';
+
+    cJSON *root = cJSON_Parse(body);
+    if (!root)
+    {
+        return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid JSON");
+    }
+
+    const cJSON *scheme_item = cJSON_GetObjectItemCaseSensitive(root,
+                                                                "colorScheme");
+    const cJSON *color_item = cJSON_GetObjectItemCaseSensitive(root,
+                                                               "primaryColor");
+    const char *scheme = cJSON_IsString(scheme_item)
+        ? scheme_item->valuestring
+        : nullptr;
+    const char *color = cJSON_IsString(color_item)
+        ? color_item->valuestring
+        : nullptr;
+
+    if (!valid_scheme(scheme) || !valid_color(color))
+    {
+        cJSON_Delete(root);
+        return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
+                                   "Invalid theme values");
+    }
+
+    nvs_handle_t handle = 0;
+    esp_err_t result = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (result == ESP_OK) result = nvs_set_str(handle, NVS_SCHEME_KEY, scheme);
+    if (result == ESP_OK) result = nvs_set_str(handle, NVS_COLOR_KEY, color);
+    if (result == ESP_OK) result = nvs_commit(handle);
+    if (handle) nvs_close(handle);
+    cJSON_Delete(root);
+
+    if (result != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Could not save theme: %s", esp_err_to_name(result));
+        return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
+                                   "Could not save theme");
+    }
+
+    return send_theme(req);
+}
+
+httpd_uri_t get_theme_uri = {
+    .uri = "/api/theme",
+    .method = HTTP_GET,
+    .handler = get_theme,
+    .user_ctx = nullptr,
+};
+
+httpd_uri_t post_theme_uri = {
+    .uri = "/api/theme",
+    .method = HTTP_POST,
+    .handler = post_theme,
+    .user_ctx = nullptr,
+};
+} // namespace
+
+esp_err_t theme_api_register(httpd_handle_t server)
+{
+    if (!server) return ESP_ERR_INVALID_ARG;
+    const esp_err_t get_result = httpd_register_uri_handler(server,
+                                                             &get_theme_uri);
+    const esp_err_t post_result = httpd_register_uri_handler(server,
+                                                              &post_theme_uri);
+    if (get_result != ESP_OK || post_result != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Could not register theme API: GET=%s POST=%s",
+                 esp_err_to_name(get_result), esp_err_to_name(post_result));
+        return get_result != ESP_OK ? get_result : post_result;
+    }
+    return ESP_OK;
+}

--- a/main/webui.cpp
+++ b/main/webui.cpp
@@ -2760,13 +2760,25 @@ esp_err_t get_log_download_handler_func(httpd_req_t *req)
     httpd_resp_set_hdr(req, "Content-Disposition", "attachment; filename=\"hb-rf-eth-log.txt\"");
     httpd_resp_set_hdr(req, "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
 
+    const uint64_t snapshot_end = LogManager::instance().getTotalWritten();
     uint64_t absolute_offset = 0;
-    char chunk[1024];
-    esp_err_t result = ESP_OK;
-    while (true)
+    constexpr size_t CHUNK_SIZE = 1024;
+    char *chunk = static_cast<char *>(malloc(CHUNK_SIZE));
+    if (!chunk)
     {
+        return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
+                                   "Could not allocate log download buffer");
+    }
+
+    esp_err_t result = ESP_OK;
+    while (absolute_offset < snapshot_end)
+    {
+        const uint64_t remaining = snapshot_end - absolute_offset;
+        const size_t requested = remaining < CHUNK_SIZE
+            ? static_cast<size_t>(remaining)
+            : CHUNK_SIZE;
         const size_t count = LogManager::instance().readChunk(
-            &absolute_offset, chunk, sizeof(chunk));
+            &absolute_offset, chunk, requested);
         if (count == 0) break;
 
         result = httpd_resp_send_chunk(req, chunk, count);
@@ -2774,6 +2786,7 @@ esp_err_t get_log_download_handler_func(httpd_req_t *req)
         vTaskDelay(pdMS_TO_TICKS(1));
     }
 
+    free(chunk);
     if (result == ESP_OK)
     {
         result = httpd_resp_send_chunk(req, nullptr, 0);

--- a/main/webui.cpp
+++ b/main/webui.cpp
@@ -47,6 +47,8 @@
 #include "log_manager.h"
 #include "reset_info.h"
 #include "system_reset.h"
+#include "system_overview_api.h"
+#include "theme_api.h"
 #include "esp_http_client.h"
 #include "esp_https_ota.h"
 #include "esp_crt_bundle.h"
@@ -2758,10 +2760,25 @@ esp_err_t get_log_download_handler_func(httpd_req_t *req)
     httpd_resp_set_hdr(req, "Content-Disposition", "attachment; filename=\"hb-rf-eth-log.txt\"");
     httpd_resp_set_hdr(req, "Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
 
-    std::string content = LogManager::instance().getLogContent();
-    httpd_resp_send(req, content.c_str(), content.length());
+    uint64_t absolute_offset = 0;
+    char chunk[1024];
+    esp_err_t result = ESP_OK;
+    while (true)
+    {
+        const size_t count = LogManager::instance().readChunk(
+            &absolute_offset, chunk, sizeof(chunk));
+        if (count == 0) break;
 
-    return ESP_OK;
+        result = httpd_resp_send_chunk(req, chunk, count);
+        if (result != ESP_OK) break;
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+
+    if (result == ESP_OK)
+    {
+        result = httpd_resp_send_chunk(req, nullptr, 0);
+    }
+    return result;
 }
 
 httpd_uri_t get_log_download_handler = {
@@ -2800,7 +2817,8 @@ void WebUI::start()
 
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.lru_purge_enable = true;
-    config.max_uri_handlers = 40;
+    // Reserve capacity for modular diagnostics/theme APIs.
+    config.max_uri_handlers = 44;
     config.uri_match_fn = httpd_uri_match_wildcard;
     config.close_fn = log_stream_close_socket;
     // Increase stack: POST handlers allocate content buffers + config structs
@@ -2815,6 +2833,8 @@ void WebUI::start()
         // so subscribers can connect before any monitoring backend is enabled.
         log_stream_init();
         httpd_register_uri_handler(_httpd_handle, &log_stream_ws_uri);
+        system_overview_api_register(_httpd_handle);
+        theme_api_register(_httpd_handle);
 
         httpd_register_uri_handler(_httpd_handle, &post_login_json_handler);
         httpd_register_uri_handler(_httpd_handle, &post_password_reset_start_handler);

--- a/webui/src/composables/useHeaderNavigation.js
+++ b/webui/src/composables/useHeaderNavigation.js
@@ -5,6 +5,8 @@ export const useHeaderNavigation = (t, loginStore) => {
     { to: '/', icon: 'dashboard', label: t('nav.home'), group: 'overview', public: true },
     { to: '/monitoring', icon: 'monitoring', label: t('nav.monitoring'), group: 'overview' },
     { to: '/settings', icon: 'settings', label: t('nav.settings'), group: 'system' },
+    { to: '/system-overview', icon: 'cpu', label: t('sysinfo.system'), group: 'system' },
+    { to: '/theme', icon: 'sun', label: t('nav.toggleTheme'), group: 'system' },
     { to: '/firmware', icon: 'firmware', label: t('nav.firmware'), group: 'system' },
     { to: '/webui', icon: 'firmware', label: 'WebUI', group: 'system' },
     { to: '/systemlog', icon: 'logs', label: t('nav.systemlog'), group: 'system' },

--- a/webui/src/main.js
+++ b/webui/src/main.js
@@ -20,6 +20,8 @@ import ChangePassword from './change-password.vue'
 import About from './about.vue'
 import Monitoring from './monitoring.vue'
 import SystemLog from './systemlog.vue'
+import SystemOverview from './systemoverview.vue'
+import ThemeSettings from './theme.vue'
 import AppIcon from './components/AppIcon.vue'
 
 // Router
@@ -32,6 +34,8 @@ const router = createRouter({
     { path: '/webui', component: WebUIUpdate, meta: { requiresAuth: true } },
     { path: '/monitoring', component: Monitoring, meta: { requiresAuth: true } },
     { path: '/systemlog', component: SystemLog, meta: { requiresAuth: true } },
+    { path: '/system-overview', component: SystemOverview, meta: { requiresAuth: true } },
+    { path: '/theme', component: ThemeSettings, meta: { requiresAuth: true } },
     { path: '/change-password', component: ChangePassword, meta: { requiresAuth: true } },
     { path: '/about', component: About },
     // bareLayout: rendered WITHOUT the app shell (no sidebar header, no footer).

--- a/webui/src/stores.js
+++ b/webui/src/stores.js
@@ -8,22 +8,87 @@ const getStoredLastActivity = () => {
   return Number.isFinite(stored) && stored > 0 ? stored : Date.now()
 }
 
+const DEFAULT_PRIMARY_COLOR = '#f26a3d'
+const isHexColor = (value) => /^#[0-9a-f]{6}$/i.test(value || '')
+const shiftColor = (hex, amount) => {
+  const value = parseInt(hex.slice(1), 16)
+  const clamp = (part) => Math.max(0, Math.min(255, part + amount))
+  const red = clamp((value >> 16) & 0xff)
+  const green = clamp((value >> 8) & 0xff)
+  const blue = clamp(value & 0xff)
+  return `#${[red, green, blue].map((part) => part.toString(16).padStart(2, '0')).join('')}`
+}
+const rgbaColor = (hex, alpha) => {
+  const value = parseInt(hex.slice(1), 16)
+  return `rgba(${(value >> 16) & 0xff}, ${(value >> 8) & 0xff}, ${value & 0xff}, ${alpha})`
+}
+
 export const useThemeStore = defineStore('theme', {
   state: () => ({
-    theme: safeLocal.get('theme') || 'light'
+    theme: safeLocal.get('theme') || 'system',
+    primaryColor: isHexColor(safeLocal.get('primaryColor'))
+      ? safeLocal.get('primaryColor')
+      : DEFAULT_PRIMARY_COLOR,
+    loadedFromDevice: false
   }),
   actions: {
-    setTheme(newTheme) {
+    apply() {
+      const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches
+      const resolved = this.theme === 'system'
+        ? (prefersDark ? 'dark' : 'light')
+        : this.theme
+      document.documentElement.setAttribute('data-bs-theme', resolved)
+
+      const color = isHexColor(this.primaryColor) ? this.primaryColor : DEFAULT_PRIMARY_COLOR
+      const root = document.documentElement.style
+      root.setProperty('--color-primary', color)
+      root.setProperty('--color-primary-hover', shiftColor(color, -20))
+      root.setProperty('--color-primary-strong', shiftColor(color, -42))
+      root.setProperty('--color-primary-dark', shiftColor(color, -42))
+      root.setProperty('--color-primary-soft', rgbaColor(color, resolved === 'dark' ? 0.16 : 0.12))
+      root.setProperty('--color-primary-light', rgbaColor(color, resolved === 'dark' ? 0.16 : 0.12))
+    },
+    persist() {
+      axios.post('/api/theme', {
+        colorScheme: this.theme,
+        primaryColor: this.primaryColor
+      }, { timeout: 5000, silent: true }).catch(() => {})
+    },
+    setTheme(newTheme, persist = true) {
+      if (!['system', 'light', 'dark'].includes(newTheme)) return
       this.theme = newTheme
       safeLocal.set('theme', newTheme)
-      document.documentElement.setAttribute('data-bs-theme', newTheme)
+      this.apply()
+      if (persist) this.persist()
+    },
+    setPrimaryColor(newColor, persist = true) {
+      if (!isHexColor(newColor)) return
+      this.primaryColor = newColor.toLowerCase()
+      safeLocal.set('primaryColor', this.primaryColor)
+      this.apply()
+      if (persist) this.persist()
     },
     toggleTheme() {
-      const newTheme = this.theme === 'light' ? 'dark' : 'light'
-      this.setTheme(newTheme)
+      const currentlyDark = document.documentElement.getAttribute('data-bs-theme') === 'dark'
+      this.setTheme(currentlyDark ? 'light' : 'dark')
     },
     init() {
-      document.documentElement.setAttribute('data-bs-theme', this.theme)
+      this.apply()
+      window.matchMedia?.('(prefers-color-scheme: dark)').addEventListener?.('change', () => {
+        if (this.theme === 'system') this.apply()
+      })
+      axios.get('/api/theme', { timeout: 5000, silent: true })
+        .then((response) => {
+          const scheme = response.data?.colorScheme
+          const color = response.data?.primaryColor
+          if (['system', 'light', 'dark'].includes(scheme)) this.theme = scheme
+          if (isHexColor(color)) this.primaryColor = color.toLowerCase()
+          safeLocal.set('theme', this.theme)
+          safeLocal.set('primaryColor', this.primaryColor)
+          this.loadedFromDevice = true
+          this.apply()
+        })
+        .catch(() => {})
     }
   }
 })

--- a/webui/src/systemoverview.vue
+++ b/webui/src/systemoverview.vue
@@ -169,8 +169,8 @@ const copy = computed(() => translations[locale.value] || translations.en)
 const usageWidth = computed(() => Math.min(100, Math.max(0, Number(data.value.internalHeapUsagePercent) || 0)))
 
 const formatBytes = (value) => {
-  const bytes = Number(value) || 0
-  if (!bytes) return '—'
+  if (value === null || value === undefined || Number.isNaN(Number(value))) return '—'
+  const bytes = Number(value)
   if (bytes < 1024) return `${bytes} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
   return `${(bytes / 1024 / 1024).toFixed(2)} MB`
@@ -185,7 +185,11 @@ const loadOverview = async () => {
     const response = await axios.get('/api/system/overview', { timeout: 8000 })
     data.value = response.data || { webui: {}, logs: {} }
   } catch (requestError) {
-    error.value = requestError.response?.data || requestError.message || 'System overview unavailable'
+    const responseData = requestError.response?.data
+    error.value = responseData?.error
+      || (typeof responseData === 'string' ? responseData : '')
+      || requestError.message
+      || 'System overview unavailable'
   } finally {
     loading.value = false
   }

--- a/webui/src/systemoverview.vue
+++ b/webui/src/systemoverview.vue
@@ -1,0 +1,226 @@
+<template>
+  <div class="page-shell system-overview-page">
+    <section class="page-hero">
+      <div class="hero-copy">
+        <span class="hero-eyebrow"><AppIcon name="cpu" /> {{ copy.eyebrow }}</span>
+        <h1 class="hero-title">{{ copy.title }}</h1>
+        <p class="hero-subtitle">{{ copy.subtitle }}</p>
+      </div>
+      <div class="hero-meta">
+        <span class="meta-chip"><AppIcon name="firmware" /> {{ data.idfVersion || '—' }}</span>
+        <span class="meta-chip"><AppIcon name="board" /> {{ data.target || 'ESP32' }}</span>
+        <span class="meta-chip" :class="data.webui?.valid ? 'success-chip' : 'warning-chip'">
+          <AppIcon :name="data.webui?.valid ? 'check' : 'alert'" />
+          {{ data.webui?.source || 'embedded' }}
+        </span>
+      </div>
+    </section>
+
+    <div v-if="loading" class="overview-grid">
+      <div v-for="index in 6" :key="index" class="overview-card skeleton"></div>
+    </div>
+
+    <template v-else>
+      <BAlert v-if="error" variant="danger" :model-value="true">{{ error }}</BAlert>
+
+      <section class="overview-grid">
+        <article class="overview-card">
+          <span class="overview-label">{{ copy.freeRam }}</span>
+          <strong>{{ formatBytes(data.freeInternalHeap) }}</strong>
+          <small>{{ copy.currentAvailable }}</small>
+        </article>
+        <article class="overview-card">
+          <span class="overview-label">{{ copy.usedRam }}</span>
+          <strong>{{ formatBytes(data.usedInternalHeap) }}</strong>
+          <small>{{ formatPercent(data.internalHeapUsagePercent) }}</small>
+          <div class="usage-track"><span :style="{ width: usageWidth + '%' }"></span></div>
+        </article>
+        <article class="overview-card">
+          <span class="overview-label">{{ copy.totalRam }}</span>
+          <strong>{{ formatBytes(data.totalInternalHeap) }}</strong>
+          <small>{{ copy.allocatableRam }}</small>
+        </article>
+        <article class="overview-card">
+          <span class="overview-label">{{ copy.minimumHeap }}</span>
+          <strong>{{ formatBytes(data.minimumFreeHeap) }}</strong>
+          <small>{{ copy.sinceBoot }}</small>
+        </article>
+        <article class="overview-card">
+          <span class="overview-label">{{ copy.largestBlock }}</span>
+          <strong>{{ formatBytes(data.largestFreeBlock) }}</strong>
+          <small>{{ copy.contiguous }}</small>
+        </article>
+        <article class="overview-card">
+          <span class="overview-label">{{ copy.flash }}</span>
+          <strong>{{ formatBytes(data.flashBytes) }}</strong>
+          <small>{{ copy.physicalFlash }}</small>
+        </article>
+      </section>
+
+      <section class="detail-grid">
+        <article class="detail-card">
+          <div class="detail-heading">
+            <span class="icon-badge soft"><AppIcon name="cpu" /></span>
+            <div><h2>{{ copy.runtime }}</h2><p>{{ copy.runtimeHint }}</p></div>
+          </div>
+          <div class="kv-list">
+            <div class="kv-row"><span>{{ copy.idf }}</span><strong class="mono">{{ data.idfVersion || '—' }}</strong></div>
+            <div class="kv-row"><span>{{ copy.target }}</span><strong>{{ data.target || '—' }}</strong></div>
+            <div class="kv-row"><span>{{ copy.cores }}</span><strong>{{ data.chipCores ?? '—' }}</strong></div>
+            <div class="kv-row"><span>{{ copy.chipRevision }}</span><strong>{{ data.chipRevision ?? '—' }}</strong></div>
+            <div class="kv-row"><span>{{ copy.resetReason }}</span><strong>{{ data.resetReasonText || data.resetReason || '—' }}</strong></div>
+            <div class="kv-row"><span>{{ copy.psram }}</span><strong>{{ data.psramAvailable ? copy.available : copy.notAvailable }}</strong></div>
+            <div v-if="data.psramAvailable" class="kv-row"><span>{{ copy.psramTotal }}</span><strong>{{ formatBytes(data.totalPsram) }}</strong></div>
+            <div v-if="data.psramAvailable" class="kv-row"><span>{{ copy.psramFree }}</span><strong>{{ formatBytes(data.freePsram) }}</strong></div>
+          </div>
+        </article>
+
+        <article class="detail-card">
+          <div class="detail-heading">
+            <span class="icon-badge warning"><AppIcon name="firmware" /></span>
+            <div><h2>{{ copy.partitions }}</h2><p>{{ copy.partitionsHint }}</p></div>
+          </div>
+          <div class="kv-list">
+            <div class="kv-row"><span>{{ copy.runningPartition }}</span><strong class="mono">{{ data.runningPartition || '—' }}</strong></div>
+            <div class="kv-row"><span>{{ copy.runningSize }}</span><strong>{{ formatBytes(data.runningPartitionSize) }}</strong></div>
+            <div class="kv-row"><span>{{ copy.nextPartition }}</span><strong class="mono">{{ data.nextUpdatePartition || '—' }}</strong></div>
+            <div class="kv-row"><span>{{ copy.nextSize }}</span><strong>{{ formatBytes(data.nextUpdatePartitionSize) }}</strong></div>
+          </div>
+        </article>
+
+        <article class="detail-card">
+          <div class="detail-heading">
+            <span class="icon-badge info"><AppIcon name="globe" /></span>
+            <div><h2>WebUI</h2><p>{{ copy.webuiHint }}</p></div>
+          </div>
+          <div class="kv-list">
+            <div class="kv-row"><span>{{ copy.source }}</span><strong>{{ data.webui?.source || 'embedded' }}</strong></div>
+            <div class="kv-row"><span>{{ copy.version }}</span><strong class="mono">{{ data.webui?.version || 'embedded' }}</strong></div>
+            <div class="kv-row"><span>{{ copy.partitionSize }}</span><strong>{{ formatBytes(data.webui?.partitionBytes) }}</strong></div>
+            <div class="kv-row"><span>{{ copy.used }}</span><strong>{{ formatBytes(data.webui?.usedBytes) }}</strong></div>
+          </div>
+        </article>
+
+        <article class="detail-card">
+          <div class="detail-heading">
+            <span class="icon-badge success"><AppIcon name="logs" /></span>
+            <div><h2>{{ copy.logs }}</h2><p>{{ copy.logsHint }}</p></div>
+          </div>
+          <div class="kv-list">
+            <div class="kv-row"><span>{{ copy.capture }}</span><strong>{{ data.logs?.enabled ? copy.active : copy.inactive }}</strong></div>
+            <div class="kv-row"><span>{{ copy.bufferSize }}</span><strong>{{ formatBytes(data.logs?.bufferBytes) }}</strong></div>
+            <div class="kv-row"><span>{{ copy.availableLogs }}</span><strong>{{ formatBytes(data.logs?.availableBytes) }}</strong></div>
+            <div class="kv-row"><span>{{ copy.totalStream }}</span><strong>{{ formatBytes(data.logs?.totalWritten) }}</strong></div>
+            <div class="kv-row"><span>{{ copy.subscribers }}</span><strong>{{ data.logs?.subscribers ?? 0 }}</strong></div>
+            <div class="kv-row"><span>{{ copy.crashTail }}</span><strong :class="data.logs?.crashTailAvailable ? 'warning-text' : ''">{{ data.logs?.crashTailAvailable ? copy.available : copy.notAvailable }}</strong></div>
+          </div>
+        </article>
+      </section>
+
+      <BAlert variant="info" :model-value="true">
+        {{ copy.onDemandHint }} <code>/recovery</code>
+      </BAlert>
+
+      <div class="action-row">
+        <BButton variant="outline-primary" :disabled="loading" @click="loadOverview">
+          <AppIcon name="refresh" /> {{ copy.refresh }}
+        </BButton>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import axios from 'axios'
+
+const { locale } = useI18n()
+const loading = ref(true)
+const error = ref('')
+const data = ref({ webui: {}, logs: {} })
+
+const translations = {
+  de: {
+    eyebrow: 'Diagnose', title: 'Systemübersicht',
+    subtitle: 'RAM, Flash, Partitionen, Logs und aktive Weboberfläche auf einen Blick.',
+    freeRam: 'RAM frei', usedRam: 'RAM belegt', totalRam: 'RAM gesamt', minimumHeap: 'RAM-Minimum', largestBlock: 'Größter Block', flash: 'Flash',
+    currentAvailable: 'Aktuell verfügbar', allocatableRam: 'Vom Heap nutzbarer interner RAM', sinceBoot: 'Niedrigster Wert seit Start', contiguous: 'Größte zusammenhängende Allokation', physicalFlash: 'Erkannter Flash-Speicher',
+    runtime: 'Laufzeitumgebung', runtimeHint: 'ESP-IDF, Hardware und letzter Neustart', idf: 'ESP-IDF', target: 'Zielplattform', cores: 'CPU-Kerne', chipRevision: 'Chip-Revision', resetReason: 'Letzter Resetgrund', psram: 'PSRAM', psramTotal: 'PSRAM gesamt', psramFree: 'PSRAM frei',
+    partitions: 'OTA-Partitionen', partitionsHint: 'Aktive und nächste Firmware-Partition', runningPartition: 'Aktiv', runningSize: 'Aktive Größe', nextPartition: 'Nächstes Update', nextSize: 'Update-Größe',
+    webuiHint: 'Quelle und Speicher des New Designs', source: 'Quelle', version: 'Version', partitionSize: 'Partitionsgröße', used: 'Belegt',
+    logs: 'Log-Puffer', logsHint: 'Speicher, Crash-Tail und aktive Live-Streams', capture: 'Aufzeichnung', active: 'Aktiv', inactive: 'Inaktiv', bufferSize: 'Puffergröße', availableLogs: 'Gespeicherte Logs', totalStream: 'Gesamt geschrieben', subscribers: 'Subscriber', crashTail: 'Crash-Tail', available: 'Vorhanden', notAvailable: 'Nicht vorhanden',
+    onDemandHint: 'Alle Werte werden nur beim Öffnen oder manuellen Aktualisieren gelesen. Die unabhängige Notfallseite ist erreichbar unter', refresh: 'Aktualisieren'
+  },
+  en: {
+    eyebrow: 'Diagnostics', title: 'System Overview',
+    subtitle: 'RAM, flash, partitions, logs and the active web interface at a glance.',
+    freeRam: 'Free RAM', usedRam: 'Used RAM', totalRam: 'Total RAM', minimumHeap: 'RAM minimum', largestBlock: 'Largest block', flash: 'Flash',
+    currentAvailable: 'Currently available', allocatableRam: 'Internal RAM available to the heap', sinceBoot: 'Lowest value since boot', contiguous: 'Largest contiguous allocation', physicalFlash: 'Detected flash storage',
+    runtime: 'Runtime', runtimeHint: 'ESP-IDF, hardware and last restart', idf: 'ESP-IDF', target: 'Target', cores: 'CPU cores', chipRevision: 'Chip revision', resetReason: 'Last reset reason', psram: 'PSRAM', psramTotal: 'Total PSRAM', psramFree: 'Free PSRAM',
+    partitions: 'OTA partitions', partitionsHint: 'Running and next firmware partition', runningPartition: 'Running', runningSize: 'Running size', nextPartition: 'Next update', nextSize: 'Update size',
+    webuiHint: 'New Design source and storage', source: 'Source', version: 'Version', partitionSize: 'Partition size', used: 'Used',
+    logs: 'Log buffer', logsHint: 'Memory, crash tail and active live streams', capture: 'Capture', active: 'Active', inactive: 'Inactive', bufferSize: 'Buffer size', availableLogs: 'Buffered logs', totalStream: 'Total written', subscribers: 'Subscribers', crashTail: 'Crash tail', available: 'Available', notAvailable: 'Not available',
+    onDemandHint: 'All values are read only when this page is opened or manually refreshed. The independent emergency page is available at', refresh: 'Refresh'
+  }
+}
+
+const copy = computed(() => translations[locale.value] || translations.en)
+const usageWidth = computed(() => Math.min(100, Math.max(0, Number(data.value.internalHeapUsagePercent) || 0)))
+
+const formatBytes = (value) => {
+  const bytes = Number(value) || 0
+  if (!bytes) return '—'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+}
+
+const formatPercent = (value) => `${(Number(value) || 0).toFixed(1)} %`
+
+const loadOverview = async () => {
+  loading.value = true
+  error.value = ''
+  try {
+    const response = await axios.get('/api/system/overview', { timeout: 8000 })
+    data.value = response.data || { webui: {}, logs: {} }
+  } catch (requestError) {
+    error.value = requestError.response?.data || requestError.message || 'System overview unavailable'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadOverview)
+</script>
+
+<style scoped>
+.system-overview-page { display: flex; flex-direction: column; gap: 20px; }
+.success-chip { color: var(--color-success); }
+.warning-chip, .warning-text { color: var(--color-warning); }
+.overview-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }
+.overview-card, .detail-card { border: 1px solid var(--color-border-light); background: var(--color-surface); box-shadow: var(--shadow-sm); }
+.overview-card { min-height: 135px; border-radius: var(--radius-lg); padding: 20px; display: flex; flex-direction: column; gap: 8px; }
+.overview-card strong { font-size: 1.5rem; }
+.overview-card small, .overview-label { color: var(--color-text-secondary); }
+.overview-label { font-size: .76rem; text-transform: uppercase; letter-spacing: .08em; font-weight: 800; }
+.usage-track { height: 6px; border-radius: var(--radius-full); background: var(--color-border-light); overflow: hidden; margin-top: auto; }
+.usage-track span { display: block; height: 100%; background: var(--color-primary); }
+.detail-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+.detail-card { border-radius: var(--radius-xl); padding: 22px; min-width: 0; }
+.detail-heading { display: flex; gap: 12px; align-items: flex-start; margin-bottom: 18px; }
+.detail-heading h2 { margin: 0; font-size: 1.2rem; }
+.detail-heading p { margin: 3px 0 0; color: var(--color-text-secondary); font-size: .88rem; }
+.kv-list { display: flex; flex-direction: column; }
+.kv-row { display: flex; justify-content: space-between; gap: 14px; padding: 11px 0; border-bottom: 1px solid var(--color-border-light); }
+.kv-row:last-child { border-bottom: 0; }
+.kv-row span { color: var(--color-text-secondary); }
+.kv-row strong { text-align: right; overflow-wrap: anywhere; }
+.mono { font-family: var(--font-mono, monospace); }
+.action-row { display: flex; justify-content: flex-end; }
+.skeleton { min-height: 135px; animation: pulse 1.4s ease-in-out infinite; }
+@keyframes pulse { 0%,100% { opacity: .45; } 50% { opacity: .8; } }
+@media (max-width: 1000px) { .overview-grid, .detail-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 700px) { .overview-grid, .detail-grid { grid-template-columns: 1fr; } }
+@media (max-width: 560px) { .kv-row { flex-direction: column; gap: 4px; } .kv-row strong { text-align: left; } }
+</style>

--- a/webui/src/theme.vue
+++ b/webui/src/theme.vue
@@ -1,0 +1,171 @@
+<template>
+  <div class="page-shell theme-page">
+    <section class="page-hero">
+      <div class="hero-copy">
+        <span class="hero-eyebrow"><AppIcon name="sun" /> {{ copy.eyebrow }}</span>
+        <h1 class="hero-title">{{ copy.title }}</h1>
+        <p class="hero-subtitle">{{ copy.subtitle }}</p>
+      </div>
+      <div class="hero-meta">
+        <span class="meta-chip"><span class="color-dot" :style="{ background: themeStore.primaryColor }"></span>{{ themeStore.primaryColor }}</span>
+        <span class="meta-chip"><AppIcon :name="resolvedDark ? 'moon' : 'sun'" /> {{ themeLabel }}</span>
+      </div>
+    </section>
+
+    <section class="theme-grid">
+      <article class="theme-card">
+        <div class="card-heading">
+          <span class="icon-badge soft"><AppIcon name="moon" /></span>
+          <div><h2>{{ copy.scheme }}</h2><p>{{ copy.schemeHint }}</p></div>
+        </div>
+        <div class="scheme-selector">
+          <button
+            v-for="option in schemes"
+            :key="option.value"
+            type="button"
+            class="scheme-option"
+            :class="{ active: themeStore.theme === option.value }"
+            @click="themeStore.setTheme(option.value)"
+          >
+            <AppIcon :name="option.icon" />
+            <strong>{{ option.label }}</strong>
+          </button>
+        </div>
+      </article>
+
+      <article class="theme-card">
+        <div class="card-heading">
+          <span class="icon-badge info"><AppIcon name="sun" /></span>
+          <div><h2>{{ copy.accent }}</h2><p>{{ copy.accentHint }}</p></div>
+        </div>
+        <div class="color-presets">
+          <button
+            v-for="preset in presets"
+            :key="preset"
+            type="button"
+            class="color-preset"
+            :class="{ active: themeStore.primaryColor === preset }"
+            :style="{ background: preset }"
+            :aria-label="preset"
+            @click="themeStore.setPrimaryColor(preset)"
+          ></button>
+        </div>
+        <label class="custom-color">
+          <span>{{ copy.custom }}</span>
+          <input
+            type="color"
+            :value="themeStore.primaryColor"
+            @input="previewColor"
+            @change="saveColor"
+          />
+          <code>{{ pendingColor }}</code>
+        </label>
+      </article>
+
+      <article class="theme-card preview-card">
+        <div class="card-heading">
+          <span class="icon-badge success"><AppIcon name="check" /></span>
+          <div><h2>{{ copy.preview }}</h2><p>{{ copy.previewHint }}</p></div>
+        </div>
+        <div class="preview-panel">
+          <div class="preview-header">
+            <span class="preview-logo"></span>
+            <strong>HB-RF-ETH-ng</strong>
+            <span class="preview-status">{{ copy.online }}</span>
+          </div>
+          <div class="preview-content">
+            <div class="preview-metric"><span>CPU</span><strong>12%</strong><i style="width:12%"></i></div>
+            <div class="preview-metric"><span>RAM</span><strong>43%</strong><i style="width:43%"></i></div>
+            <button type="button" class="preview-button">{{ copy.action }}</button>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <BAlert variant="info" :model-value="true">
+      {{ copy.deviceWide }}
+    </BAlert>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useThemeStore } from './stores.js'
+
+const { locale } = useI18n()
+const themeStore = useThemeStore()
+const pendingColor = ref(themeStore.primaryColor)
+
+watch(() => themeStore.primaryColor, (value) => { pendingColor.value = value })
+
+const translations = {
+  de: {
+    eyebrow: 'Darstellung', title: 'Theme konfigurieren',
+    subtitle: 'Farbschema und Akzentfarbe werden direkt auf dem Gerät gespeichert.',
+    scheme: 'Farbschema', schemeHint: 'Automatisch dem System folgen oder fest einstellen.',
+    system: 'System', light: 'Hell', dark: 'Dunkel', accent: 'Akzentfarbe',
+    accentHint: 'Wird für Navigation, Buttons und Hervorhebungen verwendet.', custom: 'Eigene Farbe',
+    preview: 'Vorschau', previewHint: 'Beispiel für Karten und Aktionen.', online: 'Online', action: 'Aktion',
+    deviceWide: 'Die Einstellung gilt geräteweit. Andere Browser übernehmen sie beim nächsten Öffnen automatisch.'
+  },
+  en: {
+    eyebrow: 'Appearance', title: 'Configure Theme',
+    subtitle: 'Color scheme and accent color are stored directly on the device.',
+    scheme: 'Color scheme', schemeHint: 'Follow the operating system or choose a fixed mode.',
+    system: 'System', light: 'Light', dark: 'Dark', accent: 'Accent color',
+    accentHint: 'Used for navigation, buttons and highlights.', custom: 'Custom color',
+    preview: 'Preview', previewHint: 'Example cards and actions.', online: 'Online', action: 'Action',
+    deviceWide: 'This setting is device-wide. Other browsers automatically adopt it when opened.'
+  }
+}
+
+const copy = computed(() => translations[locale.value] || translations.en)
+const schemes = computed(() => [
+  { value: 'system', label: copy.value.system, icon: 'settings' },
+  { value: 'light', label: copy.value.light, icon: 'sun' },
+  { value: 'dark', label: copy.value.dark, icon: 'moon' }
+])
+const presets = ['#f26a3d', '#3971e8', '#1ca971', '#8b5cf6', '#e89a24']
+const resolvedDark = computed(() => {
+  if (themeStore.theme === 'dark') return true
+  if (themeStore.theme === 'light') return false
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches || false
+})
+const themeLabel = computed(() => schemes.value.find((item) => item.value === themeStore.theme)?.label || copy.value.system)
+
+const previewColor = (event) => {
+  pendingColor.value = event.target.value
+  themeStore.setPrimaryColor(event.target.value, false)
+}
+const saveColor = (event) => themeStore.setPrimaryColor(event.target.value, true)
+</script>
+
+<style scoped>
+.theme-page { display: flex; flex-direction: column; gap: 20px; }
+.color-dot { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
+.theme-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
+.theme-card { border: 1px solid var(--color-border-light); background: var(--color-surface); border-radius: var(--radius-xl); box-shadow: var(--shadow-sm); padding: 24px; }
+.preview-card { grid-column: 1 / -1; }
+.card-heading { display: flex; gap: 12px; align-items: flex-start; margin-bottom: 20px; }
+.card-heading h2 { font-size: 1.25rem; }
+.card-heading p { color: var(--color-text-secondary); margin-top: 4px; }
+.scheme-selector { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.scheme-option { border: 1px solid var(--color-border); background: var(--color-bg-alt); color: var(--color-text); border-radius: var(--radius-md); min-height: 88px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; cursor: pointer; }
+.scheme-option.active { border-color: var(--color-primary); color: var(--color-primary); background: var(--color-primary-soft); box-shadow: inset 0 0 0 1px var(--color-primary); }
+.color-presets { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 20px; }
+.color-preset { width: 46px; height: 46px; border-radius: 50%; border: 4px solid var(--color-surface); box-shadow: 0 0 0 1px var(--color-border-strong); cursor: pointer; }
+.color-preset.active { box-shadow: 0 0 0 3px var(--color-text), 0 0 0 5px var(--color-surface); }
+.custom-color { display: grid; grid-template-columns: 1fr auto auto; gap: 12px; align-items: center; border-top: 1px solid var(--color-border-light); padding-top: 18px; }
+.custom-color input { width: 52px; height: 38px; border: 0; background: transparent; cursor: pointer; }
+.preview-panel { border: 1px solid var(--color-border); border-radius: var(--radius-lg); overflow: hidden; background: var(--color-bg); }
+.preview-header { display: flex; align-items: center; gap: 10px; padding: 14px 18px; background: var(--color-surface); border-bottom: 1px solid var(--color-border-light); }
+.preview-logo { width: 24px; height: 24px; border-radius: 8px; background: var(--color-primary); }
+.preview-status { margin-left: auto; color: var(--color-success); font-size: .82rem; font-weight: 700; }
+.preview-content { display: grid; grid-template-columns: repeat(2, 1fr) auto; gap: 14px; align-items: end; padding: 20px; }
+.preview-metric { position: relative; padding: 14px; border-radius: var(--radius-md); background: var(--color-surface); display: flex; justify-content: space-between; overflow: hidden; }
+.preview-metric i { position: absolute; left: 0; bottom: 0; height: 4px; background: var(--color-primary); }
+.preview-button { border: 0; border-radius: var(--radius-md); background: var(--color-primary); color: white; min-height: 48px; padding: 0 22px; font-weight: 700; }
+@media (max-width: 760px) { .theme-grid { grid-template-columns: 1fr; } .preview-card { grid-column: auto; } .preview-content { grid-template-columns: 1fr; } }
+@media (max-width: 480px) { .scheme-selector { grid-template-columns: 1fr; } .custom-color { grid-template-columns: 1fr auto; } .custom-color code { grid-column: 1 / -1; } }
+</style>


### PR DESCRIPTION
Neu aufgebaut auf dem aktuellen `main` nach Merge von #380.

Enthält Systemübersicht, RAM-/Heap-Diagnose, minimale Recovery-Seite, geräteweite Themes, Crash-Tail-Status und speicherschonenden Log-Download. Es werden keine neuen Dauer-Tasks, Statistikpuffer oder automatischen Polling-Schleifen eingeführt.

Der identische Featurestand war bereits vollständig grün. Dieser PR führt alle Firmware-, Größen-, WebUI-, Security- und Dokumentationsprüfungen erneut auf dem aktuellen Basisstand aus. Hardwaretests werden in den ersten Beta-Testzyklus verschoben.