### PR TITLE
docs: align update-search docs with hardware field test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Priorität 3 (Relay-Kette: 15) und kann dem Funkpfad keine CPU nehmen.
 - Eine übersprungene Suche wird als solche angezeigt und niemals als
   „kein Update gefunden“.
+- Hardware-Feldtest (2026-09-09, productive Gerät mit aktiver CCU über die
+  UART/UDP-Brücke): 30+ Suchen über API und WebUI, Heap-Drift nach 20 Suchen
+  172 Bytes, kein Watchdog-Reset, keine CCU-Trennung, keine Crash-Einträge.
+  Doku entsprechend korrigiert: Die Suche blockt nur bei laufender
+  **Firmware**-Installation (nicht WebUI-Upload), und die
+  Speicher-Akzeptanzschwelle des Testprotokolls unterscheidet jetzt Idle- und
+  CCU-Lastfall.
 
 ## [2.2.7-Beta.8] - 2026-09-08
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -608,9 +608,10 @@ started:
 worker task could not be created.
 
 A search is refused before any network activity when free memory is too low,
-when a firmware or WebUI installation is in progress, or when another outbound
-TLS operation holds the device-wide network gate. The reason then appears in
-`lastSkipReason`.
+when a firmware installation is in progress, or when another outbound TLS
+operation holds the device-wide network gate. (A WebUI upload does not gate
+the search; both were verified to run concurrently on hardware.) The reason
+then appears in `lastSkipReason`.
 
 ---
 

--- a/docs/OTA_TEST_PROTOCOL.md
+++ b/docs/OTA_TEST_PROTOCOL.md
@@ -125,9 +125,21 @@ request itself.
 
 **Memory gate — the acceptance criterion.** Read
 `esp_get_minimum_free_heap_size()` (WebUI system overview, or
-`status/min_free_heap`) before and after. The manual search must not push the
-minimum free heap below **80 KB**, and after twenty consecutive searches the
-free heap must return to within 4 KB of its starting value.
+`status/min_free_heap`) before and after, and record the load state first,
+because the floor depends on the baseline:
+
+- On an **idle device** (no CCU session, optional services off; roughly
+  110 KB free after boot), the manual search must not push the minimum free
+  heap below **80 KB**.
+- On a device **with an active CCU session** (idle free heap around 60–65 KB,
+  where an 80 KB floor is unreachable by design), the transient minimum must
+  stay above **15 KB** during the search's TLS handshake.
+
+In both states, after twenty consecutive searches the free heap must return
+to within 4 KB of its starting value. Field reference (2026-09-09, active
+CCU on RPI-RF-MOD fw 4.4.22): idle free 63.6 KB / largest block 45.0 KB,
+transient minimum 17.4 KB, free heap after 20 searches within 172 bytes of
+the start; no relay impact, no watchdog reset.
 
 - [ ] Press "Search for updates now" with the device idle: a result appears and
       the displayed check time advances.


### PR DESCRIPTION
## Summary

Field test of the manual update search (stage B1) on a production device
(2026-09-09, active CCU session over the UART/UDP relay, RPI-RF-MOD fw
4.4.22) surfaced two documentation/reality mismatches. This PR corrects the
docs; no functional change.

## Changes

- `docs/API.md`: the search is gated only by a **firmware** installation in
  progress. The previous text also promised a refusal during a WebUI upload,
  but only the firmware OTA path sets the gate flag — a live search was
  observed running concurrently with a WebUI/SPIFFS upload, and both
  completed cleanly.
- `docs/OTA_TEST_PROTOCOL.md`: the 80 KB minimum-free-heap floor is
  unreachable on a CCU-attached device (idle free heap ~60–65 KB). The memory
  gate is now baseline-aware: 80 KB for an idle device, >15 KB transient
  during the TLS handshake with an active CCU session, and the 4 KB recovery
  rule after twenty searches for both states, with the measured field
  reference numbers.
- `CHANGELOG.md`: Notes entry recording the field test result (30+ searches
  via API and WebUI, 172-byte heap drift after 20 searches, no watchdog
  reset, no CCU disconnect, no crash entries).

## Testing

- [x] Hardware field test on a production device (the source of these fixes)
- [x] Docs-only change; no firmware/WebUI code touched
