### PR TITLE
fix(stability): op-tag flight recorder to name stuck operations at reset

### DIFF
--- a/include/crash_blackbox.h
+++ b/include/crash_blackbox.h
@@ -51,6 +51,23 @@
 extern "C" {
 #endif
 
+// Op-tag flight recorder: names the blocking operation in flight, if any,
+// at the moment of an Interrupt-Watchdog/panic reset. This is what actually
+// answers "what was the firmware doing" for issue #362 — the periodic heap
+// sample above only bounds the picture (rules out slow heap exhaustion), it
+// cannot name a specific call site.
+//
+// Both tracked domains already have a single project-wide serialization
+// primitive (NvsStorageLock's recursive mutex; g_net_fetch_mutex, a plain
+// binary semaphore), so at most one task ever owns a domain's tag at a time.
+// That makes plain (unlocked) RTC writes from crash_blackbox_*_op_begin/end
+// race-free by construction: only the current owner of the underlying mutex
+// ever writes its domain's slot. The NVS domain uses a small stack because
+// the recursive mutex lets its owning task nest calls; the net-fetch domain
+// is a single slot because that semaphore never nests.
+#define CRASH_BLACKBOX_TAG_LEN 24
+#define CRASH_BLACKBOX_NVS_STACK_DEPTH 4
+
 typedef struct {
     uint32_t magic;         // CRASH_BLACKBOX_MAGIC when the slot holds a valid sample
     uint32_t free_heap;     // heap_caps_get_free_size(MALLOC_CAP_DEFAULT) at sample time
@@ -60,6 +77,13 @@ typedef struct {
     uint32_t uptime_s;      // xTaskGetTickCount()/portTICK_PERIOD_MS/1000 at sample time
     uint32_t low_streak;    // heap_watchdog low-heap streak at sample time
     uint32_t sample_count;  // number of samples written since first boot of this RTC cycle
+
+    uint32_t nvs_op_magic;  // set on first push since this RTC cycle started
+    uint8_t  nvs_op_depth;  // number of NvsStorageLock instances currently held
+    char     nvs_op_stack[CRASH_BLACKBOX_NVS_STACK_DEPTH][CRASH_BLACKBOX_TAG_LEN];
+
+    uint32_t net_op_magic;  // set while g_net_fetch_mutex is held with a tag
+    char     net_op_tag[CRASH_BLACKBOX_TAG_LEN];
 } crash_blackbox_t;
 
 // Record a fresh sample. Called periodically (e.g. every 60 s) from the
@@ -77,6 +101,28 @@ const crash_blackbox_t *crash_blackbox_read(void);
 // Invalidate the slot so a subsequent normal reboot does not surface stale
 // crash data. Called after the boot path has consumed and logged the sample.
 void crash_blackbox_clear(void);
+
+// Push/pop a short tag naming the NVS operation an NvsStorageLock instance
+// guards. Called from NvsStorageLock's constructor/destructor; never call
+// directly. Safe (no-op) beyond CRASH_BLACKBOX_NVS_STACK_DEPTH nesting —
+// depth is still tracked so end() stays balanced, just without a label for
+// levels past the array.
+void crash_blackbox_nvs_op_begin(const char *tag);
+void crash_blackbox_nvs_op_end(void);
+
+// Record/clear the tag naming the operation currently holding
+// g_net_fetch_mutex. Call begin() right after a successful take and end()
+// right before the matching give.
+void crash_blackbox_net_op_begin(const char *tag);
+void crash_blackbox_net_op_end(void);
+
+// If the previous boot's RTC slot shows an operation that was pushed but
+// never popped (i.e. still "in flight" when the reset happened), returns a
+// short static description such as "nvs:settings.save" or
+// "nvs:settings.save net:mqtt_tls" (both domains stuck at once). Returns
+// NULL if nothing was stuck. Does not clear any state — callers still own
+// crash_blackbox_clear().
+const char *crash_blackbox_describe_stuck_op(void);
 
 #ifdef __cplusplus
 }

--- a/include/nvs_storage_lock.h
+++ b/include/nvs_storage_lock.h
@@ -10,9 +10,17 @@
 //
 // Recursive semantics let a high-level transaction (for example restore)
 // reserve the partition while helpers take the same lock internally.
+//
+// `tag` names the operation for the crash_blackbox flight recorder (see
+// crash_blackbox.h): while this instance holds the lock, the tag is pushed
+// onto the RTC-backed op stack and popped again on release/destruction. If a
+// reset happens while the tag is still pushed, the next boot can report
+// exactly which NVS operation was in flight instead of just "something
+// crashed". Pass NULL (the default) to skip tracking for call sites that are
+// too hot/uninteresting to name individually.
 class NvsStorageLock {
 public:
-    explicit NvsStorageLock(TickType_t timeout = portMAX_DELAY);
+    explicit NvsStorageLock(TickType_t timeout = portMAX_DELAY, const char *tag = nullptr);
     ~NvsStorageLock();
 
     NvsStorageLock(const NvsStorageLock &) = delete;
@@ -24,4 +32,5 @@ public:
 private:
     SemaphoreHandle_t mutex_;
     bool locked_;
+    bool tracked_;
 };

--- a/main/crash_blackbox.cpp
+++ b/main/crash_blackbox.cpp
@@ -23,6 +23,11 @@
 
 #include "crash_blackbox.h"
 #include "esp_attr.h" // RTC_NOINIT_ATTR
+#include <cstdio>
+#include <cstring>
+
+#define CRASH_BLACKBOX_NVS_OP_MAGIC 0xA55AF00Du
+#define CRASH_BLACKBOX_NET_OP_MAGIC 0xA55AF00Eu
 
 // RTC_NOINIT_ATTR places this struct in the ".rtc_noinit" section of RTC slow
 // memory. ESP-IDF does NOT initialize this section at boot, so its contents
@@ -62,4 +67,76 @@ void crash_blackbox_clear(void)
 {
     s_blackbox.magic = 0;
     s_blackbox.sample_count = 0;
+}
+
+static void nvs_op_stack_reset_if_stale(void)
+{
+    if (s_blackbox.nvs_op_magic != CRASH_BLACKBOX_NVS_OP_MAGIC) {
+        s_blackbox.nvs_op_magic = CRASH_BLACKBOX_NVS_OP_MAGIC;
+        s_blackbox.nvs_op_depth = 0;
+    }
+}
+
+void crash_blackbox_nvs_op_begin(const char *tag)
+{
+    nvs_op_stack_reset_if_stale();
+
+    if (s_blackbox.nvs_op_depth < CRASH_BLACKBOX_NVS_STACK_DEPTH) {
+        char *dst = s_blackbox.nvs_op_stack[s_blackbox.nvs_op_depth];
+        strncpy(dst, tag ? tag : "?", CRASH_BLACKBOX_TAG_LEN - 1);
+        dst[CRASH_BLACKBOX_TAG_LEN - 1] = '\0';
+    }
+    // Depth still counts past the array capacity so a deeply-nested caller's
+    // end() calls stay balanced with begin(); only the label is dropped.
+    if (s_blackbox.nvs_op_depth < 255) {
+        s_blackbox.nvs_op_depth++;
+    }
+}
+
+void crash_blackbox_nvs_op_end(void)
+{
+    if (s_blackbox.nvs_op_magic == CRASH_BLACKBOX_NVS_OP_MAGIC &&
+        s_blackbox.nvs_op_depth > 0) {
+        s_blackbox.nvs_op_depth--;
+    }
+}
+
+void crash_blackbox_net_op_begin(const char *tag)
+{
+    s_blackbox.net_op_magic = CRASH_BLACKBOX_NET_OP_MAGIC;
+    strncpy(s_blackbox.net_op_tag, tag ? tag : "?", CRASH_BLACKBOX_TAG_LEN - 1);
+    s_blackbox.net_op_tag[CRASH_BLACKBOX_TAG_LEN - 1] = '\0';
+}
+
+void crash_blackbox_net_op_end(void)
+{
+    s_blackbox.net_op_magic = 0;
+    s_blackbox.net_op_tag[0] = '\0';
+}
+
+const char *crash_blackbox_describe_stuck_op(void)
+{
+    static char buf[CRASH_BLACKBOX_TAG_LEN * 2 + 8];
+
+    const bool nvs_stuck = s_blackbox.nvs_op_magic == CRASH_BLACKBOX_NVS_OP_MAGIC &&
+                            s_blackbox.nvs_op_depth > 0;
+    const bool net_stuck = s_blackbox.net_op_magic == CRASH_BLACKBOX_NET_OP_MAGIC &&
+                            s_blackbox.net_op_tag[0] != '\0';
+
+    if (!nvs_stuck && !net_stuck) {
+        return NULL;
+    }
+
+    // The outermost (index 0) NVS frame names the top-level operation the
+    // caller started; that is more useful than the innermost helper it
+    // happened to be nested in when the reset hit.
+    if (nvs_stuck && net_stuck) {
+        snprintf(buf, sizeof(buf), "nvs:%s net:%s",
+                 s_blackbox.nvs_op_stack[0], s_blackbox.net_op_tag);
+    } else if (nvs_stuck) {
+        snprintf(buf, sizeof(buf), "nvs:%s", s_blackbox.nvs_op_stack[0]);
+    } else {
+        snprintf(buf, sizeof(buf), "net:%s", s_blackbox.net_op_tag);
+    }
+    return buf;
 }

--- a/main/dcf.cpp
+++ b/main/dcf.cpp
@@ -111,9 +111,28 @@ time_t dcf2epoch(struct tm *dcf_tm, uint8_t tz)
     return res;
 }
 
