### PR TITLE
fix(security): TLS cert verification, rate-limiter bypass, header injection

### DIFF
--- a/include/sysinfo.h
+++ b/include/sysinfo.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 typedef enum
 {
@@ -43,7 +44,12 @@ public:
     const char* getCurrentVersion();
     const char *getSerialNumber();
     board_type_t getBoardType();
-    const char* getBoardRevisionString();
+    // Returns by value (not a shared static buffer): this is called
+    // concurrently from the WebUI HTTP task and the MQTT publish task, and a
+    // shared static char[] previously let one task's write tear a
+    // concurrently-running task's read (data race), corrupting whichever
+    // caller lost the race.
+    std::string getBoardRevisionString();
     // Raw ADC voltage (in millivolts) from the board-revision sense pin, captured
     // during detectBoard(). Useful for support / diagnostics when the revision
     // resolves to "Unknown" — exposes what the divider actually produced.
@@ -54,11 +60,12 @@ public:
     // Compact diagnostic summary of all FreeRTOS tasks: name + stack
     // high-water mark (bytes remaining) for each, sorted smallest-first so
     // tasks closest to stack exhaustion remain visible if output truncates.
-    // Returned pointer is valid until the next call. Exposed
+    // Returned by value (see getBoardRevisionString() above for why — same
+    // concurrent WebUI/MQTT caller race applied here too). Exposed
     // via /sysinfo.json (taskStacks) and MQTT status/task_stacks so that
     // under- and over-provisioned task stacks can be spotted from a remote
     // support request without needing serial access. Cheap to call (transient
     // ~2 KB scratch for uxTaskGetSystemState), but not free — callers
     // should not poll it more often than once per second.
-    const char* getTaskStackInfo();
+    std::string getTaskStackInfo();
 };

--- a/include/validation.h
+++ b/include/validation.h
@@ -71,3 +71,10 @@ bool validateCcuAddress(const char *address);
 // that are unambiguously safe in any context (no spaces, quotes, slashes,
 // control chars). Length: 8..63 characters. Allowed: A-Z a-z 0-9 - _ .
 bool validateMqttCommandToken(const char *token);
+
+// Rejects CR/LF and other C0 control characters. Required for any field that
+// is later interpolated verbatim into a line-oriented protocol (raw SMTP
+// command/header lines, an HTTP header value) — without this, an embedded
+// \r\n lets the value break out into additional protocol lines/headers
+// (command/header injection). Empty strings are valid (field is optional).
+bool validateNoControlChars(const char *str);

--- a/main/dcf.cpp
+++ b/main/dcf.cpp
@@ -197,12 +197,30 @@ static void handlePinChange(int64_t flankTime, int state)
                 dcf_tm.tm_min = bcd2bin((int)((_buffer >> 21) & 0x7f));
                 dcf_tm.tm_sec = 0;
 
