### PR TITLE
ci: deploy manifests to GitHub Pages after every release

### DIFF
--- a/.github/workflows/release-webui.yml
+++ b/.github/workflows/release-webui.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write  # dispatch pages.yml after the manifest push
 
     steps:
       - name: Checkout main
@@ -284,3 +285,8 @@ jobs:
           if git diff --cached --quiet; then exit 0; fi
           git commit -m "chore: update WebUI manifest for ${{ steps.webui.outputs.TAG }}"
           git push origin main
+          # A GITHUB_TOKEN push raises no push event, so pages.yml would not
+          # run and devices would keep being served the previous manifest
+          # until the next human push to main. workflow_dispatch is the
+          # documented exception that triggers even for GITHUB_TOKEN.
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" gh workflow run pages.yml --ref main -R "${{ github.repository }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write  # dispatch pages.yml after the manifest push
 
     steps:
       - name: Checkout repository
@@ -459,3 +460,8 @@ jobs:
           if git diff --cached --quiet; then exit 0; fi
           git commit -m "chore: update manifests for ${{ steps.firmware.outputs.TAG }}"
           git push origin main
+          # A GITHUB_TOKEN push raises no push event, so pages.yml would not
+          # run and devices would keep being served the previous manifest
+          # until the next human push to main. workflow_dispatch is the
+          # documented exception that triggers even for GITHUB_TOKEN.
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" gh workflow run pages.yml --ref main -R "${{ github.repository }}"


### PR DESCRIPTION
## Summary

Devices fetch their update manifest from GitHub Pages. The manifest
publish steps in `release.yml` and `release-webui.yml` push to `main`
using `GITHUB_TOKEN` — and such pushes deliberately raise no `push`
event, so `pages.yml` never ran for them. After every release, devices
kept being served the **previous** manifest until the next human push to
main happened to rebuild Pages.

Observed live today while releasing v2.2.7-Beta.9: the manifest commit
landed on main at 17:47, but `https://xerolux.github.io/.../beta.json`
still served Beta.8 until a manual `workflow_dispatch` deployed it.
v2.2.7-Beta.8 before it only went live with the next day's merge. For
the planned auto-update stages this would mean devices report "up to
date" for hours or days after a release.

## Changes

- Both manifest publish steps (`Publish combined update manifest`,
  `Publish WebUI-only manifest update`) now dispatch `pages.yml` right
  after `git push origin main`. `workflow_dispatch` is the documented
  exception that triggers even for `GITHUB_TOKEN`, so no PAT is needed.
- Both jobs gain `actions: write` (required to dispatch a workflow).
- The dispatch sits after the early-exit for unchanged manifests, so a
  no-op release deploys nothing.

## Testing

- [x] Reproduced the gap live during the v2.2.7-Beta.9 release
- [x] Verified the manual `workflow_dispatch` path deploys the fresh
      manifest and devices immediately find the new version
      (search on a device returned `2.2.7-Beta.9 / update available`
      within a minute of the deploy)
- [ ] Next release exercises the automated path end-to-end