+// GPIO 34-39 (including DCF_PIN) are input-only on the ESP32 and have no
+// internal pull-up/pull-down; gpio_config() cannot compensate. Without a
+// receiver physically attached (or on a wiring fault), ANYEDGE on a floating
+// input can free-run at a rate bound only by pin capacitance/noise, far above
+// any real DCF77 signal. A genuine DCF77 edge never repeats faster than the
+// shortest pulse validated in handlePinChange() (80 ms); gate the ISR to a
+// fraction of that so a floating/storming pin cannot monopolize interrupt
+// time on this core, while every legitimate edge still passes through
+// untouched.
+static constexpr int64_t DCF_MIN_ISR_INTERVAL_US = 5000; // 5 ms, well under the 80 ms floor
+static volatile int64_t _last_isr_time = 0;
+
 static void IRAM_ATTR onPinChange(void *arg)
 {
     int64_t flankTime = esp_timer_get_time();
+
+    if (flankTime - _last_isr_time < DCF_MIN_ISR_INTERVAL_US)
+    {
+        return;
+    }
+    _last_isr_time = flankTime;
+
     int state = gpio_get_level(DCF_PIN);
 
     flank_event_t event;

--- a/main/events.cpp
+++ b/main/events.cpp
@@ -23,6 +23,7 @@
 
 #include "events.h"
 #include "monitoring.h"
+#include "crash_blackbox.h"
 #include "settings.h"
 #include "metrics.h"
 #include "esp_log.h"
@@ -341,7 +342,9 @@ static bool send_webhook(const EventEntry &e, const EventMeta &m,
     if (g_net_fetch_mutex && mutex_wait_ms > 0 &&
         xSemaphoreTake(g_net_fetch_mutex,
                        pdMS_TO_TICKS(mutex_wait_ms)) == pdTRUE) {
+        crash_blackbox_net_op_begin("events_webhook");
         if (!s_running.load(std::memory_order_acquire)) {
+            crash_blackbox_net_op_end();
             xSemaphoreGive(g_net_fetch_mutex);
             free(body);
             return false;
@@ -361,6 +364,7 @@ static bool send_webhook(const EventEntry &e, const EventMeta &m,
             esp_http_client_close(client);
             esp_http_client_cleanup(client);
         }
+        crash_blackbox_net_op_end();
         xSemaphoreGive(g_net_fetch_mutex);
     }
     free(body);
@@ -408,7 +412,9 @@ static bool send_telegram(const EventEntry &e, const EventMeta &m,
     if (g_net_fetch_mutex && mutex_wait_ms > 0 &&
         xSemaphoreTake(g_net_fetch_mutex,
                        pdMS_TO_TICKS(mutex_wait_ms)) == pdTRUE) {
+        crash_blackbox_net_op_begin("events_telegram");
         if (!s_running.load(std::memory_order_acquire)) {
+            crash_blackbox_net_op_end();
             xSemaphoreGive(g_net_fetch_mutex);
             free(body);
             return false;
@@ -425,6 +431,7 @@ static bool send_telegram(const EventEntry &e, const EventMeta &m,
             esp_http_client_close(client);
             esp_http_client_cleanup(client);
         }
+        crash_blackbox_net_op_end();
         xSemaphoreGive(g_net_fetch_mutex);
     }
     free(body);
@@ -565,6 +572,7 @@ static bool send_email(const EventEntry &e, const EventMeta &m,
     if (mutex_wait_ms <= 0 ||
         xSemaphoreTake(g_net_fetch_mutex,
                        pdMS_TO_TICKS(mutex_wait_ms)) != pdTRUE) return false;
+    crash_blackbox_net_op_begin("events_smtp");
 
     // Implicit TLS: full TLS from the start. STARTTLS: plaintext then upgrade.
     const bool use_tls = config.smtp_tls == 2;
@@ -719,6 +727,7 @@ static bool send_email(const EventEntry &e, const EventMeta &m,
     } else if (sock >= 0) {
         close_plain_socket(sock);
     }
+    crash_blackbox_net_op_end();
     xSemaphoreGive(g_net_fetch_mutex);
     return ok;
 }

--- a/main/log_manager.cpp
+++ b/main/log_manager.cpp
@@ -497,7 +497,7 @@ bool LogManager::saveCrashTailNvs(const char *tag) {
     // This path runs immediately before a protective restart. Never let a
     // concurrent configuration transaction turn best-effort diagnostics into
     // an unbounded wait which prevents that restart.
-    NvsStorageLock storage_lock(pdMS_TO_TICKS(20));
+    NvsStorageLock storage_lock(pdMS_TO_TICKS(20), "log.save_crash_tail");
     if (!storage_lock) return false;
 
     nvs_handle_t h;

--- a/main/monitoring.cpp
+++ b/main/monitoring.cpp
@@ -822,7 +822,7 @@ static esp_err_t save_config_to_nvs(const monitoring_config_t *config)
         config_nvs_entry_requirement(config, &required_entries);
     if (err != ESP_OK) return err;
 
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "monitoring.save_config");
     if (!storage_lock) return ESP_ERR_NO_MEM;
 
     nvs_handle_t config_handle;
@@ -908,7 +908,7 @@ esp_err_t monitoring_validate_config_storage(
         config_nvs_entry_requirement(config, &required_entries);
     if (err != ESP_OK) return err;
 
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "monitoring.validate_storage");
     if (!storage_lock) return ESP_ERR_NO_MEM;
     nvs_handle_t config_handle;
     err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &config_handle);
@@ -1219,7 +1219,7 @@ static esp_err_t load_config_from_nvs(monitoring_config_t *config)
     // value and the combined monitoring form can no longer save MQTT.
     monitoring_config_set_defaults(config);
 
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "monitoring.load_config");
     if (!storage_lock) return ESP_ERR_NO_MEM;
 
     nvs_handle_t nvs_handle;

--- a/main/mqtt_handler.cpp
+++ b/main/mqtt_handler.cpp
@@ -26,6 +26,7 @@
 #include "sysinfo.h"
 #include "webui_storage.h"
 #include "reset_info.h"
+#include "crash_blackbox.h"
 #include "system_reset.h"
 #include "nvs_storage_lock.h"
 #include "events.h"
@@ -300,12 +301,14 @@ static void mqtt_take_tls_gate_if_needed()
         }
     }
     mqtt_tls_gate_held.store(true, std::memory_order_release);
+    crash_blackbox_net_op_begin("mqtt_tls");
 }
 
 static void mqtt_release_tls_gate_if_held()
 {
     if (mqtt_tls_gate_held.exchange(false, std::memory_order_acq_rel) &&
         g_net_fetch_mutex != NULL) {
+        crash_blackbox_net_op_end();
         xSemaphoreGive(g_net_fetch_mutex);
     }
 }
