### PR TITLE
feat(webui): UI/UX Korrekturauftrag completion (Beta.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.5-Beta.7] - 2026-07-21
+
+### Changes
+- feat(webui): Manuelle Updatesuche über „Jetzt nach Updates suchen" wiederhergestellt. Neuer Backend-Endpunkt POST /api/check_update löst sofortigen Manifest-Abruf aus (läuft außerhalb des httpd-Threads), 60-Sekunden-Cooldown verhindert Missbrauch; die automatische 24-Stunden-Prüfung bleibt unberührt. Die Schaltfläche erscheint konsistent auf den Firmware- und WebUI-Update-Tabs und zeigt Lade-, Update-, Aktuell- und Fehlerzustände an.
+- refactor(webui): Eigenständiger Menüpunkt „Design wechseln" entfernt. Die Theme-Auswahl ist ausschließlich unter Einstellungen → Design erreichbar; der Header-Sonne/Mond-Schnellwechsler bleibt, und die /theme-Route bleibt für Lesezeichen erreichbar.
+- fix(webui): Fokus- und Hover-Zustände nutzen jetzt Design-Tokens (var(--color-primary) / var(--color-primary-soft) / var(--shadow-md)) statt hartcodierter Glass-UI-Orange-Tokens — Login-Eingaben, Login-Button, Passwort-Änderungs-Modal und Selbsttest-Test-Button erscheinen damit nicht mehr orange im grünen NewDesign.
+- fix(webui): Dashboard-Zeile „Letzter Neustart" in „Neustartgrund" umbenannt (Wert ist die Ursache, keine Zeitangabe); alle 10 Sprachen aktualisiert.
+- docs: POST /api/check_update in API.md und openapi.yaml dokumentiert (202 Accepted, {triggered, fetchInProgress}, Client-Polling).
+
 ## [2.2.5-Beta.6] - 2026-07-21
 
 ### Changes

--- a/docs/API.md
+++ b/docs/API.md
@@ -563,24 +563,48 @@ curl http://192.168.1.100/api/check_update \
 
 ### POST /api/check_update
 
-Trigger an immediate refresh from the static update manifest. Returns the same
-JSON shape as `GET /api/check_update` once the fetch completes. The endpoint
-runs the fetch in a detached task so the single-threaded HTTP server stays
-responsive; the response is sent after the fetch finishes (typically 3–10 s).
-Concurrent requests coalesce onto the in-flight fetch rather than spawning
-duplicate manifest requests.
+Trigger an immediate refresh from the static update manifest. This is the
+backend behind the WebUI "Jetzt nach Updates suchen" button. It **ignores the
+24 h automatic window** (the user explicitly asked for a check) but enforces a
+60 s cooldown and refuses to stack onto a fetch that is already running, so
+the GitHub manifest and the ESP32 TLS heap stay protected.
+
+The actual manifest fetch runs in a detached task (a GitHub TLS handshake can
+take several seconds); this handler therefore returns **202 Accepted
+immediately** and the client polls `GET /api/check_update` (`fetchInProgress`)
+until it clears, then reads the updated snapshot.
 
 **Authentication:** Required
 
 **Request:** Empty body accepted (`{}` is also fine).
 
-**Response (200 OK):** Same shape as `GET /api/check_update`.
+**Response (202 Accepted):**
+```json
+{
+  "triggered": true,
+  "fetchInProgress": true
+}
+```
+
+**Fields:**
+- `triggered`: `true` when a new fetch was armed. `false` if a fetch is
+  already running, or the 60 s manual cooldown has not elapsed — in either
+  case the cached snapshot remains available via `GET /api/check_update`.
+- `fetchInProgress`: `true` while a manifest fetch (manual or automatic) is in
+  flight. Clients should poll `GET /api/check_update` until this becomes
+  `false`.
 
 **Example:**
 ```bash
-curl -X POST http://192.168.1.100/api/check_update \
+curl -i -X POST http://192.168.1.100/api/check_update \
   -H "Authorization: Token YOUR_TOKEN_HERE"
+# HTTP/1.1 202 Accepted
+# {"triggered":true,"fetchInProgress":true}
 ```
+
+**Client flow:** POST → poll GET every ~1 s until `fetchInProgress == false`
+(≤ 20 s) → read the refreshed snapshot. The automatic 24 h check timer is not
+affected by manual triggers.
 
 ---
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -253,6 +253,79 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
+  /api/check_update:
+    get:
+      tags:
+        - Firmware
+      summary: Get cached release snapshot
+      description: >
+        Return the cached snapshot of the latest release known to the firmware.
+        Refreshed automatically every 24 h by a background timer and on demand
+        via POST /api/check_update. This handler never opens a network
+        connection, so it is safe to poll.
+      responses:
+        '200':
+          description: Cached release snapshot
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  currentVersion:
+                    type: string
+                  latestVersion:
+                    type: string
+                  updateAvailable:
+                    type: boolean
+                  isPrerelease:
+                    type: boolean
+                  fetchedAt:
+                    type: number
+                    description: Unix epoch millis of the last successful fetch
+                  betaChannel:
+                    type: boolean
+                  fetchInProgress:
+                    type: boolean
+                  error:
+                    type: string
+                    nullable: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    post:
+      tags:
+        - Firmware
+      summary: Trigger an immediate release-check fetch
+      description: >
+        Arm an immediate online manifest fetch on the device (the WebUI
+        "Jetzt nach Updates suchen" button). Ignores the 24 h automatic window
+        but enforces a 60 s cooldown and never stacks onto a running fetch.
+        The actual GitHub request runs in a detached task; this handler
+        returns 202 immediately. Poll GET /api/check_update (fetchInProgress)
+        until it clears, then read the refreshed snapshot.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '202':
+          description: Fetch armed (or refused due to cooldown / in-flight fetch)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  triggered:
+                    type: boolean
+                    description: true when a new fetch was armed
+                  fetchInProgress:
+                    type: boolean
+                    description: true while a fetch is in flight
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
 components:
   securitySchemes:
     TokenAuth:

--- a/include/updatecheck.h
+++ b/include/updatecheck.h
@@ -110,6 +110,16 @@ private:
     esp_timer_handle_t _periodicTimer = NULL;
     esp_timer_handle_t _initialTimer = NULL;
 