-                struct timeval tv;
-                tv.tv_sec = dcf2epoch(&dcf_tm, timezone);
-                tv.tv_usec = esp_timer_get_time() - _secondMark + _settings->getDcfOffset();
+                // bcd2bin() is a pseudo-BCD decode with no defined behavior for
+                // non-BCD nibbles (e.g. bcd2bin(0x1f)=25), and the parity checks
+                // above only cover even-parity over bit ranges, not the decoded
+                // field's plausible value range. Without this, a noisy/malformed
+                // signal that happens to pass parity can produce tm_mon up to 24,
+                // and dcf2epoch()'s "for (i=0; i<tm_mon; ++i) res += ndays[i];"
+                // would then read past the 12-element ndays[] array.
+                if (dcf_tm.tm_mon < 0 || dcf_tm.tm_mon > 11 ||
+                    dcf_tm.tm_mday < 1 || dcf_tm.tm_mday > 31 ||
+                    dcf_tm.tm_hour < 0 || dcf_tm.tm_hour > 23 ||
+                    dcf_tm.tm_min < 0 || dcf_tm.tm_min > 59)
+                {
+                    ESP_LOGE(TAG, "Received frame with out-of-range field(s): mon=%d mday=%d hour=%d min=%d",
+                             dcf_tm.tm_mon, dcf_tm.tm_mday, dcf_tm.tm_hour, dcf_tm.tm_min);
+                }
+                else
+                {
+                    struct timeval tv;
+                    tv.tv_sec = dcf2epoch(&dcf_tm, timezone);
+                    tv.tv_usec = esp_timer_get_time() - _secondMark + _settings->getDcfOffset();
 
-                ESP_LOGI(TAG, "Updated time to %02d-%02d-%02d %02d:%02d:%02d.%06ld %s", dcf_tm.tm_year + 1900, dcf_tm.tm_mon + 1, dcf_tm.tm_mday, dcf_tm.tm_hour, dcf_tm.tm_min, dcf_tm.tm_sec, tv.tv_usec, timezone == 2 ? "CET" : "CEST");
-                _clk->setTime(&tv);
+                    ESP_LOGI(TAG, "Updated time to %02d-%02d-%02d %02d:%02d:%02d.%06ld %s", dcf_tm.tm_year + 1900, dcf_tm.tm_mon + 1, dcf_tm.tm_mday, dcf_tm.tm_hour, dcf_tm.tm_min, dcf_tm.tm_sec, tv.tv_usec, timezone == 2 ? "CET" : "CEST");
+                    _clk->setTime(&tv);
+                }
             }
 
             _buffer = pulseValue;

--- a/main/events.cpp
+++ b/main/events.cpp
@@ -538,7 +538,14 @@ static bool smtp_setup_tls(mbedtls_ssl_context *ssl,
                                     MBEDTLS_SSL_PRESET_DEFAULT) != 0) {
         return false;
     }
-    mbedtls_ssl_conf_authmode(conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+    // VERIFY_REQUIRED, not OPTIONAL: with OPTIONAL, mbedtls_ssl_handshake()
+    // returns 0 (success) even for an invalid/expired/hostname-mismatched
+    // peer certificate — the failure only shows up in
+    // mbedtls_ssl_get_verify_result(), which this code never checked. That
+    // silently accepted a MITM'd SMTP session, exposing the AUTH LOGIN
+    // credentials sent right after. REQUIRED makes the handshake itself fail
+    // closed on a bad certificate.
+    mbedtls_ssl_conf_authmode(conf, MBEDTLS_SSL_VERIFY_REQUIRED);
     esp_crt_bundle_attach(conf);
     const int remaining_ms = remaining_deadline_ms(deadline_us);
     if (remaining_ms <= 0) return false;

--- a/main/monitoring_api.cpp
+++ b/main/monitoring_api.cpp
@@ -640,6 +640,13 @@ esp_err_t post_monitoring_handler_func(httpd_req_t *req)
                 cJSON_Delete(root);
                 return send_json_error(req, "Webhook secret too long");
             }
+            // The secret is sent verbatim as an HTTP header value
+            // (X-HB-RF-ETH-Secret); an embedded CR/LF would let it inject
+            // extra request headers.
+            if (!validateNoControlChars(nws->valuestring)) {
+                cJSON_Delete(root);
+                return send_json_error(req, "Webhook secret contains invalid characters");
+            }
             copy_string_field(config.notify.webhook_secret, sizeof(config.notify.webhook_secret), nws->valuestring);
         }
         cJSON *ntgtok = cJSON_GetObjectItem(notify, "telegramTokenClear");
@@ -702,6 +709,13 @@ esp_err_t post_monitoring_handler_func(httpd_req_t *req)
                 cJSON_Delete(root);
                 return send_json_error(req, "SMTP from too long");
             }
