### PR TITLE
chore(idf): upgrade ESP-IDF from v6.1-beta1 to v6.1-rc1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,10 +78,10 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Setup ESP-IDF v6.1-beta1
+      - name: Setup ESP-IDF v6.1-rc1
         run: |
           python -m pip install --upgrade pip
-          git clone --depth 1 --branch v6.1-beta1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
+          git clone --depth 1 --branch v6.1-rc1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
           git -C "$HOME/esp-idf" submodule update --init --recursive --depth 1
           "$HOME/esp-idf/install.sh" esp32
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -182,10 +182,10 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
-      - name: Setup ESP-IDF v6.1-beta1
+      - name: Setup ESP-IDF v6.1-rc1
         run: |
           python -m pip install --upgrade pip
-          git clone --depth 1 --branch v6.1-beta1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
+          git clone --depth 1 --branch v6.1-rc1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
           git -C "$HOME/esp-idf" submodule update --init --recursive --depth 1
           "$HOME/esp-idf/install.sh" esp32
       - name: Build and check firmware size

--- a/.github/workflows/release-webui.yml
+++ b/.github/workflows/release-webui.yml
@@ -102,10 +102,10 @@ jobs:
       - name: Prepare standalone WebUI assets
         run: python3 rename_webui_files.py
 
-      - name: Setup ESP-IDF v6.1-beta1
+      - name: Setup ESP-IDF v6.1-rc1
         run: |
           python -m pip install --upgrade pip
-          git clone --depth 1 --branch v6.1-beta1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
+          git clone --depth 1 --branch v6.1-rc1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
           git -C "$HOME/esp-idf" submodule update --init --recursive --depth 1
           "$HOME/esp-idf/install.sh" esp32
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,10 +179,10 @@ jobs:
               output.write(f'MIN_FIRMWARE={minimum}\n')
           PY
 
-      - name: Setup ESP-IDF v6.1-beta1
+      - name: Setup ESP-IDF v6.1-rc1
         run: |
           python -m pip install --upgrade pip
-          git clone --depth 1 --branch v6.1-beta1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
+          git clone --depth 1 --branch v6.1-rc1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
           git -C "$HOME/esp-idf" submodule update --init --recursive --depth 1
           "$HOME/esp-idf/install.sh" esp32
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,11 +64,11 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Setup ESP-IDF v6.1-beta1
+      - name: Setup ESP-IDF v6.1-rc1
         if: matrix.language == 'cpp'
         run: |
           python -m pip install --upgrade pip
-          git clone --depth 1 --branch v6.1-beta1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
+          git clone --depth 1 --branch v6.1-rc1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
           git -C "$HOME/esp-idf" submodule update --init --recursive --depth 1
           "$HOME/esp-idf/install.sh" esp32
 
@@ -115,10 +115,10 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Setup ESP-IDF v6.1-beta1
+      - name: Setup ESP-IDF v6.1-rc1
         run: |
           python -m pip install --upgrade pip
-          git clone --depth 1 --branch v6.1-beta1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
+          git clone --depth 1 --branch v6.1-rc1 https://github.com/espressif/esp-idf.git "$HOME/esp-idf"
           git -C "$HOME/esp-idf" submodule update --init --recursive --depth 1
           "$HOME/esp-idf/install.sh" esp32
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ HB-RF-ETH-ng/
 
 | Tool | Version |
 |------|---------|
-| ESP-IDF | v6.1-beta1 (pre-release, cloned fresh in CI from `espressif/esp-idf`) |
+| ESP-IDF | v6.1-rc1 (pre-release, cloned fresh in CI from `espressif/esp-idf`) |
 | IDF target | `esp32` |
 | SDK config | `sdkconfig.defaults;sdkconfig.hb-rf-eth-ng` |
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # HB-RF-ETH-ng
 
-**Modernisierte HomeMatic Netzwerk-Firmware | ESP-IDF 6.1-beta1**
+**Modernisierte HomeMatic Netzwerk-Firmware | ESP-IDF 6.1-rc1**
 
 [![GitHub Release][releases-shield]][releases]
 [![GitHub Activity][commits-shield]][commits]
@@ -17,7 +17,7 @@
 
 ## Modernisierte Fork von Xerolux (2025)
 
-Diese Version ist eine modernisierte und aktualisierte Fork der originalen HB-RF-ETH Firmware von Alexander Reinert. Die Firmware basiert auf ESP-IDF 6.1-beta1 und ist für moderne Toolchains optimiert.
+Diese Version ist eine modernisierte und aktualisierte Fork der originalen HB-RF-ETH Firmware von Alexander Reinert. Die Firmware basiert auf ESP-IDF 6.1-rc1 und ist für moderne Toolchains optimiert.
 
 > Alle detaillierten Änderungen pro Version finden Sie im [CHANGELOG.md](CHANGELOG.md).
 
@@ -41,7 +41,7 @@ Hierbei gilt, dass bei einer debmatic oder piVCCU3 Installation immer nur ein Fu
 - **Monitoring via MQTT** (mit Home Assistant Auto-Discovery, TLS/mTLS, Kommando-Token) und CheckMK
 - Manuelle Firmware-Updates per `.bin`-Datei-Upload in der WebUI (automatische
   Update-Suche, URL-OTA und MQTT/Home-Assistant-OTA wurden entfernt)