@@ -750,7 +753,7 @@ static void publish_legacy_topic_cleanup(void)
     static const uint8_t CLEANUP_VERSION = 2;
     bool needs_cleanup = false;
     {
-        NvsStorageLock storage_lock;
+        NvsStorageLock storage_lock(portMAX_DELAY, "mqtt.legacy_marker_read");
         if (!storage_lock) return;
         nvs_handle_t h;
         esp_err_t marker_result = nvs_open(CLEANUP_NS, NVS_READWRITE, &h);
@@ -814,7 +817,7 @@ static void publish_legacy_topic_cleanup(void)
     // Mark this cleanup version complete so it never runs again until the
     // version is bumped again.
     {
-        NvsStorageLock storage_lock;
+        NvsStorageLock storage_lock(portMAX_DELAY, "mqtt.legacy_marker_write");
         if (!storage_lock) {
             ESP_LOGW(TAG, "Could not persist legacy-topic cleanup marker");
             return;

--- a/main/nvs_storage_lock.cpp
+++ b/main/nvs_storage_lock.cpp
@@ -1,4 +1,5 @@
 #include "nvs_storage_lock.h"
+#include "crash_blackbox.h"
 
 namespace {
 
@@ -13,11 +14,16 @@ SemaphoreHandle_t nvs_storage_mutex()
 
 } // namespace
 
-NvsStorageLock::NvsStorageLock(TickType_t timeout)
+NvsStorageLock::NvsStorageLock(TickType_t timeout, const char *tag)
     : mutex_(nvs_storage_mutex()),
       locked_(mutex_ != nullptr &&
-              xSemaphoreTakeRecursive(mutex_, timeout) == pdTRUE)
+              xSemaphoreTakeRecursive(mutex_, timeout) == pdTRUE),
+      tracked_(false)
 {
+    if (locked_ && tag != nullptr) {
+        crash_blackbox_nvs_op_begin(tag);
+        tracked_ = true;
+    }
 }
 
 NvsStorageLock::~NvsStorageLock()
@@ -28,6 +34,10 @@ NvsStorageLock::~NvsStorageLock()
 void NvsStorageLock::release()
 {
     if (locked_) {
+        if (tracked_) {
+            crash_blackbox_nvs_op_end();
+            tracked_ = false;
+        }
         xSemaphoreGiveRecursive(mutex_);
         locked_ = false;
     }

--- a/main/reset_info.cpp
+++ b/main/reset_info.cpp
@@ -70,7 +70,7 @@ static const char* get_reason_text(reset_reason_type_t reason) {
 }
 
 void ResetInfo::init() {
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "reset_info.nvs_init");
     if (!storage_lock) {
         ESP_LOGE(TAG, "Could not reserve NVS storage during initialization");
         return;
@@ -89,7 +89,7 @@ void ResetInfo::storeResetReason(reset_reason_type_t reason) {
 }
 
 void ResetInfo::storeResetReason(reset_reason_type_t reason, const char *diag) {
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "reset_info.store_reason");
     if (!storage_lock) {
         ESP_LOGE(TAG, "Could not reserve NVS storage for reset reason");
         return;
@@ -244,8 +244,28 @@ const char* ResetInfo::getResetDetails() {
                 if (hw == ESP_RST_INT_WDT || hw == ESP_RST_TASK_WDT ||
                     hw == ESP_RST_WDT || hw == ESP_RST_PANIC ||
                     hw == ESP_RST_BROWNOUT) {
+                    // The op-tag flight recorder answers "what was the
+                    // firmware doing", which is strictly more actionable than
+                    // the heap snapshot below (that only rules heap exhaustion
+                    // in or out). Prefer it whenever an operation was still
+                    // in flight — pushed by NvsStorageLock/g_net_fetch_mutex
+                    // but never popped — when the reset hit.
+                    const char *stuck_op = crash_blackbox_describe_stuck_op();
                     const crash_blackbox_t *bb = crash_blackbox_read();
-                    if (bb) {
+                    if (stuck_op) {
+                        if (bb) {
+                            snprintf(diag_bounded, sizeof(diag_bounded),
+                                     "stuck op: %s (up=%us free=%u)",
+                                     stuck_op, (unsigned)bb->uptime_s,
+                                     (unsigned)bb->free_heap);
+                        } else {
+                            snprintf(diag_bounded, sizeof(diag_bounded),
+                                     "stuck op: %s", stuck_op);
+                        }
+                        ESP_LOGI(TAG,
+                                 "Crash black box: operation still in flight "
+                                 "at reset time: %s", stuck_op);
+                    } else if (bb) {
                         snprintf(diag_bounded, sizeof(diag_bounded),
                                  "pre-crash heap: free=%u larg=%u min=%u int=%u up=%us",
                                  (unsigned)bb->free_heap,
@@ -264,6 +284,8 @@ const char* ResetInfo::getResetDetails() {
                                  (unsigned)bb->uptime_s,
                                  (unsigned)bb->low_streak,
                                  (unsigned)bb->sample_count);
+                    }
+                    if (bb) {
                         crash_blackbox_clear();
                     }
                 }
@@ -287,7 +309,7 @@ const char* ResetInfo::getResetDetails() {
 }
 
 void ResetInfo::clearResetReason() {
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "reset_info.clear_reason");
     if (!storage_lock) return;
 
     nvs_handle_t nvs_handle;

--- a/main/settings.cpp
+++ b/main/settings.cpp
@@ -575,7 +575,7 @@ static bool valid_stored_admin_username(const char *value)
 
 esp_err_t Settings::load()
 {
-  NvsStorageLock storage_lock;
+  NvsStorageLock storage_lock(portMAX_DELAY, "settings.load");
   if (!storage_lock) {
     ESP_LOGE(TAG, "Could not reserve NVS storage while loading settings");
     if (_mutex) xSemaphoreTake(_mutex, portMAX_DELAY);
@@ -849,7 +849,7 @@ esp_err_t Settings::load()
   // NOT_FOUND is success). Runs under the storage lock because it is a flash
   // write, and best-effort so a failure never blocks settings loading.
   {
-    NvsStorageLock storage_lock(pdMS_TO_TICKS(50));
+    NvsStorageLock storage_lock(pdMS_TO_TICKS(50), "settings.purge_legacy_crl");
     if (!storage_lock) {
       ESP_LOGW(TAG, "Could not reserve NVS storage to purge legacy CRL cache");
     } else {
@@ -994,7 +994,7 @@ esp_err_t Settings::validateStorageCapacityLocked(
 
 esp_err_t Settings::validateStorageCapacity()
 {
-  NvsStorageLock storage_lock;
+  NvsStorageLock storage_lock(portMAX_DELAY, "settings.capacity_check");
   if (!storage_lock) return ESP_ERR_NO_MEM;
   if (_mutex) xSemaphoreTake(_mutex, portMAX_DELAY);
 
@@ -1011,7 +1011,7 @@ esp_err_t Settings::validateStorageCapacity()
 
 esp_err_t Settings::beginRestoreTransaction()
 {
-  NvsStorageLock storage_lock;
+  NvsStorageLock storage_lock(portMAX_DELAY, "settings.restore_begin");
   if (!storage_lock) return ESP_ERR_NO_MEM;
   if (s_restore_transaction_active) return ESP_ERR_INVALID_STATE;
 
@@ -1027,7 +1027,7 @@ esp_err_t Settings::beginRestoreTransaction()
 
 esp_err_t Settings::finishRestoreTransaction()
 {
-  NvsStorageLock storage_lock;
+  NvsStorageLock storage_lock(portMAX_DELAY, "settings.restore_finish");
   if (!storage_lock) return ESP_ERR_NO_MEM;
   if (!s_restore_transaction_active) return ESP_ERR_INVALID_STATE;
 
@@ -1038,7 +1038,7 @@ esp_err_t Settings::finishRestoreTransaction()
 
 esp_err_t Settings::save()
 {
-  NvsStorageLock storage_lock;
+  NvsStorageLock storage_lock(portMAX_DELAY, "settings.save");
   if (!storage_lock) return ESP_ERR_NO_MEM;
   if (_mutex) xSemaphoreTake(_mutex, portMAX_DELAY);
 
@@ -1249,7 +1249,7 @@ esp_err_t Settings::clear()
   // WebUI image/transaction metadata; factory reset must not uninstall the
   // firmware or the separately installed WebUI.
   {
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "settings.factory_reset");
     if (!storage_lock) {
       ESP_LOGE(TAG, "Could not reserve NVS storage for factory reset");
       return ESP_ERR_NO_MEM;
@@ -1810,7 +1810,7 @@ void Settings::setTestDesignEnabled(bool enabled)
 
 bool Settings::loadAdminToken(char *out, size_t size)
 {
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "settings.load_admin_token");
     if (!storage_lock) return false;
     if (_mutex) xSemaphoreTake(_mutex, portMAX_DELAY);
     if (!out || size == 0) {
@@ -1836,7 +1836,7 @@ bool Settings::loadAdminToken(char *out, size_t size)
 
 esp_err_t Settings::saveAdminToken(const char *token)
 {
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "settings.save_admin_token");
     if (!storage_lock) {
       return ESP_ERR_NO_MEM;
     }
@@ -1860,7 +1860,7 @@ esp_err_t Settings::saveAdminToken(const char *token)
 
 esp_err_t Settings::clearAdminToken()
 {
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "settings.clear_admin_token");
     if (!storage_lock) {
       return ESP_ERR_NO_MEM;
     }

--- a/main/syslog.cpp
+++ b/main/syslog.cpp
@@ -24,6 +24,7 @@
 #include "syslog.h"
 #include "log_manager.h"
 #include "monitoring.h"
+#include "crash_blackbox.h"
 #include "settings.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
@@ -560,6 +561,7 @@ static void syslog_task(void *pv)
             // upload of heap. The log line is dropped; the queue keeps moving.
             if (!net_fetch_ota_active() && g_net_fetch_mutex) {
                 if (xSemaphoreTake(g_net_fetch_mutex, 0) == pdTRUE) {
+                    crash_blackbox_net_op_begin("syslog_tls");
                     // Stop may race with the non-blocking mutex acquisition.
                     // Recheck after ownership so no TLS setup begins while the
                     // lifecycle is already unwinding.
@@ -567,6 +569,7 @@ static void syslog_task(void *pv)
                         syslog_tls_send(&tls, s_cfg.server, s_cfg.port,
                                         wire, wire_len);
                     }
+                    crash_blackbox_net_op_end();
                     xSemaphoreGive(g_net_fetch_mutex);
                 }
             }

--- a/main/theme_api.cpp
+++ b/main/theme_api.cpp
@@ -126,7 +126,7 @@ void load_theme(char *scheme, size_t scheme_size,
 {
     set_default_theme(scheme, scheme_size, color, color_size);
 
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "theme.load");
     if (!storage_lock)
     {
         ESP_LOGE(TAG, "Could not acquire NVS storage lock while loading theme");
@@ -310,7 +310,7 @@ esp_err_t theme_api_set_config(const char *scheme, const char *color)
     snprintf(config.color, sizeof(config.color), "%s", color);
     config.checksum = config_checksum(config);
 
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "theme.save");
     if (!storage_lock) return ESP_ERR_NO_MEM;
 
     nvs_handle_t handle = 0;

--- a/main/webui.cpp
+++ b/main/webui.cpp
@@ -49,6 +49,7 @@
 #include "log_manager.h"
 #include "reset_info.h"
 #include "nvs_storage_lock.h"
+#include "crash_blackbox.h"
 #include "system_reset.h"
 #include "system_overview_api.h"
 #include "theme_api.h"
@@ -2172,7 +2173,7 @@ esp_err_t post_restore_handler_func(httpd_req_t *req)
     // Keep every app-owned writer out of the shared 16 KiB NVS partition
     // from capacity preflight through the final commit. Nested helpers take
     // this recursive lock as well.
-    NvsStorageLock restore_storage;
+    NvsStorageLock restore_storage(portMAX_DELAY, "webui.restore");
     if (!restore_storage) {
         cJSON_Delete(root);
         return send_json_error(req, "503 Service Unavailable",
@@ -2600,6 +2601,7 @@ esp_err_t post_ota_update_handler_func(httpd_req_t *req)
                                        "Network/TLS subsystem busy");
         }
         net_gate_held = true;
+        crash_blackbox_net_op_begin("webui_ota_upload");
     }
 
     esp_ota_handle_t ota_handle = 0;
@@ -2610,7 +2612,7 @@ esp_err_t post_ota_update_handler_func(httpd_req_t *req)
         ESP_LOGE(TAG, "Failed to allocate OTA buffer");
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Memory allocation failed");
         _ota_status = OTA_FAILED;
-        if (net_gate_held) xSemaphoreGive(g_net_fetch_mutex);
+        if (net_gate_held) { crash_blackbox_net_op_end(); xSemaphoreGive(g_net_fetch_mutex); }
         net_fetch_set_ota_active(false);
         ota_operation_finish();
         return ESP_FAIL;
@@ -2621,7 +2623,7 @@ esp_err_t post_ota_update_handler_func(httpd_req_t *req)
         ESP_LOGW(TAG, "Rejected 320 KiB WebUI image on firmware endpoint");
         free(ota_buff);
         _ota_status = OTA_FAILED;
-        if (net_gate_held) xSemaphoreGive(g_net_fetch_mutex);
+        if (net_gate_held) { crash_blackbox_net_op_end(); xSemaphoreGive(g_net_fetch_mutex); }
         net_fetch_set_ota_active(false);
         ota_operation_finish();
         return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
@@ -2803,6 +2805,7 @@ esp_err_t post_ota_update_handler_func(httpd_req_t *req)
     // may be waiting on this gate and its cooperative stop must be allowed to
     // finish. No more upload buffer or flash write is active beyond this point.
     if (net_gate_held) {
+        crash_blackbox_net_op_end();
         xSemaphoreGive(g_net_fetch_mutex);
         net_gate_held = false;
     }
@@ -2846,7 +2849,7 @@ esp_err_t post_ota_update_handler_func(httpd_req_t *req)
 
 err:
     if (ota_buff) free(ota_buff);
-    if (net_gate_held) xSemaphoreGive(g_net_fetch_mutex);
+    if (net_gate_held) { crash_blackbox_net_op_end(); xSemaphoreGive(g_net_fetch_mutex); }
     net_fetch_set_ota_active(false);
     _statusLED->setState(LED_STATE_OFF);
     _ota_status = OTA_FAILED;
@@ -3333,7 +3336,7 @@ esp_err_t get_crash_log_handler_func(httpd_req_t *req)
 
     // Best-effort erase: the snapshot has now been delivered to the UI; we
     // do not want it to reappear on every reload.
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "webui.crash_tail_erase");
     if (storage_lock) {
         nvs_handle_t h;
         if (nvs_open("reset_info", NVS_READWRITE, &h) == ESP_OK) {

--- a/main/webui_storage.cpp
+++ b/main/webui_storage.cpp
@@ -21,6 +21,7 @@
 #include "nvs.h"
 
 #include "monitoring.h"
+#include "crash_blackbox.h"
 #include "nvs_storage_lock.h"
 #include "security_headers.h"
 #include "webui_compatibility.h"
@@ -165,7 +166,7 @@ void reset_manifest_metadata_locked()
 
 esp_err_t set_transaction_pending_locked(bool pending)
 {
-    NvsStorageLock storage_lock;
+    NvsStorageLock storage_lock(portMAX_DELAY, "webui_storage.transaction_pending");
     if (!storage_lock) return ESP_ERR_NO_MEM;
 
     nvs_handle_t handle = 0;
@@ -832,6 +833,7 @@ esp_err_t post_webui_update_handler(httpd_req_t *req)
                                               "Update subsystem busy");
         }
         net_locked = true;
+        crash_blackbox_net_op_begin("webui_storage_upload");
     }
 
     char expected_sha256[SHA256_HEX_LENGTH + 1] = {};
@@ -845,7 +847,7 @@ esp_err_t post_webui_update_handler(httpd_req_t *req)
         static_cast<size_t>(req->content_len), expected_sha256);
     if (result != ESP_OK)
     {
-        if (net_locked) xSemaphoreGive(g_net_fetch_mutex);
+        if (net_locked) { crash_blackbox_net_op_end(); xSemaphoreGive(g_net_fetch_mutex); }
         const WebUIStorageStatus status = webui_storage_get_status();
         return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
                                    status.lastError[0]
@@ -857,7 +859,7 @@ esp_err_t post_webui_update_handler(httpd_req_t *req)
     if (!buffer)
     {
         webui_storage_update_abort();
-        if (net_locked) xSemaphoreGive(g_net_fetch_mutex);
+        if (net_locked) { crash_blackbox_net_op_end(); xSemaphoreGive(g_net_fetch_mutex); }
         return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
                                    "Could not allocate WWW upload buffer");
     }
@@ -910,7 +912,7 @@ esp_err_t post_webui_update_handler(httpd_req_t *req)
         webui_storage_update_abort();
     }
 
-    if (net_locked) xSemaphoreGive(g_net_fetch_mutex);
+    if (net_locked) { crash_blackbox_net_op_end(); xSemaphoreGive(g_net_fetch_mutex); }
 
     if (result != ESP_OK)
     {

--- a/test/host/test_interrupt_safety_policy.py
+++ b/test/host/test_interrupt_safety_policy.py
@@ -225,8 +225,12 @@ class InterruptSafetyPolicyTest(unittest.TestCase):
         crash_tail = log_manager_source[
             log_manager_source.index("bool LogManager::saveCrashTailNvs") :
         ]
+        # The bounded 20 ms timeout is the invariant that matters here (this
+        # runs on the path immediately before a protective restart and must
+        # never wait unboundedly); the crash_blackbox op-tag argument after
+        # it is an additive diagnostic, not part of the contract.
         self.assertIn(
-            "NvsStorageLock storage_lock(pdMS_TO_TICKS(20))", crash_tail
+            "NvsStorageLock storage_lock(pdMS_TO_TICKS(20)", crash_tail
         )
         self.assertLess(
             crash_tail.index("NvsStorageLock storage_lock"),


### PR DESCRIPTION
## Description

Adds a lightweight "flight recorder" that names the specific blocking operation in flight (if any) at the moment of an Interrupt-Watchdog/panic reset, plus a small ISR hardening fix for the optional DCF77 feature.

Every NVS/flash write in the firmware already funnels through `NvsStorageLock`'s recursive mutex, and every outbound TLS call already serializes on `g_net_fetch_mutex`. Both now accept a short tag naming the call site. The tag is pushed onto an RTC-backed (`RTC_NOINIT_ATTR`) op stack when the lock/mutex is acquired and popped when released. Because each domain's underlying mutex already guarantees single-task ownership at a time, this tracking is race-free by construction — no additional locking needed.

If a reset happens while a tag is still pushed (the operation started but never finished), `ResetInfo::getResetDetails()` now reports e.g. `stuck op: nvs:settings.save` or `stuck op: net:mqtt_tls` instead of just `Interrupt Watchdog reset`, giving a specific call site to chase on the next field crash report.

Also hardens the DCF77 GPIO ISR (`main/dcf.cpp`): GPIO 34-39 (including `DCF_PIN`) have no internal pull resistor on the ESP32, so an unconnected/misconfigured receiver can leave the `ANYEDGE` interrupt free-running on floating-pin noise. The ISR now gates to 5 ms between accepted edges — a real DCF77 edge never repeats faster than 80 ms — so a floating pin cannot monopolize interrupt time on that core.

## Motivation and Context

Fixes/advances #362. That issue's Interrupt-Watchdog resets have resisted every fix tried across ~15 beta releases (heap policy changes, supporter-key/CRL removal, DMA buffer tuning, MQTT publish-rate reduction). The maintainer's own crash telemetry (the existing RTC heap "crash blackbox") rules out heap exhaustion — every recorded crash shows a healthy, unfragmented heap (`low_streak=0`). Crashes recur anywhere from 3 minutes to 32+ hours after boot across different hardware revisions and configurations, which points to a rare, timing-sensitive interrupt-disabled stall rather than a deterministic bug or leak.

The team's own debug notes for this issue say plainly: "the WebUI log ring buffer does not survive the reboot... without a serial console attached at crash time there is NO backtrace... making the crash effectively undiagnosable." This PR addresses that diagnosability gap directly, without needing a coredump partition (the 4 MB flash has no room for one) or a serial console in the field.

I considered raising `CONFIG_ESP_INT_WDT_TIMEOUT_MS` above the IDF default of 300 ms as a defensive margin (SPI flash erase worst-case timing can approach that), but found an existing regression test (`test_watchdog_remains_a_fault_detector`) explicitly pinning it at 300 — a deliberate prior team decision to keep the watchdog a tight fault detector rather than mask a potential real bug. I left that value untouched.

## How Has This Been Tested?

- All 31 existing Python host policy/regression tests pass (`python3 -m unittest discover -s test/host -p 'test_*policy.py'`), including the interrupt-safety and NVS-transaction policy suites, after adjusting one assertion in `test_interrupt_safety_policy.py` that did an exact-substring match against the now-tagged `NvsStorageLock` call in `log_manager.cpp` (the bounded-timeout invariant it checks is preserved).
- `main/crash_blackbox.cpp` syntax-checked standalone with `g++ -std=c++17 -Wall -Wextra -Werror -fsyntax-only` against a minimal `esp_attr.h` stub.
- Manually traced every `crash_blackbox_net_op_begin`/`_end` pair across all early-return/error paths in `events.cpp`, `syslog.cpp`, `mqtt_handler.cpp`, `webui.cpp`, and `webui_storage.cpp` to confirm every acquisition path has a matching release-time pop.
- `git diff --check` is clean.
- A full `idf.py build` (ESP-IDF v6.1-beta1, WebUI + firmware) was kicked off to confirm end-to-end compilation; I'll follow up in this PR/thread once it completes.

## Screenshots (if appropriate):

N/A (backend/firmware diagnostics change, no UI change).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes. (adjusted existing host policy test to match)
- [x] All new and existing tests passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_018RwHPn3V3ysBPMhnp9Z4j3)_

## Summary by Sourcery

Add an RTC-backed operation flight recorder to identify NVS and network/TLS operations that were in flight at the time of watchdog/panic resets, and surface this information in reset diagnostics.

New Features:
- Introduce crash_blackbox op tagging APIs to track in-flight NVS and network/TLS operations across resets.
- Add per-call-site tagging to NvsStorageLock and key network mutex users to record which high-level operation holds each domain lock.

Bug Fixes:
- Limit DCF77 GPIO interrupt handling rate to prevent floating or misconfigured inputs from monopolizing interrupt time on ESP32 input-only pins.

Enhancements:
- Include stuck operation tags alongside heap snapshots in ResetInfo diagnostics and log output when watchdog or panic resets occur.
- Extend existing interrupt-safety test to tolerate additional crash_blackbox tagging parameters while preserving its timeout invariant.

Tests:
- Adjust interrupt-safety host test to match updated NvsStorageLock usage without weakening the bounded-timeout contract.