+            // Interpolated verbatim into raw "MAIL FROM:<%s>" / "From: %s"
+            // protocol lines; an embedded CR/LF would inject extra SMTP
+            // commands/headers.
+            if (!validateNoControlChars(nsf->valuestring)) {
+                cJSON_Delete(root);
+                return send_json_error(req, "SMTP from contains invalid characters");
+            }
             copy_string_field(config.notify.smtp_from, sizeof(config.notify.smtp_from), nsf->valuestring);
         }
         cJSON *nsto = cJSON_GetObjectItem(notify, "smtpTo");
@@ -709,6 +723,13 @@ esp_err_t post_monitoring_handler_func(httpd_req_t *req)
             if (!validateStringLength(nsto->valuestring, sizeof(config.notify.smtp_to) - 1)) {
                 cJSON_Delete(root);
                 return send_json_error(req, "SMTP to too long");
+            }
+            // Interpolated verbatim into raw "RCPT TO:<%s>" / "To: %s"
+            // protocol lines; an embedded CR/LF would inject extra SMTP
+            // commands/headers.
+            if (!validateNoControlChars(nsto->valuestring)) {
+                cJSON_Delete(root);
+                return send_json_error(req, "SMTP to contains invalid characters");
             }
             copy_string_field(config.notify.smtp_to, sizeof(config.notify.smtp_to), nsto->valuestring);
         }

--- a/main/mqtt_handler.cpp
+++ b/main/mqtt_handler.cpp
@@ -537,13 +537,13 @@ void mqtt_handler_publish_task_stacks(void)
     SysInfo *sysInfo = monitoring_get_sysinfo();
     if (!sysInfo) return;
 
-    const char *stacks = sysInfo->getTaskStackInfo();
-    if (!stacks || !stacks[0]) return;
+    std::string stacks = sysInfo->getTaskStackInfo();
+    if (stacks.empty()) return;
 
     char topic[160];
     snprintf(topic, sizeof(topic), "%s/status/task_stacks",
              current_mqtt_config.topic_prefix);
-    mqtt_publish_connected(topic, stacks, 0, 0, 1);
+    mqtt_publish_connected(topic, stacks.c_str(), 0, 0, 1);
 }
 
 // Publish one value under <prefix>/<subtopic> with retain=1, QoS=0.
@@ -602,7 +602,7 @@ void mqtt_handler_publish_status(void)
     char webuiVersion[32] = {};
     webui_storage_get_effective_version(webuiVersion, sizeof(webuiVersion));
     PUBLISH_STR("status/webui_version", webuiVersion);
-    PUBLISH_STR("status/board_revision", sysInfo->getBoardRevisionString());
+    PUBLISH_STR("status/board_revision", sysInfo->getBoardRevisionString().c_str());
 
     // ---- System metrics ---------------------------------------------------
     PUBLISH_DOUBLE("status/cpu_usage", sysInfo->getCpuUsage(), 1);
@@ -874,7 +874,7 @@ void mqtt_handler_publish_ha_discovery(void)
     cJSON_AddStringToObject(device, "model", "HB-RF-ETH-ng");
     cJSON_AddStringToObject(device, "manufacturer", "Xerolux");
     cJSON_AddStringToObject(device, "sw_version", sysInfo->getCurrentVersion());
-    cJSON_AddStringToObject(device, "hw_version", sysInfo->getBoardRevisionString());
+    cJSON_AddStringToObject(device, "hw_version", sysInfo->getBoardRevisionString().c_str());
 
     // Helper: publish a sensor / binary_sensor / button / update config.
     auto publish_config = [&](const char* component, const char* object_id, const char* name,

--- a/main/sysinfo.cpp
+++ b/main/sysinfo.cpp
@@ -282,7 +282,7 @@ const char *SysInfo::getCurrentVersion()
     return _currentVersion;
 }
 
