### PR TITLE
ci: skip the ESP-IDF ECO3 patch on the JavaScript CodeQL leg

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,6 +73,7 @@ jobs:
           "$HOME/esp-idf/install.sh" esp32
 
       - name: Enable ESP32 ECO3 cache-lock livelock workaround (errata WDT-3.15, issue #362)
+        if: matrix.language == 'cpp'
         run: bash scripts/patch_idf_eco3_fix.sh "$HOME/esp-idf"
 
       - name: Build with ESP-IDF


### PR DESCRIPTION
## Description

Macht `main` wieder grün. Einzeiler in `.github/workflows/security.yml`:

```diff
       - name: Enable ESP32 ECO3 cache-lock livelock workaround (errata WDT-3.15, issue #362)
+        if: matrix.language == 'cpp'
         run: bash scripts/patch_idf_eco3_fix.sh "$HOME/esp-idf"
```

Der Job `codeql-analysis` ist über `language: [cpp, javascript]` gematrixt. Der Schritt, der ESP-IDF klont, ist auf `cpp` beschränkt — der Patch-Schritt direkt darunter war als einziger ESP-IDF-Schritt im Job nicht beschränkt. Im JavaScript-Lauf existiert `$HOME/esp-idf` deshalb nie, das Skript bricht korrekt ab, und der Job endet als „configuration error":

```
patch_idf_eco3_fix.sh: /home/runner/esp-idf/components/esp_system/port/soc/esp32/Kconfig.system not found — is this an ESP-IDF checkout?
##[error]Process completed with exit code 1
```

Der JavaScript-Lauf braucht ESP-IDF ohnehin nicht — CodeQL analysiert JavaScript ohne Build.

Die fünf weiteren Aufrufe des Skripts (`build.yml`, `pr-check.yml`, `release.yml`, `release-webui.yml` und der zweite in `security.yml`) stehen in ungematrixten Jobs, die ESP-IDF immer klonen; die bleiben unberührt.

## Motivation and Context

„Security Checks" ist auf `main` dauerhaft rot — die letzten zehn Läufe, zuletzt auf `f3798d1` ([Run 34073194062](https://github.com/Xerolux/HB-RF-ETH-ng/actions/runs/34073194062)). In diesem Lauf ist `CodeQL Analysis (javascript)` Schritt 6 der einzige Fehlschlag; die anderen drei Jobs (NPM Security Audit, CodeQL Analysis (cpp), Check for Updates) sind grün, und `Setup ESP-IDF` / `Build with ESP-IDF` / `Perform CodeQL Analysis` wurden in diesem Job übersprungen bzw. gar nicht erreicht.

„Security Checks" ist außerdem der **einzige** rote Workflow auf `main` — Build Firmware, Documentation Checks, Deploy to GitHub Pages, Release und Stale sind grün. Diese eine Zeile genügt also.

Nebeneffekt: Der JavaScript-CodeQL-Scan lief seit Einführung des Patch-Schritts nie durch. Mit dem Guard wird er tatsächlich zum ersten Mal ausgeführt.

## How Has This Been Tested?

- Fehlerbild lokal reproduziert — identische Meldung und Exit-Code wie in CI, das Skript verhält sich also korrekt:
  ```
  $ bash scripts/patch_idf_eco3_fix.sh /nonexistent-idf
  patch_idf_eco3_fix.sh: /nonexistent-idf/components/esp_system/port/soc/esp32/Kconfig.system not found — is this an ESP-IDF checkout?
  exit: 1
  ```
- Workflow nach der Änderung mit `yaml.safe_load` geparst und die Schritte des Jobs aufgelistet: `Checkout` und `Initialize CodeQL` laufen für beide Sprachen, die vier C++/ESP-IDF-Schritte sind `cpp`-guarded, `Perform CodeQL Analysis` läuft für beide. Geprüfte Invariante „kein Schritt referenziert `$HOME/esp-idf` ohne `if: matrix.language == 'cpp'`" — erfüllt.
- Die anderen fünf Vorkommen des Skripts durchgesehen: alle in ungematrixten Jobs, die ESP-IDF unmittelbar davor klonen. Bestätigt durch den grünen Job `Check for Updates` im selben Lauf, der denselben Schritt ohne Guard fehlerfrei ausführt.

Der eigentliche Beweis ist der CI-Lauf dieses PRs: `CodeQL Analysis (javascript)` muss grün werden.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. — nicht nötig, reine Workflow-Korrektur.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. — für GitHub-Actions-Schritte nicht anwendbar; der CI-Lauf dieses PRs ist der Test.
- [x] All new and existing tests passed.

Gefunden beim Aufräumen der README-Screenshots in #437; dort war die rote Prüfung nicht durch den Diff verursacht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGY2CfQ33vHXikEKGVcSDs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGY2CfQ33vHXikEKGVcSDs)_