### PR TITLE
chore(ci): bump actions/setup-python from v5 to v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: python3 rename_webui_files.py
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Rename WebUI files
         run: python3 rename_webui_files.py
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
       - name: Setup ESP-IDF v6.1-beta1

--- a/.github/workflows/release-webui.yml
+++ b/.github/workflows/release-webui.yml
@@ -53,7 +53,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           echo "TRIGGERED_BY_TAG=$TRIGGERED_BY_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Setup build environment for C++
         if: matrix.language == 'cpp'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
@@ -111,7 +111,7 @@ jobs:
           npm outdated || true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 


### PR DESCRIPTION
Clean replacement for #373 — original Dependabot branch diverged from an old base and conflicted with recent main changes (mDNS removal, WebUI refactor, API cleanup).

Same intended change re-applied on current main: `actions/setup-python@v5` → `@v7` in 6 places across 5 workflow files.

Build.yml, pr-check.yml, release-webui.yml, release.yml, security.yml.

Supersedes #373.