-const char* SysInfo::getBoardRevisionString()
+std::string SysInfo::getBoardRevisionString()
 {
     switch (_board)
     {
@@ -298,7 +298,7 @@ const char* SysInfo::getBoardRevisionString()
         // Include the raw ADC reading so a user looking at the WebUI / log
         // share can immediately see what the divider produced — usually one
         // of: open pin, unsupported board rev, or ADC calibration drift.
-        static char unknown_buf[40];
+        char unknown_buf[40];
         snprintf(unknown_buf, sizeof(unknown_buf), "Unknown (%" PRIu32 " mV)", _lastBoardSenseVoltage);
         return unknown_buf;
     }
@@ -322,15 +322,13 @@ const char* SysInfo::getResetReason()
     return ResetInfo::getResetDetails();
 }
 
-const char* SysInfo::getTaskStackInfo()
+std::string SysInfo::getTaskStackInfo()
 {
     // Build a compact "name=hwm_bytes" list sorted by HWM ascending.
     // The high-water mark (uxTaskGetStackHighWaterMark) is the minimum free
     // stack ever observed for a task — small values flag tasks close to
     // overflow, large values flag over-provisioned stacks that waste heap.
-    // Returned pointer is a static buffer so callers must copy if they need
-    // to keep the value across another call.
-    static char out[512];
+    char out[512];
 
     // uxTaskGetSystemState needs CONFIG_FREERTOS_USE_TRACE_FACILITY (set in
     // sdkconfig.defaults). Estimate an upper bound on the task count so the

--- a/main/syslog.cpp
+++ b/main/syslog.cpp
@@ -398,7 +398,13 @@ static bool syslog_tls_connect(syslog_tls_session *s, const char *host, uint16_t
         syslog_tls_teardown(s);
         return false;
     }
-    mbedtls_ssl_conf_authmode(&s->conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+    // VERIFY_REQUIRED, not OPTIONAL: with OPTIONAL, mbedtls_ssl_handshake()
+    // returns 0 (success) even for an invalid/expired/hostname-mismatched
+    // peer certificate — the failure only shows up in
+    // mbedtls_ssl_get_verify_result(), which this code never checked. That
+    // silently accepted a MITM'd syslog TLS session. REQUIRED makes the
+    // handshake itself fail closed on a bad certificate.
+    mbedtls_ssl_conf_authmode(&s->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
     esp_crt_bundle_attach(&s->conf);
     if (mbedtls_ssl_setup(&s->ssl, &s->conf) != 0) {
         syslog_tls_teardown(s);

--- a/main/validation.cpp
+++ b/main/validation.cpp
@@ -764,3 +764,21 @@ bool validateMqttCommandToken(const char *token)
     }
     return true;
 }
+
+bool validateNoControlChars(const char *str)
+{
+    if (str == NULL) {
+        return false;
+    }
+    for (const unsigned char *p = (const unsigned char *)str; *p; p++) {
+        // Reject the full C0 control range (0x00-0x1F) and DEL (0x7F). This
+        // covers \r and \n specifically (the SMTP/HTTP-header line-injection
+        // vector) plus other bytes that have no legitimate reason to appear
+        // in an email address, SMTP header field, or HTTP header value.
+        if (*p < 0x20 || *p == 0x7F) {
+            ESP_LOGW(TAG, "Rejected string with control character 0x%02x", *p);
+            return false;
+        }
+    }
+    return true;
+}

--- a/main/webui.cpp
+++ b/main/webui.cpp
@@ -43,6 +43,7 @@
 #include "mbedtls/base64.h"
 #include "monitoring_api.h"
 #include "monitoring.h"
+#include "events.h"
 #include "rate_limiter.h"
 #include "security_headers.h"
 #include "secure_utils.h"
@@ -363,15 +364,19 @@ esp_err_t post_login_json_handler_func(httpd_req_t *req)
 {
     add_security_headers(req);
 
-    // Check rate limit, but allow whitelisted IP
-    // Prioritize manual setting, fallback to dynamic raw uart listener
+    // Check rate limit, but allow the whitelisted CCU IP. Only an explicitly,
+    // authenticated-admin-configured static CCU address is trusted here.
+    // The previous fallback to _rawUartUdpListener->getConnectedRemoteAddress()
+    // let any LAN host bypass the login brute-force throttle for free: that
+    // address is set by the unauthenticated raw-uart protocol (port 3008)
+    // whenever ANY host sends a 5-byte "connect" packet — no credential or
+    // proof of being the real CCU required. Trusting it for a security
+    // control was an unauthenticated-network-signal-based bypass.
     ip4_addr_t ccu_ip = {0};
     const char* storedCCUIP = _settings->getCCUIP();
 
     if (storedCCUIP && strlen(storedCCUIP) > 0) {
         ip4addr_aton(storedCCUIP, &ccu_ip);
-    } else {
-        ccu_ip = _rawUartUdpListener->getConnectedRemoteAddress();
     }
 
     if (!rate_limiter_is_whitelisted(req, &ccu_ip) && !rate_limiter_check_login(req))
@@ -646,7 +651,7 @@ esp_err_t get_sysinfo_json_handler_func(httpd_req_t *req)
     httpd_resp_send_chunk(req, buf, strlen(buf));
 
     snprintf(buf, sizeof(buf), "\"boardRevision\":\"%s\",\"boardSenseVoltage\":%" PRIu32 ",\"resetReason\":\"%s\",",
-             _sysInfo->getBoardRevisionString(), (uint32_t)_sysInfo->getBoardSenseVoltage(), _sysInfo->getResetReason());
+             _sysInfo->getBoardRevisionString().c_str(), (uint32_t)_sysInfo->getBoardSenseVoltage(), _sysInfo->getResetReason());
     httpd_resp_send_chunk(req, buf, strlen(buf));
 
     snprintf(buf, sizeof(buf), "\"ethernetConnected\":%s,\"ethernetSpeed\":%d,\"ethernetDuplex\":\"%s\",",
@@ -700,13 +705,13 @@ esp_err_t get_sysinfo_json_handler_func(httpd_req_t *req)
     // are legal in JSON strings; only escape quotes and backslashes (defensive
     // — task names are bounded ASCII).
     {
-        const char *stacks = _sysInfo->getTaskStackInfo();
+        std::string stacks = _sysInfo->getTaskStackInfo();
         char stack_buf[640];
         size_t pos = 0;
         stack_buf[0] = 0;
         pos += snprintf(stack_buf + pos, sizeof(stack_buf) - pos,
                         ",\"taskStacks\":\"");
-        for (const char *p = stacks; *p && pos + 4 < sizeof(stack_buf); p++) {
+        for (const char *p = stacks.c_str(); *p && pos + 4 < sizeof(stack_buf); p++) {
             if (*p == '"' || *p == '\\') {
                 stack_buf[pos++] = '\\';
             }
@@ -1692,6 +1697,20 @@ static esp_err_t parse_monitoring_backup(
         backup_get_uint(notify, "cooldownSeconds", UINT16_MAX, &number);
     if (valid) {
         config->notify.cooldown_seconds = static_cast<uint16_t>(number);
+    }
+    // Same CRLF/control-char rejection as the normal POST /api/monitoring
+    // path (monitoring_api.cpp): these three fields are interpolated
+    // verbatim into raw SMTP protocol lines / an HTTP header, so a crafted
+    // or corrupted backup file must not be able to reintroduce header/command
+    // injection through the restore path.
+    if (valid && config->notify.webhook_secret[0] != '\0') {
+        valid = validateNoControlChars(config->notify.webhook_secret);
+    }
+    if (valid && config->notify.smtp_from[0] != '\0') {
+        valid = validateNoControlChars(config->notify.smtp_from);
+    }
+    if (valid && config->notify.smtp_to[0] != '\0') {
+        valid = validateNoControlChars(config->notify.smtp_to);
     }
 
     if (!valid) {
@@ -2888,6 +2907,13 @@ esp_err_t post_restart_handler_func(httpd_req_t *req)
     // Store reset reason before restart
     ResetInfo::storeResetReason(RESET_REASON_USER_RESTART);
 
+    // Queue the notification before the delay below so the events worker has
+    // a chance to pick it up (queue poll: 500ms) and start delivery before
+    // full_system_restart()'s monitoring_pause_for_ota() stops the worker —
+    // that stop path waits up to 30s for an in-flight send to finish, but
+    // only if the worker already dequeued the entry.
+    events_emit(EVENT_RESTART, "manual restart via WebUI/API");
+
     // Restart after a short delay to allow response to be sent
     vTaskDelay(pdMS_TO_TICKS(1000));
     refresh_restart_sync_from_settings();
@@ -2917,6 +2943,13 @@ esp_err_t post_factory_reset_handler_func(httpd_req_t *req)
         return httpd_resp_sendstr(
             req, "Another configuration or restart operation is active");
     }
+
+    // Queue the notification against the still-live (pre-wipe) notify config
+    // before anything is erased. Same delivery-window reasoning as
+    // post_restart_handler_func: the events worker gets the 1s pre-restart
+    // delay plus up to 30s inside monitoring_pause_for_ota() to actually
+    // send it, as long as it dequeues the entry before that stop begins.
+    events_emit(EVENT_FACTORY_RESET, "factory reset via WebUI/API");
 
     // Erase every user-controlled namespace first. reset_info is deliberately
     // part of Settings::clear(), so store the one allowed post-reset metadata

--- a/test/host/test_interrupt_safety_policy.py
+++ b/test/host/test_interrupt_safety_policy.py
@@ -238,7 +238,11 @@ class InterruptSafetyPolicyTest(unittest.TestCase):
         )
 
         sysinfo = self.read("main/sysinfo.cpp")
-        task_stack = sysinfo[sysinfo.index("const char* SysInfo::getTaskStackInfo()") :]
+        # Returns std::string (not a shared static char buffer) so concurrent
+        # WebUI/MQTT callers can't tear each other's read (see
+        # SysInfo::getBoardRevisionString()'s doc comment in sysinfo.h for the
+        # data-race this replaced).
+        task_stack = sysinfo[sysinfo.index("std::string SysInfo::getTaskStackInfo()") :]
         self.assertIn(
             "hwm_bytes = (unsigned)tasks[i].usStackHighWaterMark;", task_stack
         )


### PR DESCRIPTION
## Description

A six-way parallel review (auth/sessions, input validation, network protocol parsing, TLS/secrets, WebUI frontend, general bug hunt) plus a targeted investigation of issues #416 and #411 turned up several concrete, verified issues. This PR fixes the ones that were actionable and well-scoped:

- **CRITICAL** — `syslog.cpp` and `events.cpp`'s SMTP client used `MBEDTLS_SSL_VERIFY_OPTIONAL` and never checked `mbedtls_ssl_get_verify_result()` afterward, so a TLS handshake against an invalid/expired/MITM'd certificate still returned success (the classic mbedTLS "VERIFY_OPTIONAL trap"). Switched both to `MBEDTLS_SSL_VERIFY_REQUIRED` so the handshake itself fails closed on a bad certificate. This mattered most for SMTP, whose `AUTH LOGIN` credentials went out right after a silently-unverified handshake.
- **HIGH** — the login rate-limiter's IP whitelist fell back to `RawUartUdpListener::getConnectedRemoteAddress()` whenever no static CCU IP was configured (the default state). That address is set by *any* LAN host sending an unauthenticated 5-byte raw-uart "connect" packet to port 3008 — no credential required. An attacker could trivially whitelist themselves and brute-force the admin password with no throttling. Removed the fallback; only an explicitly admin-configured static CCU IP is now trusted for the whitelist.
- **MEDIUM** — `smtpFrom` / `smtpTo` / `webhookSecret` were length-validated only, but are interpolated verbatim into raw SMTP protocol lines (`MAIL FROM:<%s>`, `RCPT TO:<%s>`, `From:`/`To:` headers) or an HTTP header value. An embedded CR/LF allowed SMTP command/header injection. Added `validateNoControlChars()` and applied it both at the normal `POST /api/monitoring` path and the config-backup restore path (which had its own separate, un-synced field parsing).
- **MEDIUM** — `SysInfo::getBoardRevisionString()` / `getTaskStackInfo()` returned pointers into shared `static char[]` buffers, called concurrently from the WebUI HTTP task and the MQTT publish task with no synchronization — a genuine cross-core data race that could corrupt one caller's string. Changed both to return `std::string`, removing the shared mutable state entirely.
- **LOW** — DCF77 time decoding computed `tm_mon` from an unvalidated 5-bit pseudo-BCD field (`bcd2bin(0x1f)` = 25), which could make `dcf2epoch()`'s `ndays[12]` loop read past the array on a malformed/noisy signal (existing parity checks don't range-validate the decoded fields). Added a range check on month/day/hour/minute before the value is used.
- Wired up `EVENT_FACTORY_RESET` and `EVENT_RESTART` emission at the manual-restart and factory-reset handlers. Both events had full webhook/email metadata defined in `events.cpp` but were never emitted anywhere — a genuine dead-code gap. This is a **partial** fix for #416: most other event types (notably `EVENT_RF_MODULE_LOST`) still have no detection logic to trigger them at all, and there is still no per-event-type selection UI, so #416 stays open — see the issue comment for the full root-cause writeup.

## Motivation and Context

Requested review of open issues, bugs, and security across the codebase. None of these were found via a specific bug report except #416/#411 — the rest surfaced from a systematic security-focused pass over auth, input validation, TLS, and concurrency.

## How Has This Been Tested?

- All 31 existing host-level policy/regression tests pass (`python3 -m unittest discover -s test/host -p 'test_*.py'`), including one updated assertion (`sysinfo.cpp` signature change from `const char*` to `std::string`).
- Full ESP-IDF v6.1-beta1 target build succeeds: `HB-RF-ETH-ng.bin` is `0x130230` bytes with 34% free in the smallest app partition.
- Each fix was independently verified by direct code reading (not just trusting the review agents' reports) before being applied.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes. *(updated the one existing test whose exact-string assertion the `sysinfo.cpp` signature change touched; no new test infrastructure needed for the rest — these are policy/regex-based source assertions plus a real build)*
- [x] All new and existing tests passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_018RwHPn3V3ysBPMhnp9Z4j3)_

## Summary by Sourcery

Harden authentication, notification, and diagnostics paths against multiple security and reliability issues, including TLS certificate verification, brute-force rate limiting, header injection, and concurrency safety.

Bug Fixes:
- Require strict TLS certificate verification for SMTP and syslog clients instead of accepting unverifiable peer certificates.
- Remove the dynamic raw UART listener IP fallback from the login rate-limiter whitelist so only the explicitly configured CCU address can bypass throttling.
- Prevent SMTP and webhook secret/config fields from containing control characters that could enable SMTP or HTTP header/command injection, including via config backup restore.
- Add range validation for decoded DCF77 time fields to avoid out-of-bounds access on malformed or noisy signals.
- Eliminate data races in SysInfo diagnostics by returning board revision and task stack info as std::string values instead of shared static buffers.

Enhancements:
- Emit EVENT_RESTART and EVENT_FACTORY_RESET notifications from the WebUI/API restart and factory-reset handlers to surface these lifecycle events.
- Clarify and document security-related behavior around login rate limiting, notification fields, and event emission in WebUI handlers and validation utilities.

Tests:
- Update the host interrupt safety policy test to reflect the SysInfo::getTaskStackInfo() signature change to std::string.