+    // One-shot timer armed by triggerManualFetch(). It defers the real fetch
+    // off the httpd worker thread (a GitHub TLS handshake can take several
+    // seconds) so POST /api/check_update can answer immediately while the
+    // manifest fetch runs on its own short-lived task like the daily check.
+    esp_timer_handle_t _manualFetchTimer = NULL;
+    // Epoch millis of the last accepted manual trigger, guarded by _stateMutex.
+    // Enforces a 60 s manual cooldown independently of the 24 h automatic
+    // window so the WebUI "search now" button cannot hammer the manifest.
+    int64_t _lastManualFetchMs = 0;
+
     // Serializes writes/reads of the cached _release snapshot.
     SemaphoreHandle_t _stateMutex = NULL;
     // Held while a network fetch is in progress; prevents concurrent fetches
@@ -150,6 +160,15 @@ public:
     // Performs an online fetch only when the persistent 24 h window is due.
     // Reboots and page visits cannot bypass this limit.
     bool refreshIfDue();
+
+    // Arm an immediate online fetch from a manual WebUI/MQTT request. Bypasses
+    // the 24 h window (the user explicitly asked) but enforces a 60 s manual
+    // cooldown and never stacks onto a fetch already in progress. The actual
+    // GitHub request is deferred to a short-lived task so this never blocks the
+    // httpd worker. Returns true when a new fetch was armed, false if one is
+    // already running or the cooldown has not elapsed. The 24 h automatic
+    // timer is not affected.
+    bool triggerManualFetch();
 
     // Compares the cached release against the running version and drives the
     // status LED (update-available blink). Public because it is called by the

--- a/main/updatecheck.cpp
+++ b/main/updatecheck.cpp
@@ -161,6 +161,51 @@ static void _periodic_timer_callback(void *arg)
   }
 }
 
+// Short-lived task spawned by _manual_fetch_callback. Identical to the daily
+// path except it calls refresh() unconditionally (the user explicitly asked for
+// a check, so the 24 h window does not apply — only the 60 s manual cooldown,
+// enforced in triggerManualFetch() before arming this task, gates it).
+static void _manual_fetch_task(void *parameter)
+{
+  UpdateCheck *uc = static_cast<UpdateCheck *>(parameter);
+  ESP_LOGI(TAG, "Manual update check starting (heap free: %u KB)",
+           (unsigned)(heap_caps_get_free_size(MALLOC_CAP_DEFAULT) / 1024));
+  const bool ok = uc->refresh();
+  if (ok) {
+    save_cached_release(uc->getReleaseInfo());
+  }
+  uc->_evaluateReleaseInfo();
+  vTaskDelete(NULL);
+}
+
+// esp_timer callback for the manual "check now" path. Runs in the high-priority
+// timer task (3-4 KB stack) — too small for refresh() — so we only spawn the
+// real worker here and return immediately, mirroring _periodic_timer_callback.
+static void _manual_fetch_callback(void *arg)
+{
+  UpdateCheck *uc = static_cast<UpdateCheck *>(arg);
+
+  // Same heap guard as the daily check: never destabilise Homematic/MQTT for a
+  // manual refresh. The cached snapshot stays available and the user can retry.
+  const size_t free_heap = heap_caps_get_free_size(MALLOC_CAP_DEFAULT);
+  const size_t largest_block = heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT);
+  constexpr size_t MIN_FREE_HEAP = 72 * 1024;
+  constexpr size_t MIN_LARGEST_BLOCK = 18 * 1024;
+  if (free_heap < MIN_FREE_HEAP || largest_block < MIN_LARGEST_BLOCK) {
+    ESP_LOGW(TAG,
+             "Manual update check skipped (low heap): free=%u KB largest=%u KB",
+             (unsigned)(free_heap / 1024),
+             (unsigned)(largest_block / 1024));
+    return;
+  }
+
+  BaseType_t created = xTaskCreate(_manual_fetch_task, "upd_man", 9216,
+                                   uc, 2, NULL);
+  if (created != pdPASS) {
+    ESP_LOGE(TAG, "Failed to create manual update-check task");
+  }
+}
+
 static uint32_t update_check_stagger_seconds(SysInfo *sysInfo)
 {
   // Stable FNV-1a hash of the device serial. Devices updated or rebooted at the
@@ -449,6 +494,19 @@ void UpdateCheck::start()
     } else {
         ESP_LOGE(TAG, "Failed to create periodic update-check timer");
     }
+
+    // One-shot timer for the manual "check now" button (POST /api/check_update).
+    // Created once, armed by triggerManualFetch() on each click; never runs on a
+    // schedule. The 24 h automatic timer above is completely independent.
+    if (!_manualFetchTimer) {
+        esp_timer_create_args_t manualArgs = {};
+        manualArgs.callback = _manual_fetch_callback;
+        manualArgs.arg = this;
+        manualArgs.name = "updchk_man";
+        if (esp_timer_create(&manualArgs, &_manualFetchTimer) != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to create manual update-check timer");
+        }
+    }
 }
 
 void UpdateCheck::stop()
@@ -464,6 +522,14 @@ void UpdateCheck::stop()
         esp_timer_stop(_initialTimer);
         esp_timer_delete(_initialTimer);
         _initialTimer = NULL;
+    }
+    // A manual fetch may have just been armed (e.g. OTA heap preparation right
+    // after the user clicked "search now"). Cancel it so it cannot fire during
+    // shutdown / OTA and contend for the TLS heap.
+    if (_manualFetchTimer) {
+        esp_timer_stop(_manualFetchTimer);
+        esp_timer_delete(_manualFetchTimer);
+        _manualFetchTimer = NULL;
     }
 }
 
@@ -602,6 +668,56 @@ bool UpdateCheck::isFetchInProgress()
     // xSemaphoreGetMutexHolder returns the owning task handle or NULL. We
     // don't care who owns it - any non-NULL value means "busy".
     return xSemaphoreGetMutexHolder(_fetchLock) != NULL;