-- ESP-IDF 6.1-beta1 Toolchain (native `idf.py` Builds), GCC 15.2 (xtensa-esp-elf)
+- ESP-IDF 6.1-rc1 Toolchain (native `idf.py` Builds), GCC 15.2 (xtensa-esp-elf)
 
 ### Login nach Update
 Nach dem Update auf eine Version mit Benutzername-Pflicht muss die Anmeldung einmalig mit dem Standard-Benutzernamen `admin` und dem bisherigen Administrator-Passwort erfolgen. Alte gespeicherte Browser-Sessions werden dabei aus Sicherheitsgründen ungültig. Der Benutzername kann anschließend unter **Einstellungen > Allgemein > Sicherheit** geändert werden, z.B. für Passwortmanager oder Installationen mit mehreren Geräten.
@@ -57,7 +57,7 @@ Backups enthalten vollständig alle wiederherstellbaren Benutzereinstellungen: A
 > HA-Entitäten, TLS-Konfiguration, Sicherheitsmodell) findet sich im
 > [Wiki – MQTT-Sektion](docs/WIKI.md#home-assistant-mqtt-integration).
 
-### Entwickler-Build (ESP-IDF 6.1-beta1)
+### Entwickler-Build (ESP-IDF 6.1-rc1)
 ```bash
 ./scripts/setup_esp_idf.sh
 . ~/esp-idf/export.sh

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -115,7 +115,7 @@ Die Firmware wurde kürzlich mit wichtigen neuen Funktionen und Verbesserungen a
 * **Event-basierte Benachrichtigungen** - Nicht-retained Events für Automatisierungen
 
 ### Technische Basis
-* **ESP-IDF 6.1-beta1** mit nativer `idf.py` Toolchain
+* **ESP-IDF 6.1-rc1** mit nativer `idf.py` Toolchain
 * **Xtensa GCC 14.2.0+20251107** Toolchain (xtensa-esp-elf)
 * **CMake** Build-System für Firmware (nicht PlatformIO)
 * **Vue.js 3** mit Composition API, Vue Router, Pinia, Vue i18n

--- a/scripts/setup_esp_idf.sh
+++ b/scripts/setup_esp_idf.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ESP_IDF_DIR="${ESP_IDF_DIR:-${HOME}/esp-idf}"
-ESP_IDF_VERSION="${ESP_IDF_VERSION:-v6.1-beta1}"
+ESP_IDF_VERSION="${ESP_IDF_VERSION:-v6.1-rc1}"
 
 if [[ ! -d "${ESP_IDF_DIR}" ]]; then
   git clone --depth 1 --branch "${ESP_IDF_VERSION}" https://github.com/espressif/esp-idf.git "${ESP_IDF_DIR}"

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,5 +1,5 @@
 # HB-RF-ETH Default Configuration
-# Compatible with ESP-IDF v6.1-beta1
+# Compatible with ESP-IDF v6.1-rc1
 
 # Partition Table
 CONFIG_PARTITION_TABLE_CUSTOM=y
@@ -55,7 +55,7 @@ CONFIG_FREERTOS_USE_TRACE_FACILITY=y
 CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y
 
 # The HB-RF-ETH board uses Ethernet (LAN8720A) only. These legacy symbols are
-# retained as documentation; ESP-IDF v6.1-beta1 may still resolve its promptless
+# retained as documentation; ESP-IDF v6.1-rc1 may still resolve its promptless
 # Wi-Fi component symbol internally, but the application never initializes it.
 # CONFIG_ESP_WIFI_ENABLED is not set
 # CONFIG_ESP32_WIFI_ENABLED is not set

--- a/test/host/test_interrupt_safety_policy.py
+++ b/test/host/test_interrupt_safety_policy.py
@@ -4,7 +4,7 @@ import unittest
 
 
 ROOT = Path(__file__).resolve().parents[2]
-STABLE_IDF = "v6.1-beta1"
+STABLE_IDF = "v6.1-rc1"
 LOCKFILE_IDF_VERSION = "6.1.0"
 SDKCONFIG_IDF_INIT_VERSION = "6.1.0"
 FIRMWARE_WORKFLOWS = (
@@ -58,7 +58,7 @@ class InterruptSafetyPolicyTest(unittest.TestCase):
         self.assertIn(f'ESP_IDF_VERSION="${{ESP_IDF_VERSION:-{STABLE_IDF}}}"', setup_script)
 
         readme = self.read("README.md")
-        self.assertIn("ESP-IDF 6.1-beta1", readme)
+        self.assertIn("ESP-IDF 6.1-rc1", readme)
 
     def test_watchdog_remains_a_fault_detector(self) -> None:
         sdkconfig = self.read("sdkconfig.hb-rf-eth-ng")


### PR DESCRIPTION
## Summary
- Upgrades the ESP-IDF toolchain from v6.1-beta1 to v6.1-rc1 across all five CI workflows, the local setup script, and docs
- Verified against the [v6.1-rc1 release notes](https://github.com/espressif/esp-idf/releases/tag/v6.1-rc1): all listed breaking changes are relative to v6.0 and were already handled for the beta1 upgrade (MQTT via component manager, GPIO ROM prefix, SPI-Flash private headers, UART header path — none used by this project)
- \dependencies.lock\ needs no change (rc1 reports as 6.1.0 internally, same as beta1)
- Policy test updated (\STABLE_IDF\) — all 9 host tests pass locally

## Test plan
- [ ] CI: \Build Firmware\ with v6.1-rc1 on this PR
- [ ] Firmware size within app partition limits
- [ ] Release as v2.2.7-Beta.1 after merge