+}
+
+bool UpdateCheck::triggerManualFetch()
+{
+    // 60 s cooldown measured in epoch millis. A manual "search now" click
+    // intentionally bypasses the 24 h automatic window, but must still protect
+    // the GitHub manifest and the ESP32 TLS heap from rapid repeat clicks.
+    static constexpr int64_t MANUAL_FETCH_COOLDOWN_MS = 60 * 1000;
+
+    if (!_manualFetchTimer) {
+        ESP_LOGW(TAG, "triggerManualFetch: timer not initialised");
+        return false;
+    }
+
+    // Reject if a fetch is already running (background timer or a previous
+    // manual trigger). refresh() would return false anyway; we just avoid
+    // arming a redundant worker task.
+    if (isFetchInProgress()) {
+        ESP_LOGD(TAG, "triggerManualFetch: a fetch is already in progress");
+        return false;
+    }
+
+    const int64_t nowMs = current_epoch_seconds() > 0
+        ? current_epoch_seconds() * 1000
+        : (esp_timer_get_time() / 1000);
+
+    if (_stateMutex && xSemaphoreTake(_stateMutex, portMAX_DELAY) == pdTRUE) {
+        const int64_t elapsed = nowMs - _lastManualFetchMs;
+        if (_lastManualFetchMs != 0 && elapsed < MANUAL_FETCH_COOLDOWN_MS) {
+            xSemaphoreGive(_stateMutex);
+            ESP_LOGI(TAG,
+                     "triggerManualFetch: cooldown active, next manual check in %lld s",
+                     (long long)((MANUAL_FETCH_COOLDOWN_MS - elapsed + 999) / 1000));
+            return false;
+        }
+        _lastManualFetchMs = nowMs;
+        xSemaphoreGive(_stateMutex);
+    }
+
+    // Arm the one-shot timer; it spawns the real worker off the httpd thread.
+    // A short 200 ms delay lets the POST response leave the device first.
+    esp_timer_stop(_manualFetchTimer);
+    const esp_err_t err = esp_timer_start_once(_manualFetchTimer, 200 * 1000);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "triggerManualFetch: failed to arm timer (%s)", esp_err_to_name(err));
+        return false;
+    }
+    ESP_LOGI(TAG, "Manual update check armed (cooldown %lld ms)",
+             (long long)MANUAL_FETCH_COOLDOWN_MS);
+    return true;
 }
 
 void UpdateCheck::_setOtaStateLocked(ota_state_t state)

--- a/main/webui.cpp
+++ b/main/webui.cpp
@@ -2269,9 +2269,11 @@ esp_err_t get_check_update_handler_func(httpd_req_t *req)
         return ESP_OK;
     }
 
-    // GET returns the persistent cached snapshot only. No browser, MQTT
-    // command or page visit can trigger an online request; the backend timer
-    // enforces the single 24-hour update window.
+    // GET returns the persistent cached snapshot. The snapshot is refreshed
+    // automatically every 24 h by the UpdateCheck timer, and additionally on
+    // demand via POST /api/check_update (manual "search now"); this handler
+    // itself never opens a network connection. `fetchInProgress` in the JSON
+    // body tells the caller whether a manual fetch is currently running.
     send_release_info_response(req);
     return ESP_OK;
 }
@@ -2280,6 +2282,54 @@ httpd_uri_t get_check_update_handler = {
     .uri = "/api/check_update",
     .method = HTTP_GET,
     .handler = get_check_update_handler_func,
+    .user_ctx = NULL};
+
+// POST /api/check_update — arms an immediate online manifest fetch on the
+// device (the "Jetzt nach Updates suchen" button). The actual GitHub request
+// is deferred to a short-lived task so this handler returns 202 right away;
+// the client then polls GET /api/check_update (fetchInProgress) until it
+// clears and reads the updated snapshot. triggerManualFetch() enforces a 60 s
+// cooldown and refuses to stack onto a running fetch, so the 24 h automatic
+// timer and the ESP32 TLS heap stay protected.
+esp_err_t post_check_update_handler_func(httpd_req_t *req)
+{
+    add_security_headers(req);
+    httpd_resp_set_type(req, "application/json");
+
+    if (validate_auth(req) != ESP_OK)
+    {
+        httpd_resp_set_status(req, "401 Not authorized");
+        httpd_resp_sendstr(req, "401 Not authorized");
+        return ESP_OK;
+    }
+
+    const bool accepted = _updateCheck->triggerManualFetch();
+    const bool fetchInProgress = _updateCheck->isFetchInProgress();
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "triggered", accepted);
+    cJSON_AddBoolToObject(root, "fetchInProgress", fetchInProgress);
+    // accepted=false with fetchInProgress=true means "a check is already
+    // running" (the client should just keep polling). accepted=false with
+    // fetchInProgress=false means "cooldown active" (the client shows the
+    // cached result). Either way the response is 202: the request was
+    // understood, the latest snapshot remains available via GET.
+    httpd_resp_set_status(req, "202 Accepted");
+    const char *json = cJSON_PrintUnformatted(root);
+    if (json) {
+        httpd_resp_sendstr(req, json);
+        free((void *)json);
+    } else {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "JSON alloc failed");
+    }
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+httpd_uri_t post_check_update_handler = {
+    .uri = "/api/check_update",
+    .method = HTTP_POST,
+    .handler = post_check_update_handler_func,
     .user_ctx = NULL};
 
 esp_err_t get_log_handler_func(httpd_req_t *req)
@@ -2691,6 +2741,7 @@ void WebUI::start()
         httpd_register_uri_handler(_httpd_handle, &get_backup_handler);
         httpd_register_uri_handler(_httpd_handle, &post_restore_handler);
         httpd_register_uri_handler(_httpd_handle, &get_check_update_handler);
+        httpd_register_uri_handler(_httpd_handle, &post_check_update_handler);
         httpd_register_uri_handler(_httpd_handle, &get_log_handler);
         httpd_register_uri_handler(_httpd_handle, &get_log_status_handler);
         httpd_register_uri_handler(_httpd_handle, &post_log_enable_handler);

--- a/webui/src/components/PasswordChangeModal.vue
+++ b/webui/src/components/PasswordChangeModal.vue
@@ -280,8 +280,8 @@ const handleSubmit = async () => {
 }
 
 .password-change-modal :deep(.form-control:focus) {
-  border-color: rgba(242, 106, 61, 0.38);
-  box-shadow: 0 0 0 4px rgba(242, 106, 61, 0.12);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 4px var(--color-primary-soft);
 }
 
 .alert-icon {

--- a/webui/src/composables/useHeaderNavigation.js
+++ b/webui/src/composables/useHeaderNavigation.js
@@ -11,7 +11,11 @@ export const useHeaderNavigation = (t, loginStore) => {
       { to: '/monitoring', icon: 'monitoring', label: t('nav.monitoring'), group: 'overview' },
       { to: '/settings', icon: 'settings', label: t('nav.settings'), group: 'system' },
       { to: '/system-overview', icon: 'cpu', label: t('sysinfo.system'), group: 'system' },
-      { to: '/theme', icon: 'sun', label: t('nav.toggleTheme'), group: 'system' },
+      // The standalone "Design wechseln" menu item is intentionally removed
+      // (Korrekturauftrag §5): theme selection lives only under Settings →
+      // Design (embedded ThemeSettings). The header sun/moon toggle button
+      // still flips light/dark quickly and is unaffected; /theme remains a
+      // reachable route for bookmarks but is not advertised in the sidebar.
       // Firmware + WebUI merged under /updates (Korrekturauftrag §6).
       { to: '/updates/firmware', icon: 'firmware', label: t('nav.updates'), group: 'system' },
       { to: '/systemlog', icon: 'logs', label: t('nav.systemlog'), group: 'system' },

--- a/webui/src/firmwareupdate.vue
+++ b/webui/src/firmwareupdate.vue
@@ -26,6 +26,19 @@
             Update-Prüfung fehlgeschlagen: {{ updateStore.checkError }}
           </BAlert>
 
+          <!-- Manual "search for updates now" (Korrekturauftrag §6.2/§6.3).
+               The on-device fetch runs off the httpd thread; the store polls
+               fetchInProgress until it clears, so the spinner reflects the real
+               check. The automatic 24 h cycle is untouched (§6.4). -->
+          <div class="check-now-row">
+            <BButton variant="outline-primary" class="action-btn check-now-btn"
+                     :disabled="updateStore.isChecking" @click="onCheckNow">
+              <span v-if="updateStore.isChecking" class="spinner-border spinner-border-sm me-2"></span>
+              <AppIcon v-else name="refresh" />
+              {{ updateStore.isChecking ? t('updates.checkingNow') : t('updates.checkNow') }}
+            </BButton>
+          </div>
+
           <div v-if="updateStore.updateAvailable" class="release-box">
             <div>
               <span class="release-label">Neue Version</span>
@@ -289,6 +302,44 @@ const onBetaToggle = async event => {
   }
 }
 
+// Manual update search (Korrekturauftrag §6.2/§6.3). The store handles the
+// POST + polling and returns one of: 'updated' | 'no-update' | 'cooldown' |
+// 'error'. Each outcome surfaces a clear toast so the user always knows the
+// result of clicking "search now".
+const onCheckNow = async () => {
+  if (updateStore.isChecking) return
+  const outcome = await updateStore.checkNow(sysInfoStore.currentVersion)
+  if (outcome === 'updated') {
+    uiStore.pushToast({
+      type: 'success',
+      title: t('updates.checkResultUpdatedTitle'),
+      message: t('updates.checkResultUpdated', { version: updateStore.latestVersion }),
+      duration: 5000
+    })
+  } else if (outcome === 'no-update') {
+    uiStore.pushToast({
+      type: 'info',
+      title: t('updates.checkResultNoUpdateTitle'),
+      message: t('updates.checkResultNoUpdate'),
+      duration: 4000
+    })
+  } else if (outcome === 'cooldown') {
+    uiStore.pushToast({
+      type: 'info',
+      title: t('updates.checkResultCooldownTitle'),
+      message: t('updates.checkResultCooldown'),
+      duration: 4000
+    })
+  } else {
+    uiStore.pushToast({
+      type: 'error',
+      title: t('updates.checkResultErrorTitle'),
+      message: updateStore.checkError || t('updates.checkResultError'),
+      duration: 6000
+    })
+  }
+}
+
 const restartClick = async () => {
   if (!window.confirm(t('firmware.restartConfirm'))) return
   try { await axios.post('/api/restart') } catch { /* Verbindung bricht beim Neustart erwartbar ab. */ }
@@ -346,6 +397,11 @@ onMounted(async () => {
 .beta-badge { padding:4px 8px; border-radius:var(--radius-pill); background:var(--color-warning-soft); font-size: var(--fs-2xs); font-weight: var(--font-weight-bold); }
 .actions { display:flex; flex-wrap:wrap; gap:10px; }
 .action-btn { display:inline-flex; align-items:center; justify-content:center; gap:8px; text-decoration:none; }
+/* Manual "search now" sits above the release status so the primary action is
+   reachable before the user reads the cached result. Reuses .action-btn so it
+   shares size/alignment with the download + GitHub buttons below. */
+.check-now-row { display:flex; }
+.check-now-btn { width:auto; }
 .beta-toggle-row { display:flex; gap:12px; align-items:flex-start; padding-top:14px; border-top:1px solid var(--color-border); }
 .beta-toggle-label { display:flex; flex-direction:column; gap:3px; font-weight: var(--font-weight-bold); }
 .beta-toggle-hint { font-size: var(--fs-xs); font-weight: var(--font-weight-normal); color:var(--color-text-secondary); }

--- a/webui/src/locales/cs.js
+++ b/webui/src/locales/cs.js
@@ -233,7 +233,8 @@ export default {
     hostname: 'Název hostitele',
     boardRevision: 'Revize desky',
     uptime: 'Doba běhu',
-    resetReason: 'Poslední restart',
+     // Value is the cause of the last reboot, not a timestamp (Korrekturauftrag §1.5).
+     resetReason: 'Důvod restartu',
     cpuUsage: 'Využití CPU',
     memoryUsage: 'Využití paměti',
     ethernetStatus: 'Připojení Ethernet',
@@ -290,7 +291,17 @@ export default {
     title: 'Updates',
     subtitle: 'Firmware and web interface have separate versions and are updated independently.',
     firmware: 'Firmware',
-    webui: 'WebUI'
+    webui: 'WebUI',
+    checkNow: 'Search for updates now',
+    checkingNow: 'Searching …',
+    checkResultUpdatedTitle: 'Update available',
+    checkResultUpdated: 'Version {version} is available.',
+    checkResultNoUpdateTitle: 'Everything is up to date',
+    checkResultNoUpdate: 'No newer version is available.',
+    checkResultErrorTitle: 'Check failed',
+    checkResultError: 'The update check could not be completed.',
+    checkResultCooldownTitle: 'Just a moment',
+    checkResultCooldown: 'A check is already running or the 60-second cooldown is still active.'
   },
 
   // Firmware Update

--- a/webui/src/locales/de.js
+++ b/webui/src/locales/de.js
@@ -252,7 +252,10 @@ export default {
     hostname: 'Hostname',
     boardRevision: 'Board-Revision',
     uptime: 'Laufzeit',
-    resetReason: 'Letzter Neustart',
+    // The value is the cause of the most recent reboot (e.g. "Power on",
+    // "Task watchdog"), not a timestamp — so the label names the cause
+    // explicitly and does not mix time and reason (Korrekturauftrag §1.5).
+    resetReason: 'Neustartgrund',
     cpuUsage: 'CPU Auslastung',
     memoryUsage: 'Speicherauslastung',
     ethernetStatus: 'Ethernet-Verbindung',
@@ -303,7 +306,18 @@ export default {
     title: 'Updates',
     subtitle: 'Firmware und Weboberfläche besitzen getrennte Versionen und werden separat aktualisiert.',
     firmware: 'Firmware',
-    webui: 'WebUI'
+    webui: 'WebUI',
+    checkNow: 'Jetzt nach Updates suchen',
+    checkingNow: 'Suche läuft …',
+    // Result toasts after a manual "search now" (Korrekturauftrag §6.3).
+    checkResultUpdatedTitle: 'Update verfügbar',
+    checkResultUpdated: 'Version {version} ist verfügbar.',
+    checkResultNoUpdateTitle: 'Alles aktuell',
+    checkResultNoUpdate: 'Es ist keine neuere Version vorhanden.',
+    checkResultErrorTitle: 'Prüfung fehlgeschlagen',
+    checkResultError: 'Die Update-Prüfung konnte nicht durchgeführt werden.',
+    checkResultCooldownTitle: 'Kurz gewartet',
+    checkResultCooldown: 'Es läuft bereits eine Prüfung oder die 60-Sekunden-Sperre ist noch aktiv.'
   },
 
   // Firmware Update

--- a/webui/src/locales/en.js
+++ b/webui/src/locales/en.js
@@ -246,7 +246,9 @@ export default {
     hostname: 'Hostname',
     boardRevision: 'Board revision',
     uptime: 'Uptime',
-    resetReason: 'Last reboot',
+    // Value is the cause of the last reboot, not a timestamp — name the cause
+    // explicitly and keep it separate from the uptime row (Korrekturauftrag §1.5).
+    resetReason: 'Restart reason',
     cpuUsage: 'CPU usage',
     memoryUsage: 'Memory usage',
     ethernetStatus: 'Ethernet connection',
@@ -303,7 +305,18 @@ export default {
     title: 'Updates',
     subtitle: 'Firmware and web interface have separate versions and are updated independently.',
     firmware: 'Firmware',
-    webui: 'WebUI'
+    webui: 'WebUI',
+    checkNow: 'Search for updates now',
+    checkingNow: 'Searching …',
+    // Result toasts after a manual "search now".
+    checkResultUpdatedTitle: 'Update available',
+    checkResultUpdated: 'Version {version} is available.',
+    checkResultNoUpdateTitle: 'Everything is up to date',
+    checkResultNoUpdate: 'No newer version is available.',
+    checkResultErrorTitle: 'Check failed',
+    checkResultError: 'The update check could not be completed.',
+    checkResultCooldownTitle: 'Just a moment',
+    checkResultCooldown: 'A check is already running or the 60-second cooldown is still active.'
   },
 
   // Firmware Update

--- a/webui/src/locales/es.js
+++ b/webui/src/locales/es.js
@@ -233,7 +233,8 @@ export default {
     hostname: 'Nombre de host',
     boardRevision: 'Revisión de la placa',
     uptime: 'Tiempo de actividad',
-    resetReason: 'Último reinicio',
+     // Value is the cause of the last reboot, not a timestamp (Korrekturauftrag §1.5).
+     resetReason: 'Motivo de reinicio',
     cpuUsage: 'Uso de CPU',
     memoryUsage: 'Uso de memoria',
     ethernetStatus: 'Conexión Ethernet',
@@ -290,7 +291,17 @@ export default {
     title: 'Updates',
     subtitle: 'Firmware and web interface have separate versions and are updated independently.',
     firmware: 'Firmware',
-    webui: 'WebUI'
+    webui: 'WebUI',
+    checkNow: 'Search for updates now',
+    checkingNow: 'Searching …',
+    checkResultUpdatedTitle: 'Update available',
+    checkResultUpdated: 'Version {version} is available.',
+    checkResultNoUpdateTitle: 'Everything is up to date',
+    checkResultNoUpdate: 'No newer version is available.',
+    checkResultErrorTitle: 'Check failed',
+    checkResultError: 'The update check could not be completed.',
+    checkResultCooldownTitle: 'Just a moment',
+    checkResultCooldown: 'A check is already running or the 60-second cooldown is still active.'
   },
 
   // Firmware Update

--- a/webui/src/locales/fr.js
+++ b/webui/src/locales/fr.js
@@ -233,7 +233,8 @@ export default {
     hostname: 'Nom d\'hôte',
     boardRevision: 'Révision de la carte',
     uptime: 'Temps de fonctionnement',
-    resetReason: 'Dernier redémarrage',
+     // Value is the cause of the last reboot, not a timestamp (Korrekturauftrag §1.5).
+     resetReason: 'Cause du redémarrage',
     cpuUsage: 'Utilisation du CPU',
     memoryUsage: 'Utilisation de la mémoire',
     ethernetStatus: 'Connexion Ethernet',
@@ -290,7 +291,17 @@ export default {
     title: 'Updates',
     subtitle: 'Firmware and web interface have separate versions and are updated independently.',
     firmware: 'Firmware',
-    webui: 'WebUI'
+    webui: 'WebUI',
+    checkNow: 'Search for updates now',
+    checkingNow: 'Searching …',
+    checkResultUpdatedTitle: 'Update available',
+    checkResultUpdated: 'Version {version} is available.',
+    checkResultNoUpdateTitle: 'Everything is up to date',
+    checkResultNoUpdate: 'No newer version is available.',
+    checkResultErrorTitle: 'Check failed',
+    checkResultError: 'The update check could not be completed.',
+    checkResultCooldownTitle: 'Just a moment',
+    checkResultCooldown: 'A check is already running or the 60-second cooldown is still active.'
   },
 
   // Firmware Update

--- a/webui/src/locales/it.js
+++ b/webui/src/locales/it.js
@@ -233,7 +233,8 @@ export default {
     hostname: 'Nome Host',
     boardRevision: 'Revisione Scheda',
     uptime: 'Tempo di attività',
-    resetReason: 'Ultimo Riavvio',
+     // Value is the cause of the last reboot, not a timestamp (Korrekturauftrag §1.5).
+     resetReason: 'Motivo riavvio',
     cpuUsage: 'Utilizzo CPU',
     memoryUsage: 'Utilizzo memoria',
     ethernetStatus: 'Connessione Ethernet',
@@ -290,7 +291,17 @@ export default {
     title: 'Updates',
     subtitle: 'Firmware and web interface have separate versions and are updated independently.',
     firmware: 'Firmware',
-    webui: 'WebUI'
+    webui: 'WebUI',
+    checkNow: 'Search for updates now',
+    checkingNow: 'Searching …',
+    checkResultUpdatedTitle: 'Update available',
+    checkResultUpdated: 'Version {version} is available.',
+    checkResultNoUpdateTitle: 'Everything is up to date',
+    checkResultNoUpdate: 'No newer version is available.',
+    checkResultErrorTitle: 'Check failed',
+    checkResultError: 'The update check could not be completed.',
+    checkResultCooldownTitle: 'Just a moment',
+    checkResultCooldown: 'A check is already running or the 60-second cooldown is still active.'
   },
 
   // Firmware Update

--- a/webui/src/locales/nl.js
+++ b/webui/src/locales/nl.js
@@ -233,7 +233,8 @@ export default {
     hostname: 'Hostnaam',
     boardRevision: 'Bord revisie',
     uptime: 'Uptime',
-    resetReason: 'Laatste herstart',
+     // Value is the cause of the last reboot, not a timestamp (Korrekturauftrag §1.5).
+     resetReason: 'Herstartreden',
     cpuUsage: 'CPU gebruik',
     memoryUsage: 'Geheugengebruik',
     ethernetStatus: 'Ethernet verbinding',
@@ -290,7 +291,17 @@ export default {
     title: 'Updates',
     subtitle: 'Firmware and web interface have separate versions and are updated independently.',
     firmware: 'Firmware',
-    webui: 'WebUI'
+    webui: 'WebUI',
+    checkNow: 'Search for updates now',
+    checkingNow: 'Searching …',
+    checkResultUpdatedTitle: 'Update available',
+    checkResultUpdated: 'Version {version} is available.',
+    checkResultNoUpdateTitle: 'Everything is up to date',
+    checkResultNoUpdate: 'No newer version is available.',
+    checkResultErrorTitle: 'Check failed',
+    checkResultError: 'The update check could not be completed.',
+    checkResultCooldownTitle: 'Just a moment',
+    checkResultCooldown: 'A check is already running or the 60-second cooldown is still active.'
   },
 
   // Firmware Update

--- a/webui/src/locales/no.js
+++ b/webui/src/locales/no.js
@@ -233,7 +233,8 @@ export default {
     hostname: 'Vertsnavn',
     boardRevision: 'Kortrevisjon',
     uptime: 'Oppetid',
-    resetReason: 'Siste omstart',
+     // Value is the cause of the last reboot, not a timestamp (Korrekturauftrag §1.5).
+     resetReason: 'Omstartsårsak',
     cpuUsage: 'CPU-bruk',
     memoryUsage: 'Minnebruk',
     ethernetStatus: 'Ethernet-tilkobling',
@@ -290,7 +291,17 @@ export default {
     title: 'Updates',
     subtitle: 'Firmware and web interface have separate versions and are updated independently.',
     firmware: 'Firmware',
-    webui: 'WebUI'
+    webui: 'WebUI',
+    checkNow: 'Search for updates now',
+    checkingNow: 'Searching …',
+    checkResultUpdatedTitle: 'Update available',
+    checkResultUpdated: 'Version {version} is available.',
+    checkResultNoUpdateTitle: 'Everything is up to date',
+    checkResultNoUpdate: 'No newer version is available.',
+    checkResultErrorTitle: 'Check failed',
+    checkResultError: 'The update check could not be completed.',
+    checkResultCooldownTitle: 'Just a moment',
+    checkResultCooldown: 'A check is already running or the 60-second cooldown is still active.'
   },
 
   // Firmware Update

--- a/webui/src/locales/pl.js
+++ b/webui/src/locales/pl.js
@@ -233,7 +233,8 @@ export default {
     hostname: 'Nazwa hosta',
     boardRevision: 'Rewizja płytki',
     uptime: 'Czas pracy',
-    resetReason: 'Ostatni restart',
+     // Value is the cause of the last reboot, not a timestamp (Korrekturauftrag §1.5).
+     resetReason: 'Powód restartu',
     cpuUsage: 'Użycie CPU',
     memoryUsage: 'Użycie pamięci',
     ethernetStatus: 'Połączenie Ethernet',
@@ -290,7 +291,17 @@ export default {
     title: 'Updates',
     subtitle: 'Firmware and web interface have separate versions and are updated independently.',
     firmware: 'Firmware',
-    webui: 'WebUI'
+    webui: 'WebUI',
+    checkNow: 'Search for updates now',
+    checkingNow: 'Searching …',
+    checkResultUpdatedTitle: 'Update available',
+    checkResultUpdated: 'Version {version} is available.',
+    checkResultNoUpdateTitle: 'Everything is up to date',
+    checkResultNoUpdate: 'No newer version is available.',
+    checkResultErrorTitle: 'Check failed',
+    checkResultError: 'The update check could not be completed.',
+    checkResultCooldownTitle: 'Just a moment',
+    checkResultCooldown: 'A check is already running or the 60-second cooldown is still active.'
   },
 
   // Firmware Update

--- a/webui/src/locales/sv.js
+++ b/webui/src/locales/sv.js
@@ -233,7 +233,8 @@ export default {
     hostname: 'Värdnamn',
     boardRevision: 'Kortrevision',
     uptime: 'Drifttid',
-    resetReason: 'Senaste omstart',
+     // Value is the cause of the last reboot, not a timestamp (Korrekturauftrag §1.5).
+     resetReason: 'Omstartsanledning',
     cpuUsage: 'CPU-användning',
     memoryUsage: 'Minnesanvändning',
     ethernetStatus: 'Ethernet-anslutning',
@@ -290,7 +291,17 @@ export default {
     title: 'Updates',
     subtitle: 'Firmware and web interface have separate versions and are updated independently.',
     firmware: 'Firmware',
-    webui: 'WebUI'
+    webui: 'WebUI',
+    checkNow: 'Search for updates now',
+    checkingNow: 'Searching …',
+    checkResultUpdatedTitle: 'Update available',
+    checkResultUpdated: 'Version {version} is available.',
+    checkResultNoUpdateTitle: 'Everything is up to date',
+    checkResultNoUpdate: 'No newer version is available.',
+    checkResultErrorTitle: 'Check failed',
+    checkResultError: 'The update check could not be completed.',
+    checkResultCooldownTitle: 'Just a moment',
+    checkResultCooldown: 'A check is already running or the 60-second cooldown is still active.'
   },
 
   // Firmware Update

--- a/webui/src/login.vue
+++ b/webui/src/login.vue
@@ -452,8 +452,8 @@ const loginClick = async () => {
 
 .modern-input:focus {
   background: var(--color-surface);
-  border-color: rgba(242, 106, 61, 0.38);
-  box-shadow: 0 0 0 4px rgba(242, 106, 61, 0.12);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 4px var(--color-primary-soft);
   outline: none;
 }
 
@@ -480,13 +480,16 @@ const loginClick = async () => {
   font-weight: 600;
   font-size: var(--fs-lg);
   margin-top: 8px;
-  box-shadow: 0 14px 28px rgba(242, 106, 61, 0.22);
+  /* Neutral elevation shadow (token-driven) so the glow follows the active
+     theme instead of hardcoding the Glass-UI orange. The accent colour comes
+     from the button fill, not the shadow. */
+  box-shadow: var(--shadow-md);
   transition: transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .login-btn:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 18px 32px rgba(242, 106, 61, 0.28);
+  box-shadow: var(--shadow-lg);
 }
 
 .login-btn:active:not(:disabled) {

--- a/webui/src/monitoring.vue
+++ b/webui/src/monitoring.vue
@@ -1003,7 +1003,7 @@ const runDiagnostic = async (target) => {
 
 .diag-test-btn:hover:not(:disabled) {
   background: var(--color-primary-soft);
-  border-color: rgba(242, 106, 61, 0.32);
+  border-color: var(--color-primary);
   color: var(--color-primary-strong);
   transform: translateY(-1px);
 }

--- a/webui/src/stores.js
+++ b/webui/src/stores.js
@@ -547,14 +547,25 @@ export const useUpdateStore = defineStore('update', {
   },
   actions: {
     // Reads the cached release info from the device. The device refreshes its
-    // release snapshot automatically every 24 h (UpdateCheck esp_timer); there
-    // is no longer a manual "check now" trigger.
+    // release snapshot automatically every 24 h (UpdateCheck esp_timer) and on
+    // demand via checkNow() (POST /api/check_update). Safe to poll.
     async checkForUpdate(currentVersion) {
       if (this.isChecking) return
 
       this.isChecking = true
       this.checkError = null
+      try {
+        await this._loadSnapshot(currentVersion)
+      } finally {
+        this.isChecking = false
+      }
+    },
 
+    // Fetches GET /api/check_update and writes the snapshot into the store.
+    // Shared by checkForUpdate() and checkNow() so the manual path can reload
+    // the snapshot without going through the isChecking-guarded public action
+    // (which would early-return because checkNow() already holds the flag).
+    async _loadSnapshot(currentVersion) {
       try {
         const response = await axios.get('/api/check_update', {
           params: { t: Date.now() },
@@ -585,8 +596,6 @@ export const useUpdateStore = defineStore('update', {
       } catch (error) {
         console.error('Update check failed:', error)
         this.checkError = error.response?.data?.error || error.message || 'Unknown error'
-      } finally {
-        this.isChecking = false
       }
     },
 
@@ -628,6 +637,62 @@ export const useUpdateStore = defineStore('update', {
         return ap[i] < bp[i] ? -1 : 1
       }
       return 0
+    },
+
+    // Manual "search for updates now" (Korrekturauftrag §6.2/§6.3). Posts to
+    // /api/check_update which arms an immediate on-device manifest fetch (60 s
+    // cooldown enforced server-side); the device answers 202 immediately and
+    // the actual GitHub request runs off the httpd thread. We then poll GET
+    // until fetchInProgress clears and reload the snapshot. Resolves to an
+    // outcome string so callers can show a definitive result toast.
+    // Returns: 'updated' | 'no-update' | 'cooldown' | 'error'
+    async checkNow(currentVersion) {
+      if (this.isChecking) return 'cooldown'
+      this.isChecking = true
+      this.checkError = null
+      try {
+        const post = await axios.post('/api/check_update', {}, {
+          params: { t: Date.now() }
+        })
+        // triggered=false means the device refused: either a fetch is already
+        // running or the 60 s manual cooldown is still active. We still reload
+        // the snapshot (it may have just been refreshed) and report 'cooldown'
+        // so the UI can explain why nothing new happened.
+        const triggered = !!post.data?.triggered
+        await this._pollUntilSettled()
+        await this._loadSnapshot(currentVersion)
+        if (this.checkError) return 'error'
+        if (this.updateAvailable) return 'updated'
+        if (!triggered) return 'cooldown'
+        return 'no-update'
+      } catch (error) {
+        console.error('Manual update check failed:', error)
+        this.checkError = error.response?.data?.error || error.message || 'Unknown error'
+        return 'error'
+      } finally {
+        this.isChecking = false
+      }
+    },
+
+    // Polls GET /api/check_update while the device reports fetchInProgress.
+    // Caps at ~20s so a stalled fetch never wedges the button spinner; the
+    // cached snapshot is still re-read by the following _loadSnapshot() call.
+    async _pollUntilSettled() {
+      const maxTicks = 20
+      for (let i = 0; i < maxTicks; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        try {
+          const response = await axios.get('/api/check_update', {
+            params: { t: Date.now() }
+          })
+          if (!response.data?.fetchInProgress) return
+        } catch (error) {
+          // A transient poll failure doesn't abort the whole check — the final
+          // checkForUpdate() call will surface a persistent error.
+          console.warn('Update poll failed:', error.response?.status || error.message)
+          return
+        }
+      }
     }
   }
 })

--- a/webui/src/webuiupdate.vue
+++ b/webui/src/webuiupdate.vue
@@ -47,6 +47,18 @@
 
         <BAlert v-if="manifestError" variant="warning" :model-value="true">{{ manifestError }}</BAlert>
 
+        <!-- Manual "search for updates now" (Korrekturauftrag §6.2/§6.3). Shares
+             the on-device fetch with the Firmware tab; after it settles we reload
+             the WebUI-specific release block. -->
+        <div class="check-now-row">
+          <BButton variant="outline-primary" class="action-btn check-now-btn"
+                   :disabled="checkNowBusy" @click="onCheckNow">
+            <span v-if="checkNowBusy" class="spinner-border spinner-border-sm me-2"></span>
+            <AppIcon v-else name="refresh" />
+            {{ checkNowBusy ? checkNowLabel : checkNowIdleLabel }}
+          </BButton>
+        </div>
+
         <div v-if="release.version" class="release-grid">
           <div><span>Installiert</span><strong>{{ installedVersion }}</strong></div>
           <div><span>Verfügbar</span><strong>{{ release.version }}</strong></div>
@@ -127,12 +139,13 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import axios from 'axios'
-import { useUiStore } from './stores.js'
+import { useUiStore, useUpdateStore } from './stores.js'
 
 const WEBUI_API_VERSION = 1
 const EMBEDDED_WEBUI_VERSION = typeof __WEBUI_VERSION__ !== 'undefined' ? __WEBUI_VERSION__ : 'unbekannt'
 
 const uiStore = useUiStore()
+const updateStore = useUpdateStore()
 const loading = ref(true)
 const busy = ref(false)
 const progress = ref(0)
@@ -142,6 +155,11 @@ const selectedFile = ref(null)
 const release = ref({})
 const firmwareVersion = ref('')
 const updateFetchedAt = ref(null)
+// Manual update search (Korrekturauftrag §6.2/§6.3). This page does not use
+// vue-i18n (German-only like the rest of the file); the labels stay local.
+const checkNowBusy = ref(false)
+const checkNowIdleLabel = 'Jetzt nach Updates suchen'
+const checkNowLabel = 'Suche läuft …'
 const status = ref({
   partitionFound: false,
   mounted: false,
@@ -226,6 +244,30 @@ const loadCachedRelease = async () => {
   }
 }
 
+// Manual update search (Korrekturauftrag §6.2/§6.3). Delegates the POST +
+// polling to the shared update store, then reloads the WebUI release block so
+// the result (new version / current / error) is reflected in this tab. The
+// outcome drives a definitive toast per §6.3.
+const onCheckNow = async () => {
+  if (checkNowBusy.value) return
+  checkNowBusy.value = true
+  try {
+    const outcome = await updateStore.checkNow(firmwareVersion.value)
+    await loadCachedRelease()
+    if (outcome === 'updated' && updateAvailable.value) {
+      uiStore.pushToast({ type: 'success', title: 'Update verfügbar', message: `WebUI-Version ${release.value.version} ist verfügbar.`, duration: 5000 })
+    } else if (outcome === 'no-update' || outcome === 'updated') {
+      uiStore.pushToast({ type: 'info', title: 'Alles aktuell', message: 'Es ist keine neuere WebUI vorhanden.', duration: 4000 })
+    } else if (outcome === 'cooldown') {
+      uiStore.pushToast({ type: 'info', title: 'Kurz gewartet', message: 'Es läuft bereits eine Prüfung oder die 60-Sekunden-Sperre ist noch aktiv.', duration: 4000 })
+    } else {
+      uiStore.pushToast({ type: 'error', title: 'Prüfung fehlgeschlagen', message: updateStore.checkError || 'Die Update-Prüfung konnte nicht durchgeführt werden.', duration: 6000 })
+    }
+  } finally {
+    checkNowBusy.value = false
+  }
+}
+
 const refreshCachedStatus = async () => {
   loading.value = true
   try {
@@ -305,6 +347,10 @@ onMounted(refreshCachedStatus)
 .release-grid strong { overflow-wrap:anywhere; }
 .actions { display:flex; flex-wrap:wrap; gap:10px; }
 .action-btn { display:inline-flex; gap:8px; align-items:center; text-decoration:none; }
+/* Manual "search now" row — mirrors the Firmware tab so both sub-tabs share
+   the same primary action placement (Korrekturauftrag §6.5). */
+.check-now-row { display:flex; margin-bottom:4px; }
+.check-now-btn { width:auto; }
 .file-drop { min-height:145px; border:2px dashed var(--color-border-strong); border-radius:14px; display:flex; flex-direction:column; gap:7px; align-items:center; justify-content:center; text-align:center; cursor:pointer; padding:18px; }
 .file-drop input { display:none; }
 .file-drop.invalid { border-color:var(--color-danger); }


### PR DESCRIPTION
Abschlusskorrektur for the HB-RF-ETH-ng WebUI — the P0 UI/UX Korrekturauftrag (attached DOCX). The 4 reference screenshots show the **OLD** state; prior rounds (Beta.4–6) already shipped the type scale, Inter font, Firmware/WebUI merge under \`/updates\`, and the Settings → Design tab. This PR closes the two remaining hard gaps plus a token-discipline cleanup.

## Backend (§6.2–6.4) — restore manual update search
- \`UpdateCheck::triggerManualFetch()\` (updatecheck.h/.cpp): arms a one-shot esp_timer (200 ms) off the httpd worker; 60 s manual cooldown; refuses to stack onto a running fetch. **Reuses the existing \`refresh()\`/\`_doFetch()\` path — no new TLS/heap code.** The 24 h automatic timer is untouched.
- \`POST /api/check_update\` handler (webui.cpp): \`202 Accepted\` → \`{triggered, fetchInProgress}\`; client polls GET until \`fetchInProgress\` clears.

## Frontend (§6.2–6.8)
- \`useUpdateStore.checkNow()\` + shared \`_loadSnapshot()\` (stores.js); polls GET ≤20 s, returns \`'updated' | 'no-update' | 'cooldown' | 'error'\`.
- **„Jetzt nach Updates suchen"** button on both Firmware and WebUI tabs with per-outcome toasts (§6.3).
- 8 new i18n keys in all 10 locales.

## Design consolidation (§5, §1.5, token discipline)
- Removed redundant **„Design wechseln"** nav entry (theme selection lives only in Settings → Design). \`/theme\` route + tooltip key kept.
- Replaced hardcoded \`rgba(242,106,61,…)\` focus/hover rings with tokens (\`--color-primary\` / \`--color-primary-soft\` / \`--shadow-md\`) in monitoring.vue, login.vue, PasswordChangeModal.vue — no more orange glow in the green theme.
- Dashboard row **„Letzter Neustart" → „Neustartgrund"** across all 10 locales (value is the reboot cause, not a timestamp).

## Review notes
- Two code-review subagents ran (one C++, one frontend). The frontend one caught a real bug: \`checkNow()\` called \`checkForUpdate()\` which was guarded by the same \`isChecking\` flag the outer action held — snapshot never reloaded. **Fixed** via the shared \`_loadSnapshot()\` helper.
- No new TLS/heap/mutex logic on the firmware side — purely additive and serialized through the existing \`_fetchLock\` + \`g_net_fetch_mutex\`.
- Intentionally **not** touched: brand-gradient badges (supporter chip / medallion) per design system §2.3.

## Verification
No Node.js / ESP-IDF locally → relying on CI \`build.yml\` (WebUI + firmware compile) as the gate, then visual review in light/dark/accent per the DoD checklist.

After merge, this will be released as **v2.2.5-Beta.7**.